### PR TITLE
added hyperlink-helper package

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -19,7 +19,8 @@
 		"https://github.com/alexstaubo/sublime_text_alternative_autocompletion",
 		"https://github.com/bgreenlee/sublime-github",
 		"https://github.com/Etsur/EE-ST2",
-		"https://github.com/Paaskehare/metabox-sublime-plugin"
+		"https://github.com/Paaskehare/metabox-sublime-plugin",
+		"https://github.com/sentience/hyperlink-helper"
 	],
 	"package_name_map": {
 		"soda-theme": "Theme - Soda",


### PR DESCRIPTION
The hyperlink-helper package is a port of the Hyperlink Helper commands from TextMate that provide convenient means for creating hyperlinks in various markup languages.
