### PR TITLE
renaming hyperlink-helper to HyperlinkHelper per ST2 package naming conventions

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -20,7 +20,7 @@
 		"https://github.com/bgreenlee/sublime-github",
 		"https://github.com/Etsur/EE-ST2",
 		"https://github.com/Paaskehare/metabox-sublime-plugin",
-		"https://github.com/sentience/hyperlink-helper"
+		"https://github.com/sentience/HyperlinkHelper"
 	],
 	"package_name_map": {
 		"soda-theme": "Theme - Soda",


### PR DESCRIPTION
Sorry for the renaming. Hopefully this comes quickly enough that few users will be affected.

Recommended naming conventions for packages were found here: http://www.sublimetext.com/forum/viewtopic.php?f=6&t=1934
