### PR TITLE
Added BracketHighlighter Repo.

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -34,7 +34,8 @@
 		"https://github.com/kemayo/sublime-text-2-clipboard-history",
 		"https://github.com/allixsenos/SublimeMRU",
 		"https://github.com/titoBouzout/SideBarEnhancements",
-		"https://bitbucket.org/nwjlyons/copy-file-name"
+		"https://bitbucket.org/nwjlyons/copy-file-name",
+		"https://github.com/facelessuser/BracketHighlighter"
 	],
 	"package_name_map": {
 		"soda-theme": "Theme - Soda",


### PR DESCRIPTION
A very configurable plugin that highlights matching tags, brackets, and quotes.  It also allows writing very simple plugins to leverage the matching for other tasks that require knowing the regions of a particular bracket, tag, or quote.  It is a fork of SublimeBrackets and SublimeTagmatcher merged together with a number of performance improvements and additional features.
