### PR TITLE
Adding new GoSublime and Jinja2 syntax highlight

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -39,8 +39,8 @@
 		"https://github.com/facelessuser/BracketHighlighter",
 		"https://github.com/aaronpowell/sublime-jquery-snippets",
 		"https://github.com/dz0ny/LiveReload-sublimetext2",
-		"https://github.com/DisposaBoy/GoSublime.git",
-		"https://github.com/mitsuhiko/jinja2-tmbundle.git"
+		"https://github.com/DisposaBoy/GoSublime",
+		"https://github.com/mitsuhiko/jinja2-tmbundle"
 	],
 	"package_name_map": {
 		"soda-theme": "Theme - Soda",
@@ -61,6 +61,6 @@
 		"CSS-Less-ish": "CSS Less(ish)",
 		"sublime-jquery-snippets": "jQuery Snippets pack",
 		"LiveReload-sublimetext2": "LiveReload",
-		"jinja2-tmbundle.git": "Jinja2"
+		"jinja2-tmbundle": "Jinja2"
 	}
 }


### PR DESCRIPTION
Hello @wbond,

Im adding GoSublime (go language support for sublime text 2) and the Jinja2 (python template language) syntax highlight.

Thanks !
