### PR TITLE
added MoveText plugin, TransposeCharacter plugin, and zenburn theme.

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -75,7 +75,10 @@
 		"https://github.com/CraigWilliams/TestChooser",
 		"https://github.com/ameyp/CscopeSublime",
 		"https://github.com/robcowie/SublimeTODO",
-		"https://raw.github.com/indynagpal/coldfusion-sublime-text-2/master/package_control.json"
+		"https://raw.github.com/indynagpal/coldfusion-sublime-text-2/master/package_control.json",
+		"https://github.com/colinta/SublimeMoveText",
+		"https://github.com/colinta/SublimeTransposeCharacters",
+		"https://github.com/colinta/zenburn"
 	],
 	"package_name_map": {
 		"soda-theme": "Theme - Soda",


### PR DESCRIPTION
MoveText brings one of my favorite TextMate tricks to Sublime Text.  Select some text, then use ⌘⌃→ (←,↑,↓) to drag the text around.

TransposeCharacter replaces the built-in `transpose` command.  Not just for fixing "teh", it can be used to quickly move a line up or down, and to reverse text.

Lastly, the zenburn theme.  Very thorough color theme!  And easy on the eyes.
