### PR TITLE
Update repo to include Haml package.

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -27,6 +27,7 @@
 		"https://github.com/bmc/ST2EmacsMiscellanea",
 		"https://github.com/BoundInCode/AutoFileName",
 		"https://github.com/BoundInCode/Display-Functions",
+		"https://github.com/brandonhilkert/TomDoc-Sublime",
 		"https://github.com/brianriley/sublime-dpaste",
 		"https://github.com/buymeasoda/soda-theme",
 		"https://github.com/cgutierrez/sublime-text-js-minifier",
@@ -193,6 +194,7 @@
 		"SublimeText2RailsRelatedFiles": "Rails Related Files",
 		"sublimetext_indentxml": "Indent XML",
 		"toggle-readonly" : "Toggle Read-Only",
+		"TomDoc-Sublime" : "TomDoc",
 		"ValaForSublime" : "Vala",
 		"whitespacecorrector" : "Whitespace Corrector"
 	},


### PR DESCRIPTION
This fork of the official Haml text mate bundle includes improved syntax for :javascript filters and ruby code in :javascript filters.
