### PR TITLE
Renamed Js Minifier to JsMinifier

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -205,7 +205,7 @@
 		"iced-coffee-script-tmbundle" : "IcedCoffeeScript",
 		"itodo": "iTodo",
 		"jinja2-tmbundle": "Jinja2",
-		"JsMinifier": "JSMinifier",
+		"JsMinifier": "JsRMinifier",
 		"LESS-sublime": "LESS",
 		"LiveReload-sublimetext2": "LiveReload",
 		"modx-sublimetext-2": "MODx Revolution Snippets",


### PR DESCRIPTION
I renamed the Js Minifier to JsMinifier to match the directory structure for when a direct clone of the repository is made.
