### PR TITLE
Adding SublemacsPro as Repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -70,6 +70,7 @@
 		"https://github.com/fmartini/sublime-rust",
 		"https://github.com/FPtje/Sublime-GLua-Highlight",
 		"https://github.com/gja/sublime-text-2-jasmine",
+		"https://github.com/grundprinzip/sublemacspro",
 		"https://github.com/jashkenas/coffee-script-tmbundle",
 		"https://github.com/jbrooksuk/SublimeWebColors",
 		"https://github.com/jclement/SublimePandoc",


### PR DESCRIPTION
Sublemacs Pro provides Emacs Bindings and Features for Sublime Text 2. It would be great if you could merge the repository.
