### PR TITLE
Rename DocBlox to phpDocumentor

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -33,7 +33,7 @@
 		"https://github.com/Azd325/sublime-text-caniuse",
 		"https://github.com/balazstth/subl-esp",
 		"https://github.com/belike81/Sublime-File-Navigator",
-		"https://github.com/benmatselby/sublime-docblox",
+		"https://github.com/benmatselby/sublime-phpdocumentor",
 		"https://github.com/benmatselby/sublime-phpcs",
 		"https://github.com/berfarah/LESS-build-sublime",
 		"https://github.com/biermeester/Pylinter",
@@ -275,7 +275,7 @@
 		"sublime-AsAbove": "AsAbove",
 		"Sublime-CMakeLists": "CMake",
 		"sublime-DefaultFileType": "Default File Type",
-		"sublime-docblox" : "DocBlox",
+		"sublime-phpdocumentor" : "phpDocumentor",
 		"sublime-edit-history": "Edit History",
 		"Sublime-File-Navigator": "Sublime File Navigator",
 		"sublime-gbk" : "GBK Encoding Support",
@@ -375,6 +375,7 @@
 		"SublimeBracketeer" : "Bracketeer",
 		"SublimeMoveText": "MoveText",
 		"SublimeQuickfind": "Quickfind",
-		"SublimeTransposeCharacter": "TransposeCharacter"
+		"SublimeTransposeCharacter": "TransposeCharacter",
+		"DocBlox": "phpDocumentor"
 	}
 }


### PR DESCRIPTION
This is because the underlying tool has also changed its name
