### PR TITLE
Add CSS Lint plugin to the repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -275,6 +275,7 @@
 		"Sublime-AdvancedNewFile": "AdvancedNewFile",
 		"sublime-AsAbove": "AsAbove",
 		"Sublime-CMakeLists": "CMake",
+		"sublime-csslint": "CSSLint",
 		"sublime-DefaultFileType": "Default File Type",
 		"sublime-docblox" : "DocBlox",
 		"sublime-edit-history": "Edit History",


### PR DESCRIPTION
With the help of csslint.net, I've created a plugin that gives Sublime Text the ability to lint css. Care to add it to the package control channel? If you'd like examples of it in use, or need more details, please let me know.
