### PR TITLE
Add SendText package

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -249,6 +249,7 @@
 		"https://github.com/vishr/local-history",
 		"https://github.com/vojtajina/sublime-OpenRelated",
 		"https://github.com/voventus/AVR-ASM-Sublime",
+		"https://github.com/wch/SendText",
 		"https://github.com/welefen/KeymapManager",
 		"https://github.com/welovewordpress/SublimeHtmlTidy",
 		"https://github.com/welovewordpress/SublimePhpTidy",


### PR DESCRIPTION
This is a package for sending a text selection to another program. It currently supports Terminal.app, iTerm, and tmux sessions.
