### PR TITLE
Modify GoToDoc in repository

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -314,7 +314,6 @@
 		"EE-ST2": "ExpressionEngine",
 		"eval_sel": "Eval Sel",
 		"Goto-Symbol": "Goto Symbol",
-		"GoToDoc": "Goto Golang Document",
 		"handcrafted-haml-textmate-bundle": "Haml",
 		"hasher": "Hasher",
 		"haxe-sublime2-bundle" : "HaXe",


### PR DESCRIPTION
If package map name is used, people get different package folder names when installing using package control, so remove the mapped name, use GoToDoc as package folder.
