### PR TITLE
Add STProjectMaker to PackageControl

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -57,6 +57,7 @@
 		"https://github.com/biermeester/Pylinter",
 		"https://github.com/billymoon/LoremIpsum",
 		"https://github.com/billymoon/Stylus",
+		"https://github.com/bit101/STProjectMaker",
 		"https://github.com/bizoo/MultiTaskBuild",
 		"https://github.com/bizoo/SortTabs",
 		"https://github.com/bmc/ST2SyntaxFromFileName",


### PR DESCRIPTION
Just added the one line in repositories.json to add the following package:

https://github.com/bit101/STProjectMaker

More info on the plugin here:

http://www.bit-101.com/blog/?p=3512

Basically, it's a plugin for creating new projects from user templates.
