### PR TITLE
Add EclipseJavaFormatter

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -225,6 +225,7 @@
 		"https://github.com/patgannon/sublimetext-scalatest",
 		"https://github.com/paulollivier/sublimetext-date",
 		"https://github.com/pdaether/Sublime-SymfonyCommander",
+		"https://github.com/phildopus/EclipseJavaFormatter"
 		"https://github.com/PhilippSchaffrath/Anypreter",
 		"https://github.com/phillipkoebbe/DetectSyntax",
 		"https://github.com/phuibonhoa/handcrafted-haml-textmate-bundle",


### PR DESCRIPTION
allows you to format Java files with the Eclipse formatter
