### PR TITLE
Package name changed

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -348,7 +348,7 @@
 		"sublime-DefaultFileType": "Default File Type",
 		"sublime-edit-history": "Edit History",
 		"Sublime-File-Navigator": "Sublime File Navigator",
-		"sublime-frontend-delight": "Frontend Delight Theme",
+		"sublime-frontend-delight": "Color Scheme - Frontend Delight",
 		"sublime-gbk" : "GBK Encoding Support",
 		"Sublime-GLua-Highlight": "GMod Lua",
 		"sublime-ipython-integration": "IPython Integration",


### PR DESCRIPTION
I've updated

```
"sublime-frontend-delight": "Frontend Delight Theme",
```

to

```
"sublime-frontend-delight": "Color Scheme - Frontend Delight",
```

from the Sublime [Package Control channel]
so it's clean.
