### PR TITLE
Add InputHelper repo

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -334,7 +334,6 @@
 		"https://github.com/wpp1983/hlsl",
 		"https://github.com/wulftone/sublime-text-2-quick-file-move",
 		"https://github.com/Xaro/SublimeSendToPasteBin",
-		"https://github.com/xgenvn/InputHelper",
 		"https://github.com/Xkeeper/SublimeTextileBuild",
 		"https://github.com/xobb1t/Sublime-AdvancedNewFile",
 		"https://github.com/zerok/Sublime2-SwitchLanguage",
@@ -364,7 +363,8 @@
 		"https://raw.github.com/theadamlt/sublime_packages/master/packages.json",
 		"https://raw.github.com/tiger2wander/sublime_packages/master/packages.json",
 		"https://raw.github.com/timonwong/sublime_packages/master/packages.json",
-		"https://raw.github.com/weslly/sublime_packages/master/packages.json"
+		"https://raw.github.com/weslly/sublime_packages/master/packages.json".
+		"https://raw.github.com/xgenvn/InputHelper/master/packages.json"
 	],
 	"package_name_map": {
 		"AngularJs.tmbundle": "AngularJS",


### PR DESCRIPTION
Simple and small plugin based on ColorPicker to help Linux users use iBus to input text. Tested on Debian Wheezy (testing state), ST2 build 2200; iBus1.4.1, ibus-unikey (for Vietnamese input) and ibus-pinyin to input Chinese.
