### PR TITLE
adding a new location for cucumber-sublime2-bundle

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -363,7 +363,8 @@
 		"https://raw.github.com/theadamlt/sublime_packages/master/packages.json",
 		"https://raw.github.com/tiger2wander/sublime_packages/master/packages.json",
 		"https://raw.github.com/timonwong/sublime_packages/master/packages.json",
-		"https://raw.github.com/weslly/sublime_packages/master/packages.json"
+		"https://raw.github.com/weslly/sublime_packages/master/packages.json",
+		"https://github.com/drewda/cucumber-sublime2-bundle"
 	],
 	"package_name_map": {
 		"AngularJs.tmbundle": "AngularJS",


### PR DESCRIPTION
This repo used to be hosted at https://github.com/sagework/cucumber-sublime2-bundle but for some reason it's no longer available. I've pushed my local copy to a new Github repo. 
