### PR TITLE
Added MSBuild package to the package channel

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -428,6 +428,7 @@
 		"https://raw.github.com/SublimeLinter/SublimeLinter/master/package_control.json",
 		"https://raw.github.com/theadamlt/sublime_packages/master/packages.json",
 		"https://raw.github.com/tiger2wander/sublime_packages/master/packages.json",
+		"https://raw.github.com/tillig/SublimeMSBuild/master/packages.json",
 		"https://raw.github.com/timonwong/sublime_packages/master/packages.json",
 		"https://raw.github.com/weslly/sublime_packages/master/packages.json",
 		"https://raw.github.com/xgenvn/InputHelper/master/packages.json"
@@ -663,6 +664,7 @@
 		"SublimeMakeExecutable": "MakeExecutable",
 		"SublimeMarkdownBuild": "MarkdownBuild",
 		"SublimeMaven": "Maven",
+		"SublimeMSBuild": "MSBuild",
 		"SublimeNESASM": "NESASM",
 		"SublimePandoc": "Pandoc (Markdown)",
 		"sublimepastecolumn": "Paste as Column",


### PR DESCRIPTION
I added a package reference to the SublimeMSBuild package at https://github.com/tillig/SublimeMSBuild for inclusion in the main package channel. This includes a name alias from SublimeMSBuild => MSBuild.
