### PR TITLE
Remove broken cakephp plugin from PackageControl

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -84,7 +84,6 @@
 		"https://github.com/buymeasoda/soda-theme",
 		"https://github.com/cabeca/SublimeChef",
 		"https://github.com/cafarm/aqua-theme",
-		"https://github.com/cakephp/cakephp-tmbundle",
 		"https://github.com/ccampbell/sublime-smart-match",
 		"https://github.com/ccreutzig/sublime-MuPAD",
 		"https://github.com/cgutierrez/JsMinifier",


### PR DESCRIPTION
The official Textmate bundle is completely broken, so it should not be available in Sublime Text.
