### PR TITLE
Added package for opening files listed in git status

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -468,6 +468,7 @@
 		"farcry-sublimetext": "FarCry",
 		"filezilla_import": "FilezillaImport",
 		"Flex-Sublimetext": "Flex",
+		"git-status-files": "Git Status Files",
 		"Goto-Symbol": "Goto Symbol",
 		"handcrafted-haml-textmate-bundle": "Haml",
 		"hasher": "Hasher",


### PR DESCRIPTION
This package opens the files from a git repository that are listed by `git status`.
