### PR TITLE
Add grid6-sublime

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -103,6 +103,7 @@
 		"https://github.com/clintberry/sublime-text-2-ini",
 		"https://github.com/cockscomb/SublimeMakeExecutable",
 		"https://github.com/condemil/Gist",
+		"https://github.com/cpojer/grid6-sublime",
 		"https://github.com/CraigWilliams/BeautifyRuby",
 		"https://github.com/CraigWilliams/TestChooser",
 		"https://github.com/CrypticTemple/sublime-xml-guesser",


### PR DESCRIPTION
This plugin adds the option to use a 3x2 Grid.

This is super simple and it is ok if this doesn't meet plugin standards and doesn't get pulled.
