### PR TITLE
JSLint for node

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -123,7 +123,7 @@
 		"https://github.com/danro/refined-theme",
 		"https://github.com/daris/sublime-kwrite-color-scheme",
 		"https://github.com/darkdelphin/Html-compressor",
-                "https://github.com/darrenderidder/Sublime-JSLint",
+		"https://github.com/darrenderidder/Sublime-JSLint",
 		"https://github.com/datevid/sublime-text-doctypes",
 		"https://github.com/davepeck/DirectorySettings",
 		"https://github.com/davidrios/jade-tmbundle",


### PR DESCRIPTION
Uses jslint for node.JS; requires npm -g install jslint.
