### PR TITLE
Another python pep8/pyFlakes syntax checker

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -531,7 +531,8 @@
 		"https://raw.github.com/weslly/sublime_packages/master/packages.json",
 		"https://raw.github.com/WhatWeDo/Sublime-Text-2-Compass-Build-System/master/packages.json",
 		"https://raw.github.com/wukkuan/AMD-Module-Editor/master/packages.json",
-		"https://raw.github.com/xgenvn/InputHelper/master/packages.json"
+		"https://raw.github.com/xgenvn/InputHelper/master/packages.json",
+		"https://raw.github.com/zehome/sublimetext_python_checker/master/packages.json"
 	],
 	"package_name_map": {
 		"AngularJs.tmbundle": "AngularJS",


### PR DESCRIPTION
This is my fork of https://github.com/vorushin/sublimetext_python_checker which is a python pep8/pyFlakes syntax checker for Linux & MacOSX.

My fork add support for sublimetext settings. (Instead of the original which needed to modify a file inside the package directory)
