### PR TITLE
Added Obsidian Color Scheme

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -532,7 +532,7 @@
 		"https://raw.github.com/WhatWeDo/Sublime-Text-2-Compass-Build-System/master/packages.json",
 		"https://raw.github.com/wukkuan/AMD-Module-Editor/master/packages.json",
 		"https://raw.github.com/xgenvn/InputHelper/master/packages.json",
-		"https://raw.github.com/mekwall/obsidian-color-scheme/packages.json"
+		"https://raw.github.com/mekwall/obsidian-color-scheme/master/packages.json"
 	],
 	"package_name_map": {
 		"AngularJs.tmbundle": "AngularJS",


### PR DESCRIPTION
Since the repo contains mutliple formats (want to keep it in one place) I created a separate download that only contains the theme file. If this doesn't work out, please get back to me on how to solve this without having to create a separate repo for this package.
