### PR TITLE
Added HighlightWhitespaces plugin

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -676,6 +676,7 @@
 		"hex-bin_system": "Hex-Bin System",
 		"Hex-to-HSL-Color": "Hex to HSL Color Converter",
 		"Hex-to-RGB": "Hex to RGB Converter",
+		"HighlightWhitespaces": "Highlight Whitespaces",
 		"hookblime": "Hookblime",
 		"Html-compressor": "HTML Compressor",
 		"iced-coffee-script-tmbundle" : "IcedCoffeeScript",


### PR DESCRIPTION
Based on TrailingSpaces code, this plugin will highlight every tab and two-or-more-spaces in the editor with separate colors. Both of the colors can be changed, in fact, encouraged to be changed. Single spaces are not highlighted.
