### PR TITLE
Correct package name: LoadFileToRepl

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -642,7 +642,6 @@
 		"li3_sublime": "Lithium Snippets",
 		"livecss": "Live CSS",
 		"LiveReload-sublimetext2": "LiveReload",
-		"LoadFileToRepl": "LoadFileToRepl",
 		"local-history": "Local History",
 		"mako-tmbundle": "Mako",
 		"mdTodo": "Markdown Todo",


### PR DESCRIPTION
Should I keep the line in `package_name_map`, if it doesn't change the name of package?
