### PR TITLE
Stupid Indent plugin

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -603,6 +603,7 @@
 		"https://raw.github.com/timonwong/sublime_packages/master/packages.json",
 		"https://raw.github.com/tmanderson/VintageLines/master/packages.json",
 		"https://raw.github.com/ttscoff/MarkdownEditing/master/packages.json",
+		"https://raw.github.com/tzvetkoff/sublime_stupid_indent/master/packages.json",
 		"https://raw.github.com/vkocubinsky/sublime_packages/master/packages.json",
 		"https://raw.github.com/weslly/sublime_packages/master/packages.json",
 		"https://raw.github.com/wistful/SublimeAutoPEP8/master/packages.json",


### PR DESCRIPTION
Hi, I've added a plugin for ST2 to determine indentation settings according to filename rather than current indentation / default indentation settings (only when there is a pattern for the filename, though)
