### PR TITLE
Added CUDA C/C++ package (syntax highlighting and snippets)

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1046,7 +1046,7 @@
 		"sublimetext-cakephp": "CakePHP (Native)",
 		"SublimeText-CasperJS": "CasperJS",
 		"SublimeText-Crypto": "Crypto",
-		"sublimetext-cuda-cpp": "CUDA C/C++",
+		"sublimetext-cuda-cpp": "CUDA C++",
 		"sublimetext-date": "Date",
 		"sublimetext-fsharp": "F#",
 		"sublimetext-grails": "Grails",


### PR DESCRIPTION
This is a package to add CUDA syntax highlighting for C and C++.  CUDA C/C++ is a set of extensions for C and C++ for parallel computing on NVIDIA's CUDA parallel computing platform and programming model (e.g. for GPUs).  The package adds syntax highlighting and a number of snippets.

Please let me know if there are any problems with the pull request.
