### PR TITLE
FreeMarker syntax

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1019,7 +1019,7 @@
 		"SublimeFiles": "Sublime Files",
 		"SublimeFileSync": "FileSync",
 		"SublimeFileTemplates": "FileTemplates",
-		"SublimeFreeMarker" : "FreeMarker",
+		"SublimeFreeMarker": "FreeMarker",
 		"SublimeFunctionNameDisplay" : "Function Name Display",
 		"SublimeGoBuild": "Go Build",
 		"SublimeGtags" : "GTags",


### PR DESCRIPTION
Adjusted to be Package Control compatible.

The repo halfninja/SublimeFreeMarker is forked from the original repo in this pull request (https://github.com/wbond/package_control_channel/pull/297), I've just moved the files to the root, with a more sensible name and a name mapping to remove the "Sublime" part on install.
