### PR TITLE
Add IMESupport plugin

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -634,6 +634,7 @@
 		"https://raw.github.com/bgreenlee/sublime-github/master/packages.json",
 		"https://raw.github.com/blueplanet/sublime-text-2-octopress/master/packages.json",
 		"https://raw.github.com/camperdave/EC2Upload/master/packages.json",
+		"https://raw.github.com/chikatoike/IMESupport/master/packages.json",
 		"https://raw.github.com/chriswong/sublime-mootools-snippets/master/packages.json",
 		"https://raw.github.com/colinta/sublime_packages/master/packages.json",
 		"https://raw.github.com/csytan/sublime-text-2-github/master/packages.json",


### PR DESCRIPTION
IMESupport is a plugin to fix an issue of Sublime Text 2 that cannot be displayed IME composition window correctly.

Please see this: https://github.com/chikatoike/IMESupport/blob/master/README_en.org
