### PR TITLE
Added CSS Color Convert plugin

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -615,7 +615,7 @@
 		"https://github.com/temochka/sublime-text-2-beanstalk",
 		"https://github.com/testdouble/sublime-test-double",
 		"https://github.com/thanpolas/sublime-google-closure-snippets",
-		"https://github.com/TheDutchCoder/ColorConvert"
+		"https://github.com/TheDutchCoder/ColorConvert",
 		"https://github.com/TheJohlin/RandomHEXColor",
 		"https://github.com/TheOnlyRew/sublime-horizontal-scroll",
 		"https://github.com/theymaybecoders/sublime-tomorrow-theme",


### PR DESCRIPTION
I've created a simple plugin to convert CSS hex colors to rgb and back (including rgba). Standard key-map: ctrl+shift+c.
