### PR TITLE
Rename plugin

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1316,6 +1316,7 @@
 		"DocBlox": "phpDocumentor",
 		"Frontend Delight Theme": "Color Scheme - Frontend Delight",
 		"Goto Golang Document": "GoToDoc",
+		"Git Gutter": "GitGutter",
 		"IncDecValue": "Inc-Dec-Value",
 		"JS Minifier": "JsMinifier",
 		"JSDocs": "DocBlockr",


### PR DESCRIPTION
I didn't realize when I named it "Git Gutter" it would be put in a directory of the same name. The code expects it to be in a directory named "GitGutter" to grab the icons from.

So I removed that entry so it will be put in a directory named "GitGutter" which would be the same as if you cloned the repo.

This should fix a problem with the icons when installed via package manager.

However I am curious, will current users be able to upgrade and get the directory change, or will they need to remove it and reinstall it?
