### PR TITLE
SublimeTransporter

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1317,6 +1317,7 @@
 		"SublimeToggleSymbol": "Toggle Symbol to String",
 		"SublimeTradsim": "Tradsim",
 		"SublimeTranslit": "Translit",
+		"SUblimeTransporter": "Transporter",
 		"SublimeTweetLine": "TweetLine",
 		"sublime-unittest": "Unittest (python)",
 		"sublime_python_imports": "Python Imports Sorter",


### PR DESCRIPTION
Allows you to move the caret up/down in a vim-like way without using vintage mode
