### PR TITLE
Added GoToClass plugin

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -389,6 +389,7 @@
 		"https://github.com/laravel/sublime-snippets",
 		"https://github.com/larlequin/PandocAcademic",
 		"https://github.com/laughedelic/LoadFileToRepl/tree/release",
+		"https://github.com/lazyguru/GoToClass",
 		"https://github.com/leon/YUI-Compressor",
 		"https://github.com/leonardoce/nimrod-sublime",
 		"https://github.com/leonardowolter/tubaina-afc",


### PR DESCRIPTION
This package adds the ability to highlight a class name and open it using either right-click "Go to class" or key binding.  Replaces underscores (_) in class name with spaces and launches the Goto Anywhere overlay with the class name pre-populated (ex, My_Very_Long_Class_Name_File becomes "My Very Long Class Name File")
