### PR TITLE
add OpenFlieList Plugin

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -203,6 +203,7 @@
 		"https://github.com/dreadatour/RPMSpec",
 		"https://github.com/drewda/cucumber-sublime2-bundle",
 		"https://github.com/drhayes/sublime-impactjs",
+		"https://github.com/drikin/OpenFileList",
 		"https://github.com/drslump/sublime-boo",
 		"https://github.com/duereg/sublime-jsvalidate",
 		"https://github.com/duydao/Text-Pastry",


### PR DESCRIPTION
I made this simple plugin which is listing up files in the same group in the same window.
ctrl+alt+l is default shortcut. I added Open File List menu under Goto -> Switch File.
User can change the focus in opening tabs using this list without iterating tab by Ctrl+Tab.
