### PR TITLE
Request to add CNPunctuationAutopair

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -783,6 +783,7 @@
 		"https://raw.github.com/kylederkacz/lettuce-farmer/master/packages.json",
 		"https://raw.github.com/Learning/sublime_packages/master/packages.json",
 		"https://raw.github.com/leporo/SublimeYammy/master/packages.json",
+		"https://raw.github.com/lucifr/CNPunctuationAutopair/master/packages.json",
 		"https://raw.github.com/lyapun/sublime-text-2-python-test-runner/master/packages.json",
 		"https://raw.github.com/mablo/sublime-text-2-meld-diff/master/packages.json",
 		"https://raw.github.com/Makopo/sublime-text-lsl/master/package.json",


### PR DESCRIPTION
CNPunctuationAutopair is a package for autopairing Chinese punctuations, such as "「」", "『』", "（）", etc.
