### PR TITLE
LoadFileToRepl: changed branch to master

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -298,7 +298,7 @@
 		"https://github.com/Ky6uk/SublimeDancer",
 		"https://github.com/laravel/sublime-snippets",
 		"https://github.com/larlequin/PandocAcademic",
-		"https://github.com/laughedelic/LoadFileToRepl/tree/release",
+		"https://github.com/laughedelic/LoadFileToRepl",
 		"https://github.com/leon/YUI-Compressor",
 		"https://github.com/leonardowolter/tubaina-afc",
 		"https://github.com/LewisW/SublimeAutoSemiColon",


### PR DESCRIPTION
Changed branch from `release` (because it's not actual) to `master` for LoadFileToRepl plugin
