### PR TITLE
Add AutoSlim Plugin

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -729,6 +729,7 @@
 		"https://github.com/TheOnlyRew/sublime-horizontal-scroll",
 		"https://github.com/theymaybecoders/sublime-tomorrow-theme",
 		"https://github.com/thierrylemoulec/Sublime-Csslisible",
+		"https://github.com/TikiTDO/AutoSlim",
 		"https://github.com/tikot/sublime-code2docs",
 		"https://github.com/timdouglas/sublime-find-function-definition",
 		"https://github.com/timdouglas/sublime-less2css",


### PR DESCRIPTION
Add AutoSlim to the package list 

This plugin allows a user to parse a Ruby Slim template into HTML, which is then saved to the clipboard.
