### PR TITLE
Request to add a new plugin to the PackageControl channel

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -699,6 +699,7 @@
 		"https://github.com/splatzgud/VGR-Assistant",
 		"https://github.com/sporto/rails_go_to_spec",
 		"https://github.com/squ1b3r/Djaneiro",
+		"https://github.com/srilumpa/SyntaxChecker",
 		"https://github.com/standfast/Translate",
 		"https://github.com/stephendavis89/sublime-liquid",
 		"https://github.com/stevenjs/M68k-Assembly",


### PR DESCRIPTION
Hi,

I have created a Sublime plugin and I would like to see it added to the PackageControl channel. I have only added the link to my GitHub repository in the "repositories" list as the name of the repository is the name I want to be displayed for the plugin.

In the case there is something wrong, please tell me so I can fix it.

Best regards,

Marc-André Doll
