### PR TITLE
Add CoffeeComplete Plus to Package Control

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1392,7 +1392,7 @@
 		"SublimeCMSMadeSimple": "CMS Made Simple Snippets",
 		"SublimeCodechef": "Codechef",
 		"SublimeColorSchemeSelector": "ColorSchemeSelector",
-		"SublimeCSAutocompletePlus": "CoffeeScript Autocomplete Plus",
+		"SublimeCSAutocompletePlus": "CoffeeComplete Plus (Autocompletion)",
 		"SublimeCSSTidy": "CSSTidy",
 		"SublimeCTagsPHP": "CTags for PHP",
 		"SublimeDataConverter": "DataConverter",


### PR DESCRIPTION
Request to add CoffeeComplete Plus to Package Control.

CoffeeComplete Plus is a plugin that provides autocomplete suggestions for CoffeeScript code. It also allows the user to use a key combination to jump to a CS class, function or variable definition.
