### PR TITLE
Previous Activated Tab for Sublime Text 2

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -454,6 +454,7 @@
 		"https://github.com/lioshi/lioshiScheme",
 		"https://github.com/lkraider/sublimetext2-apiary-blueprint",
 		"https://github.com/lmajano/cbox-coldbox-sublime",
+		"https://github.com/lucasfais/PreviousActivatedTab",
 		"https://github.com/lunixbochs/sublimelint",
 		"https://github.com/lunixbochs/SublimeXiki",
 		"https://github.com/luqman/SublimeText2RailsRelatedFiles",


### PR DESCRIPTION
A plugin to switch between the two last focused tabs. Just like C-^ for VIM.

Default key map is ctrl+6
