### PR TITLE
Removed DetectSyntax and NewFileWithSave

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -610,8 +610,6 @@
 		"https://github.com/phildopus/sublime-goto-open-file",
 		"https://github.com/philipguin/dfml-sublime-package",
 		"https://github.com/PhilippSchaffrath/Anypreter",
-		"https://github.com/phillipkoebbe/DetectSyntax",
-		"https://github.com/phillipkoebbe/NewFileWithSave",
 		"https://github.com/phuibonhoa/handcrafted-haml-textmate-bundle",
 		"https://github.com/phyllisstein/HipsterIpsum",
 		"https://github.com/phyllisstein/Markboard",


### PR DESCRIPTION
I don't use ST2 as my primary editor any more and I'm not going to be making any updates to these plugins. DetectSyntax does not work with ST3 and facelessuser has agreed to maintain it. He is planning on renaming it before submitting it back to Package Control. As for NewFileWithSave, it's simple enough that anyone could recreate it if desired.
