### PR TITLE
Add "sublime-scheme-rse" repository, hosting the 'Color Scheme RSE'

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1357,7 +1357,6 @@
 		"sublime-sane-snippets": "SaneSnippets",
 		"Sublime-SBT-Runner": "SBT Runner",
 		"sublime-scheme-cycler": "SchemeCycler",
-		"sublime-scheme-rse": "Color Scheme - RSE",
 		"sublime-selenium-snippets": "Selenium Snippets",
 		"sublime-shrink-whitespaces": "Shrink Whitespaces",
 		"sublime-sjson": "SJSON",


### PR DESCRIPTION
Hello,

would you please be so kind and merge in my change to repositories.json, containing my "sublime-scheme-rse" repository on Github, hosting my "Color Scheme - RSE" plugin for use by Package Control.

Thanks.

Ralf S. Engelschall
