### PR TITLE
Removing my UnrealScript package.

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -102,7 +102,6 @@
 		"https://github.com/bartTC/SubDpaste",
 		"https://github.com/bbonora/SublimeCMSMadeSimple",
 		"https://github.com/bcharbonnier/SublimeFileSync",
-		"https://github.com/beefsack/unrealscript-sublime",
 		"https://github.com/belike81/Sublime-File-Navigator",
 		"https://github.com/Benja-gipsy-king/ControlScroll",
 		"https://github.com/benjamin-smith/sublime-text-silverstripe",


### PR DESCRIPTION
This pull request is to remove my UnrealScript package.  All functionality was pulled into the UnrealScriptIDE package which now supersedes mine.
