### PR TITLE
Wordless package

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1419,7 +1419,6 @@
 		"Sublime-Text-2-Table-Cleaner": "Table Cleaner",
 		"sublime-text-2-twig": "Twig",
 		"Sublime-Text-2-Vlt-Plugin": "Vlt",
-		"Sublime-Text-2-Wordless": "Wordless",
 		"sublime-text-2-wordpress": "Wordpress",
 		"Sublime-Text-Block-Nav": "Block Nav",
 		"sublime-text-caniuse": "Can I Use",


### PR DESCRIPTION
New pull request: now package name is plain _Wordless_ and have deleted repo name mapping from repositories.json.
