### PR TITLE
Renamed installation folder

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1057,7 +1057,7 @@
 		"Ciapre.tmTheme": "Ciapre Color Scheme",
 		"ClickableUrls_SublimeText2": "Clickable URLs",
 		"ClojureDoc-Search": "ClojureDocSearch",
-		"cobalt2" : "Cobalt2",
+		"cobalt2" : "Theme - Cobalt2",
 		"cocosyntax": "Coco R Syntax Highlighting",
 		"codefoo": "Code Foo",
 		"codeigniter-utilities": "CodeIgniter Utilities",


### PR DESCRIPTION
Sorry to keep bugging you with pull requests, but the theme needs the folder to be called `Theme - Cobalt2` rather than just `Cobalt2`. Seems to be breaking when users install it. 
