### PR TITLE
Add bradfeehan/SublimePHPCoverage

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -925,6 +925,7 @@
 		"https://raw.github.com/apophys/sublime-packages/master/packages.json",
 		"https://raw.github.com/bits/ExpandSelectionToWhitespace-SublimeText/master/packages.json",
 		"https://raw.github.com/blueplanet/sublime-text-2-octopress/master/packages.json",
+		"https://raw.github.com/bradfeehan/SublimePHPCoverage/master/packages.json",
 		"https://raw.github.com/camperdave/EC2Upload/master/packages.json",
 		"https://raw.github.com/ccpalettes/sublime-lorem-text/master/packages.json",
 		"https://raw.github.com/chancedai/sublime-cross/master/packages.json",


### PR DESCRIPTION
A plugin for Sublime Text 2, which visualises PHP code coverage data in the editor.
## Screenshot

![Screenshot of Sublime PHP Coverage in action](https://a248.e.akamai.net/camo.github.com/94bdc5c2f971353be94a2ea49ee1f1d42bb1a3f2/687474703a2f2f692e696d6775722e636f6d2f344153636f2e706e67)
