### PR TITLE
Add Hypertext Typographer package

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -329,6 +329,7 @@
 		"https://github.com/fushnisoft/SublimeClarion",
 		"https://github.com/garyc40/Vintage-Origami",
 		"https://github.com/geoffroymontel/supercollider-package-for-sublime-text",
+		"https://github.com/geoffstokes/HypertextTypographer",
 		"https://github.com/GerjanOnline/SublimeFileCleanup",
 		"https://github.com/GianlucaGuarini/SublimeText2-Parallel-Builder-Plugin",
 		"https://github.com/gillibrand/expand-selection-to-function-js",


### PR DESCRIPTION
This adds my [HypertextTypographer package](https://github.com/geoffstokes/HypertextTypographer) to the channel.

HypertextTypographer shows potential typographical errors (non-encoded special characters) in XML, HTML and similar files.
