### PR TITLE
Adds support to hosts file syntax and commenting toggle

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -740,6 +740,7 @@
 		"https://github.com/robinmalburn/sublime-tabfilter",
 		"https://github.com/Robot-Will/Stino",
 		"https://github.com/rockerest/Signatori",
+		"https://github.com/rodrigoflores/hosts",
 		"https://github.com/rodrigoflores/today",
 		"https://github.com/rorydriscoll/LuaSublime",
 		"https://github.com/roverwire/codeigniter-utilities",


### PR DESCRIPTION
I'm adding support to `/etc/hosts` file syntax and commenting for Sublime.
