### PR TITLE
Adding Bound Keys and Find Selected plugins

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -176,6 +176,8 @@
 		"https://github.com/cockscomb/SublimeMakeExecutable",
 		"https://github.com/cockscomb/SublimePerldoc",
 		"https://github.com/codecarson/SublimeSuperSelect",
+		"https://github.com/CodeEffect/BoundKeys",
+		"https://github.com/CodeEffect/FindSelected",
 		"https://github.com/compleatang/Legal-Snippets-Sublime",
 		"https://github.com/compleatang/sublimetext-pastepdf",
 		"https://github.com/condemil/Gist",


### PR DESCRIPTION
Bound keys opens a new tab and lists the bound keys for all installed plugins along with the default and the user file. It indicates if you have any clashes and also which instance will override the other.

Find Selected is a really simple plugin to effectively make find under and find next one keypress. If text is selected it searches for that, if it isn't it searches for either the clipboard or the last find search term.
