### PR TITLE
Fix repo name for old ST2EmacsModelines

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -506,7 +506,7 @@
 		"https://github.com/kuroir/SCSS.tmbundle/tree/SublimeText2",
 		"https://github.com/kutu/PythonAnywhereEditor",
 		"https://github.com/kutu/RandomMessage",
-		"https://github.com/kvs/ST2EmacsModelines",
+		"https://github.com/kvs/STEmacsModelines",
 		"https://github.com/kvs/ST2Nginx",
 		"https://github.com/kvs/ST2Slate",
 		"https://github.com/kwattro/sublime-behat-snippets",


### PR DESCRIPTION
It now supports ST3, too, thanks to @ashb.
