### PR TITLE
SurroundWith added [Corrected]

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -969,6 +969,7 @@
 		"https://raw.github.com/akalongman/sublimetext-codeformatter/master/packages.json",
 		"https://raw.github.com/akalongman/sublimetext-stringutilities/master/packages.json",
 		"https://raw.github.com/amazedkoumei/SublimeKnifeSolo/master/packages.json",
+		"https://raw.github.com/Andr3as/Sublime-SurroundWith/master/packages.json",
 		"https://raw.github.com/aparajita/active4d-sublime/master/package_control.json",
 		"https://raw.github.com/aponxi/sublime-better-coffeescript/master/package.json",
 		"https://raw.github.com/apophys/sublime-packages/master/packages.json",


### PR DESCRIPTION
Sry, I forgot to add the packages.json instead of the repository.

So, now the right pull request:

SurroundWith is a plugin for the code editor Sublime Text 2. It adds a 'surround with' function to Sublime like Eclipse has.
