### PR TITLE
Update Floobits plugin to new repository name.

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1095,7 +1095,7 @@
 		"https://raw.github.com/farcaller/DashDoc/master/packages.json",
 		"https://raw.github.com/FichteFoll/sublime_packages/master/package_control.json",
 		"https://raw.github.com/filcab/SublimeLLDB/master/packages.json",
-		"https://raw.github.com/Floobits/sublime-text-2-plugin/master/packages.json",
+		"https://raw.github.com/Floobits/floobits-sublime/master/packages.json",
 		"https://raw.github.com/francodacosta/sublime-php-getters-setters/master/packages.json",
 		"https://raw.github.com/freewizard/sublime_packages/master/package_control.json",
 		"https://raw.github.com/gcollazo/sublime_packages/master/packages.json",


### PR DESCRIPTION
I've renamed the repo for the Floobits Sublime Plugin. The old URL will still work for a while, thanks to GitHub's new redirects.
