### PR TITLE
Add Homebrew-Formula-syntax repo

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -833,6 +833,7 @@
 		"https://github.com/samizdatco/sublime-text-shebang",
 		"https://github.com/SamPeng87/sublime-last-edit",
 		"https://github.com/samsonw/SublimeTask",
+		"https://github.com/samueljohn/Homebrew-formula-syntax",
 		"https://github.com/schnittchen/sublime-helios",
 		"https://github.com/scriptcs/scriptcs-sublime",
 		"https://github.com/scttcper/Scriptogram",


### PR DESCRIPTION
I added my github repo with a simple Syntax for Homebrew files (ruby scripts plus embedded diffs).

Would you be so kind?
