### PR TITLE
Change package name

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -2070,7 +2070,7 @@
 		"Load file to REPL": "LoadFileToRepl",
 		"Python Package to Clipboard": "Python Path to Clipboard",
 		"Quick File Renamer": "QuickFileMove",
-    "Ruby 1.9 Hash Converter", "Ruby Hash Converter",
+		"Ruby 1.9 Hash Converter": "Ruby Hash Converter",
 		"Six: Future JavaScript Syntax": "Six - Future JavaScript Syntax",
 		"Solarized Color Scheme (TextMate)": "Solarized Color Scheme",
 		"Strapdown.js Markdown Preview": "Strapdown Markdown Preview",


### PR DESCRIPTION
I had to change my package name to make it compatible with ST3.
It was ending up with an exception. ST3 doesn't like dots in package names anymore.

`ImportError: No module named 'Ruby 1'`
