### PR TITLE
Add HAMLC (CoffeeScript HAML) syntax def

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -476,6 +476,7 @@
 		"https://github.com/jimhawkridge/SublimeABC",
 		"https://github.com/jims/sublime-sjson",
 		"https://github.com/jinze/sublime-rvm",
+		"https://github.com/jisaacks/CoffeeScriptHaml",
 		"https://github.com/jisaacks/GitGutter",
 		"https://github.com/jisaacks/MaxPane",
 		"https://github.com/jlegewie/SublimePeek",


### PR DESCRIPTION
This is basically just a copy of the Ruby HAML definition swapped out to use CoffeeScript instead of Ruby.
