### PR TITLE
Fixed typo in sublime-find-function-definition listing

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -2052,6 +2052,7 @@
 		"CakePHP": "CakePHP (tmbundle)",
 		"Change List (Last Edit)": "ChangeList",
 		"DocBlox": "phpDocumentor",
+		"Find Function Definiton": "Find Function Definition",
 		"Frontend Delight Theme": "Color Scheme - Frontend Delight",
 		"Git Gutter": "GitGutter",
 		"Goto Golang Document": "GoToDoc",


### PR DESCRIPTION
"Find Function Definition" appeared as "Find Function Definiton"
