### PR TITLE
Fix repo path for SCSS.tmbundle

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -2083,3 +2083,5 @@
 		"ThinkPHP Snippets": "Thinkphp"
 	}
 }
+
+


### PR DESCRIPTION
I got a report stating that the repo doesn't appear anymore on package control, wondering if it's because of the 301 redirect not working correctly on package control.
