### PR TITLE
Override Sublime-Gitignore with forked repository.

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1140,6 +1140,7 @@
 		"https://raw.github.com/Kasoki/FancyProjects/master/packages.json",
 		"https://raw.github.com/keeganstreet/sublime-elfinder/master/packages.json",
 		"https://raw.github.com/keeganstreet/sublime-specificity/master/packages.json",
+		"https://raw.github.com/kevinxucs/Sublime-Gitignore/master/packages.json",
 		"https://raw.github.com/kik0220/sublimetext_japanize/master/packages.json",
 		"https://raw.github.com/Kronuz/SublimeCodeIntel/master/package_control.json",
 		"https://raw.github.com/kylederkacz/lettuce-farmer/master/packages.json",


### PR DESCRIPTION
Since original author doesn't seem to maintain his repository anymore, I forked his repo and fixes some bugs so that it can be run under sublime text 3.
