### PR TITLE
Adds SublimeGit packages.json url

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -2,7 +2,7 @@
 	"schema_version": "1.2",
 	"repositories": [
 		"https://github.com/SublimeText",
-		"http://release.sublimegit.net/packages.json",
+		"https://release.sublimegit.net/packages.json",
 		"http://sublime.wbond.net/packages.json",
 		"http://wuub.net/packages.json",
 		"https://bitbucket.org/abraly/zap-gremlins",


### PR DESCRIPTION
Not sure if you wanted it at the bottom, or in line with the other
non-github and non-bitbucket urls. Please let me know if i should
move it.

Packages.json has been tested as a repository directly in Sublime Text 2, and it works on all platforms.
