### PR TITLE
Sorry to reopen this again. Changes https back to http because of install issues.

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -2,7 +2,7 @@
 	"schema_version": "1.2",
 	"repositories": [
 		"https://github.com/SublimeText",
-		"https://release.sublimegit.net/packages.json",
+		"http://release.sublimegit.net/packages.json",
 		"http://sublime.wbond.net/packages.json",
 		"http://wuub.net/packages.json",
 		"https://bitbucket.org/abraly/zap-gremlins",


### PR DESCRIPTION
Some people seem to be having problems installing the package if they
are not on the bleeding edge of Package Control.

Will update to use https when a new stable package control is released.
The one on the package control website still contains the bug.
(Line 1478 in Package Control.py, domain variable doesn't exist)
