### PR TITLE
Add MasmAssembly

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -645,6 +645,7 @@
 		"https://github.com/madeingnecca/sublime-fillerati",
 		"https://github.com/madeingnecca/sublime-find-non-ascii",
 		"https://github.com/madeingnecca/sublime-slug",
+		"https://github.com/MakiseKurisu/MasmAssembly",
 		"https://github.com/malexer/SublimeTranslit",
 		"https://github.com/malroc/sourcetalk_st2",
 		"https://github.com/maltize/sublime-text-2-moo",


### PR DESCRIPTION
A complete syntax highlighting plugin in MASM/JWASM syntax.

OK there are miles to go before it can be called "complete". It just has the common instructions and directives. I believe it contains all 80386 non-privileged instructions. Full x86/x64 registers. Other than that it's incomplete. I tested it with my codes and didn't find any big issue. So I guess that should be enough for most people.
