### PR TITLE
Added https://github.com/afterdesign/jshintify to plugins list

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1158,6 +1158,7 @@
 		"https://github.com/zoomix/SublimeToggleSymbol",
 		"https://github.com/zyxar/Sublime-CMakeLists",
 		"https://raw.github.com/accerqueira/sublime/v1.2/packages.json",
+		"https://raw.github.com/afterdesign/jshintify/master/packages.json",
 		"https://raw.github.com/afterdesign/MacTerminal/master/packages.json",
 		"https://raw.github.com/ajryan/CSharpreter/master/packages.json",
 		"https://raw.github.com/akalongman/sublimetext-autobackups/master/packages.json",


### PR DESCRIPTION
jshintify has some options that are not present in other jshint plugins:
- set path to jshintrc file
- set what is showing in status bar (options called `error_messages_show_count` and `error_messages_show_first`)
- option to show/hide dot in lines with errors
- option to show/hide outline for lines with errors 
- option to filter files based on extension
- lint file on open
- additional option to show debug messages for easier issue reporting
- cool animation in statusbar (borrowed from pylint plugin)
