### PR TITLE
Removed Tita plugin which I no longer maintain

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -1299,7 +1299,6 @@
 		"https://raw.github.com/timonwong/sublime_packages/master/packages.json",
 		"https://raw.github.com/tmanderson/VintageLines/master/packages.json",
 		"https://raw.github.com/tomascayuelas/coolcodescheme/master/packages.json",
-		"https://raw.github.com/tsteur/sublimetext-tita/master/packages.json",
 		"https://raw.github.com/ttscoff/MarkdownEditing/master/packages.json",
 		"https://raw.github.com/twolfson/sublime-request/master/packages.json",
 		"https://raw.github.com/tzvetkoff/sublime_stupid_indent/master/packages.json",


### PR DESCRIPTION
I do no longer maintain this plugin and it gets outdated. Removed the plugin therefore.
