### PR TITLE
Enable Focus Last Tab for Sublime Text 3

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -333,7 +333,7 @@
 			"details": "https://github.com/eproxus/focus_last_tab", 
 			"releases": [
 				{
-					"sublime_text": "<3000", 
+					"sublime_text": "*", 
 					"details": "https://github.com/eproxus/focus_last_tab/tree/master"
 				}
 			]


### PR DESCRIPTION
Publish Focus Last Tab as compatible with Sublime Text 2 and 3 (which it is).
