### PR TITLE
VCS Gutter support ST3

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -66,7 +66,7 @@
 			"details": "https://github.com/bradsokol/VcsGutter",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/bradsokol/VcsGutter/tree/master"
 				}
 			]


### PR DESCRIPTION
Changed repository meta data to show that VCS Gutter supports ST2 and ST3.
