### PR TITLE
SassBeautify: added labels, sublime_text verions and platform types

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -54,10 +54,16 @@
 			]
 		},
 		{
+			"name": "SassBeautify",
 			"details": "https://github.com/badsyntax/SassBeautify",
+			"labels": [
+				"sass",
+				"formatting"
+			],
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
+					"platforms": "*",
 					"details": "https://github.com/badsyntax/SassBeautify/tree/master"
 				}
 			]


### PR DESCRIPTION
As the title reads, this changes adds labels, and specifies the sublime_text versions and platform types for the 'SassBeautify' plugin.
