### PR TITLE
Changed name since it needs to load after Vintageous

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -195,11 +195,11 @@
 				{
 					"sublime_text": ">=3000",
 					"details": "https://github.com/rodcloutier/Vintageous-Origami/tree/master"
-				}i
+				}
 			],
-            "previous_names": [
-                "Vintageous Origami"
-            ]
+			"previous_names": [
+				"Vintageous Origami"
+			]
 		},
 		{
 			"name": "Vlt",


### PR DESCRIPTION
This plugins needs to be loaded after Vintageous. Sublime plugin load order makes "Vintageous Origami" or "Vintageous-Origami" load after Vintageous.
