### PR TITLE
Changed Laravel 4 Artisan supported Sublime Text versions

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -16,7 +16,7 @@
 			"details": "https://github.com/m0nah/Laravel-4-Artisan",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/m0nah/Laravel-4-Artisan/tree/master"
 				}
 			]


### PR DESCRIPTION
Laravel 4 Artisan support Sublime Text 2 and 3
