### PR TITLE
Updated details href

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -684,7 +684,7 @@
 			"details": "https://github.com/erikgassler/My-Snippets",
 			"releases": [
 				{
-					"details": "https://github.com/erikgassler/My-Snippets/tree/master"
+					"details": "https://github.com/erikgassler/My-Snippets/tags"
 				}	
 			]
 		}


### PR DESCRIPTION
Previous href was a guess based on other packages. Current href should be proper link to my tags, with an initial tag for the 1st version 0.1.0
