### PR TITLE
sublime-bower works with ST2 and ST3

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -346,7 +346,7 @@
 			"details": "https://github.com/benschwarz/sublime-bower",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/benschwarz/sublime-bower/tree/master"
 				}
 			]


### PR DESCRIPTION
As stated in the [plugin's readme](https://github.com/benschwarz/sublime-bower/blob/master/README.md#platforms), this plugin works on ST3 so with @benschwarz's blessing, I'd like to make this plugin available to ST3.
