### PR TITLE
Correct ST version problem for Scala worksheet (only works on ST3)

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -121,7 +121,7 @@
 			"details": "https://bitbucket.org/inkytonik/scalaworksheet",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": ">=3000",
 					"details": "https://bitbucket.org/inkytonik/scalaworksheet/src/default"
 				}
 			]


### PR DESCRIPTION
Somehow my Scala worksheet plugin was entered as only working on ST2, but in fact, it only works on ST3 at present.
