### PR TITLE
Markdown Preview is now support both ST2 and ST3 on the master.

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -105,12 +105,8 @@
 			"details": "https://github.com/revolunet/sublimetext-markdown-preview",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/revolunet/sublimetext-markdown-preview/tree/master"
-				},
-				{
-					"sublime_text": ">=3000",
-					"details": "https://github.com/revolunet/sublimetext-markdown-preview/tree/ST3"
 				}
 			]
 		},


### PR DESCRIPTION
Hi,

I just want update the information for markdown preview.

It is now support ST2 and ST3 on master branch.
