### PR TITLE
Updating Find++ to mark it was ST3 compatible and moving it to tag based releases

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -261,10 +261,14 @@
 		{
 			"name": "Find++",
 			"details": "https://github.com/twolfson/FindPlusPlus",
+			"labels": [
+				"file navigation",
+				"search"
+			],
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"details": "https://github.com/twolfson/FindPlusPlus/tree/master"
+					"sublime_text": "*",
+					"details": "https://github.com/twolfson/FindPlusPlus/tags"
 				}
 			]
 		},


### PR DESCRIPTION
I have made Find++ compatible with Sublime Text 3. This PR updates package_control_channel to verify those changes.

https://github.com/twolfson/FindPlusPlus
