### PR TITLE
Relocated sublime-request's packages.json into package_control_channel

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -135,7 +135,6 @@
 		"https://raw.github.com/tmanderson/VintageLines/master/packages.json",
 		"https://raw.github.com/tomascayuelas/coolcodescheme/master/packages.json",
 		"https://raw.github.com/ttscoff/MarkdownEditing/master/packages.json",
-		"https://raw.github.com/twolfson/sublime-request/master/packages.json",
 		"https://raw.github.com/tzvetkoff/sublime_stupid_indent/master/packages.json",
 		"https://raw.github.com/vifo/SublimePerlTidy/master/packages.json",
 		"https://raw.github.com/vkocubinsky/sublime_packages/master/packages.json",

--- a/repository/r.json
+++ b/repository/r.json
@@ -276,6 +276,20 @@
 			]
 		},
 		{
+			"name": "Request",
+			"details": "https://github.com/twolfson/sublime-request",
+			"labels": [
+				"http",
+				"url"
+			],
+			"releases": [
+				{
+					 "sublime_text": "*",
+					 "details": "https://github.com/twolfson/sublime-request/tags"
+				}
+			]
+		},
+		{
 			"name": "Require Helper",
 			"details": "https://github.com/spadgos/sublime-require-helper",
 			"releases": [


### PR DESCRIPTION
I have added Sublime Text 3 support for `sublime-request`. In addition, to be a better Package Control citizen, I am relocating the `packages.json` information back into the `package_control_channel` repository (originally separated due to tags). In this PR:
- Removal of import from `sublime-request`'s `packages.json`
- Added `sublime-request` information to `package_control_channel`
