### PR TITLE
Addition of CSS Edit groups to the Package repository

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -5,6 +5,7 @@
 			"details": "https://github.com/Kotrotsos/sublime-cssedit-groups",
 			"releases": [
 				{
+					"name": "CSSEdit Group tags",
 					"sublime_text": "<3000",
 					"details": "https://github.com/Kotrotsos/sublime-cssedit-groups/tree/master"
 				}


### PR DESCRIPTION
CSS Edit groups package, so you can (re)use those CSS Edit group tags in Sublime Text. 
