### PR TITLE
Added "WebBuilder ST"

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -24,22 +24,22 @@
 			]
 		},
 		{
-			"name": "WebBuilder ST",
-			"details": "https://github.com/Houfeng/WebBuilder-ST",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"details": "https://github.com/Houfeng/WebBuilder-ST/tree/master"
-				}
-			]
-		},
-		{
 			"name": "Web Encoders",
 			"details": "https://github.com/revolunet/sublimetext-web-encoders",
 			"releases": [
 				{
 					"sublime_text": "<3000",
 					"details": "https://github.com/revolunet/sublimetext-web-encoders/tree/master"
+				}
+			]
+		},
+		{
+			"name": "WebBuilder ST",
+			"details": "https://github.com/Houfeng/WebBuilder-ST",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/Houfeng/WebBuilder-ST/tree/master"
 				}
 			]
 		},


### PR DESCRIPTION
Added "WebBuilder ST" 
A developed for Sublime Text2, JS + CSS compression plug-in (Require Mono or.NET).
This plugin requires mono in Mac and Linux, requires .NET in Windows, can be normal use.

插件简介:
一个为Sublime Text2开发的JS、CSS压缩插件(需Mono或.NET环境)

支持平台:
1. Windows (需要安装.net framework 3.5或以上版本)
2. Mac (需要安装Mono 2.x或以上版本)
3. Linux (需要安装Mono 2.x或以上版本)

常见问题:
1. 如果使用过程中出现 "UnicodeEncodeError: 'ascii' codec can't encode characters" 的错误, 此问题可能是ST2的Bug, 请在ST安装目录找到 "sublime_plugin.py" ,在import之后其它代码之前添加如下两行:

``` python
    reload(sys)  
    sys.setdefaultencoding("utf-8")
```
