### PR TITLE
Updating Hex-To-RGBA Converter in plugin list and including support for ST3

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -156,22 +156,22 @@
 			]
 		},
 		{
-			"name": "Hex to RGBA Converter",
-			"details": "https://github.com/aroscoe/Hex-to-RGBA",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"details": "https://github.com/aroscoe/Hex-to-RGBA/tree/master"
-				}
-			]
-		},
-		{
 			"name": "Hex to RGB Converter",
 			"details": "https://github.com/vitorleal/Hex-to-RGB",
 			"releases": [
 				{
 					"sublime_text": "<3000",
 					"details": "https://github.com/vitorleal/Hex-to-RGB/tree/master"
+				}
+			]
+		},
+		{
+			"name": "Hex to RGBA Converter",
+			"details": "https://github.com/aroscoe/Hex-to-RGBA",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/aroscoe/Hex-to-RGBA/tree/master"
 				}
 			]
 		},


### PR DESCRIPTION
Removing the old unnamed plugin in the repo list and adding support for ST3.
