### PR TITLE
Clickable URLs: ST3 ready

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -328,7 +328,7 @@
 			"details": "https://github.com/leonid-shevtsov/ClickableUrls_SublimeText2",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/leonid-shevtsov/ClickableUrls_SublimeText2/tree/master"
 				}
 			]


### PR DESCRIPTION
This package works with SublimeText 3 (see [leonid-shevtsov/ClickableUrls_SublimeText2:README.md](https://github.com/leonid-shevtsov/ClickableUrls_SublimeText2/blob/21845e2ab7e60e9aaa4e3528e6412f14e8d87a2b/README.md)).
