### PR TITLE
Highlight Whitespaces update

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -251,11 +251,11 @@
 		{
 			"name": "Highlight Whitespaces",
 			"details": "https://github.com/disq/HighlightWhitespaces",
+			"labels": ["formatting", "language syntax", "linting"],
 			"releases": [
 				{
 					"sublime_text":"*",
-					"details": "https://github.com/disq/HighlightWhitespaces/tags",
-					"labels": ["formatting", "language syntax", "linting"]
+					"details": "https://github.com/disq/HighlightWhitespaces/tags"
 				}
 			]
 		},


### PR DESCRIPTION
Update info for Highlight Whitespaces plugin

Supports ST3 so sublime_text is set to "*"
Details set to github tags
Added a few labels
