### PR TITLE
ClojureDocSearch works on ST3

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -386,7 +386,7 @@
 			"details": "https://github.com/Foxboron/ClojureDoc-Search",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/Foxboron/ClojureDoc-Search/tree/master"
 				}
 			]


### PR DESCRIPTION
ClojureDocSearch does work on ST3.
