### PR TITLE
Update sublime-git package download location

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -110,15 +110,15 @@
 		},
 		{
 			"name": "Git",
-			"details": "https://github.com/kemayo/sublime-text-2-git",
+			"details": "https://github.com/kemayo/sublime-git",
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"details": "https://github.com/kemayo/sublime-text-2-git/tree/master"
+					"details": "https://github.com/kemayo/sublime-git/tree/master"
 				},
 				{
 					"sublime_text": ">=3000",
-					"details": "https://github.com/kemayo/sublime-text-2-git/tree/python3"
+					"details": "https://github.com/kemayo/sublime-git/tree/python3"
 				}
 			]
 		},


### PR DESCRIPTION
The repository name had changed and the git plugin won't download for me any more.
Github doesn't appear to redirect the old repository for codeload download.

https://github.com/kemayo/sublime-text-2-git will redirect fine but https://codeload.github.com/kemayo/sublime-text-2-git/zip/master (which is what's used) gives a 500.
