### PR TITLE
Updating Horizontal Scroll

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -343,8 +343,8 @@
 			"details": "https://github.com/TheOnlyRew/sublime-horizontal-scroll",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"details": "https://github.com/TheOnlyRew/sublime-horizontal-scroll/tree/master"
+					"sublime_text": "*",
+					"details": "https://github.com/TheOnlyRew/sublime-horizontal-scroll/tags"
 				}
 			]
 		},


### PR DESCRIPTION
Changing version to be both ST2 and ST3 to reflect ST3-centered updates
to Horizontal Scroll. Changing releases to point to `/tags` rather than
`/tree/master`.
