### PR TITLE
Enable PowerShell extension works on Sublime Text 3

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -688,7 +688,7 @@
 			"details": "https://github.com/SublimeText/PowerShell",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/SublimeText/PowerShell/tree/master"
 				}
 			]


### PR DESCRIPTION
The PowerShell extension works on Sublime Text 3 as well, so I'd like to register it in the main channel.
