### PR TITLE
Add existing 'Color Scheme - RSE'

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -762,6 +762,17 @@
 			]
 		},
 		{
+			"name": "Color Scheme - RSE",
+			"details": "https://github.com/rse/sublime-scheme-rse",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/rse/sublime-scheme-rse/tags"
+				}
+			]
+		},
+		{
 			"name": "Color Scheme - saulhudson",
 			"details": "https://github.com/saulhudson/saulhudson-color-schemes",
 			"labels": ["color scheme"],


### PR DESCRIPTION
Add previously already existing 'Color Scheme - RSE' back under new Package Control 2 world order.
The scheme works fine under both Sublime Text 2 and 3.
