### PR TITLE
Updating Version Number for Sublemacspro

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1211,7 +1211,7 @@
 			"details": "https://github.com/grundprinzip/sublemacspro",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/grundprinzip/sublemacspro/tree/master"
 				}
 			]


### PR DESCRIPTION
It looks like with the new release of the package manager the version requirements for Sublime Text were not correctly moved. To allow using Sublemacspro in ST3 please merge this request.

Thanks
Martin
