### PR TITLE
make Haxe package available in ST3

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -119,6 +119,7 @@
 			"details": "https://github.com/clemos/haxe-sublime-bundle",
 			"releases": [
 				{
+					"sublime_text": "*",
 					"details": "https://github.com/clemos/haxe-sublime-bundle/tree/master"
 				}
 			],


### PR DESCRIPTION
Hi,
My Haxe package is compatible with both ST2 and ST3, that's it.
Thanks for your work !
