### PR TITLE
Add Razor syntax definition

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -182,15 +182,15 @@
 			]
 		},
 		{
-            		"name": "Razor",
-            		"details": "https://github.com/joseph-turner/Razor",
-            		"releases": [
-                		{
-                			"sublime_text": "*",
-                    			"details": "https://github.com/joseph-turner/Razor/tree/master"
-                		}
-            		]
-        	},
+			"name": "Razor",
+				"details": "https://github.com/joseph-turner/Razor",
+				"releases": [
+					{
+						"sublime_text": "*",
+						"details": "https://github.com/joseph-turner/Razor/tree/master"
+					}
+				]
+			},
 		{
 			"name": "Read Only Buffer",
 			"details": "https://github.com/crazybyte/SublimeReadOnlyBuffer",


### PR DESCRIPTION
Razor syntax highlighting for Sublime Text 2 & 3. I've only tested on Mac but a couple contributors have tested in Windows.
