### PR TITLE
Add previous_names for YandexTranslate

### DIFF
--- a/repository/y.json
+++ b/repository/y.json
@@ -2,9 +2,13 @@
 	"schema_version": "2.0",
 	"packages": [
 		{
-			"name": "Yandex Translate",
+			"name": "YandexTranslate",
+			"previous_names": "Yandex Translate",
 			"details": "https://github.com/pafnuty/sublime-yandex-translate",
-			"labels": ["translate"],
+			"labels": [
+				"translate",
+				"yandex"
+				],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
Today I not lucky.
I checked the plugin twice - and it works, maybe something wrong sending the patch.
