### PR TITLE
Remove version number from github repo name

### DIFF
--- a/repository/q.json
+++ b/repository/q.json
@@ -34,11 +34,11 @@
 		},
 		{
 			"name": "Quick File Move",
-			"details": "https://github.com/wulftone/sublime-text-2-quick-file-move",
+			"details": "https://github.com/wulftone/sublime-text-quick-file-move",
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/wulftone/sublime-text-2-quick-file-move/tree/master"
+					"details": "https://github.com/wulftone/sublime-text-quick-file-move/tree/master"
 				}
 			],
 			"previous_names": [


### PR DESCRIPTION
It was sublime-text-2-quick-file-move, now it's just sublime-text-quick-file-move
