### PR TITLE
Flag PureCM as compatible with ST3

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -888,7 +888,7 @@
 			"details": "https://github.com/PureCM/Sublime-Text-2-PureCM-Plugin",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/PureCM/Sublime-Text-2-PureCM-Plugin/tree/master"
 				}
 			]


### PR DESCRIPTION
With some minor edits I was able to confirm that the PureCM plugin works with the beta of Sublime Text 3.
