### PR TITLE
Updated information for the Grails plugin

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -491,6 +491,7 @@
 			"labels": ["framework support", "language syntax", "auto-complete"],
 			"releases": [
 				{
+					"sublime_text": "*",
 					"details": "https://github.com/osoco/sublimetext-grails/tags"
 				}
 			]


### PR DESCRIPTION
This plugin works fine in both Sublime 2 and 3, so I wanted to update the package control information. I also added some categories and started using versioned tags rather than the master branch. 
