### PR TITLE
SubDpaste plugin update for Sublime Text 3

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1201,11 +1201,16 @@
 			]
 		},
 		{
+			"name": "SubDpaste",
 			"details": "https://github.com/bartTC/SubDpaste",
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"details": "https://github.com/bartTC/SubDpaste/tree/master"
+					"details": "https://github.com/bartTC/SubDpaste/tree/sublime-2-stable"
+				},
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/bartTC/SubDpaste/tree/sublime-3-stable"
 				}
 			]
 		},


### PR DESCRIPTION
Added a Python 3 compatible version and added URLs for both, Sublime 2 and Sublime 3.
