### PR TITLE
GotoOpenFile is compatible with ST3

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -463,7 +463,7 @@
 			"details": "https://github.com/phildopus/sublime-goto-open-file",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/phildopus/sublime-goto-open-file/tree/master"
 				}
 			]


### PR DESCRIPTION
As discussed here:
https://github.com/phildopus/sublime-goto-open-file/issues/5
