### PR TITLE
Added "Mustang Light/Dark Color Schemes". Renamed to "Mustang Extended...

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -763,6 +763,17 @@
 			]
 		},
 		{
+			"name": "Mustang Extended Color Scheme",
+			"details": "https://github.com/piqus/sublime-themes",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/piqus/sublime-themes/tree/master"
+				}
+			]
+		},
+		{
 			"name": "MXUnit",
 			"details": "https://github.com/mxunit/sublime-text-2-mxunit",
 			"releases": [


### PR DESCRIPTION
... Color Scheme"

I used word "extended" instead of "light/dark", so without bad slash ("/").
