### PR TITLE
Removed duplicated InsertNums plugin

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -163,22 +163,17 @@
 			]
 		},
 		{
-			"name": "Insert Sequences",
+			"name": "InsertNums",
 			"details": "https://github.com/jbrooksuk/InsertNums",
+			"labels": ["automation", "utils"],
 			"releases": [
 				{
 					"sublime_text": "*",
 					"details": "https://github.com/jbrooksuk/InsertNums/tree/master"
 				}
-			]
-		},
-		{
-			"details": "https://bitbucket.org/markstahler/insert-nums",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"details": "https://bitbucket.org/markstahler/insert-nums/src/default"
-				}
+			],
+			"previous_names": [
+				"Insert Sequences"
 			]
 		},
 		{


### PR DESCRIPTION
I've removed markstahler clone of Insert Nums, renamed my previously named "Insert Sequences" plugin and added the `previous_names`.

Hopefully I've not missed anything.
