### PR TITLE
Merged old InsertNums

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -163,7 +163,7 @@
 			]
 		},
 		{
-			"name": "InsertNums",
+			"name": "Insert Nums",
 			"details": "https://github.com/jbrooksuk/InsertNums",
 			"labels": ["automation", "utils"],
 			"releases": [
@@ -173,7 +173,8 @@
 				}
 			],
 			"previous_names": [
-				"Insert Sequences"
+				"Insert Sequences",
+				"InsertNums"
 			]
 		},
 		{


### PR DESCRIPTION
I realised I had missed a space from Insert Nums, so the old plugin still existed. Now however, I've changed that and add "InsertNums" as a previous name, so all of the stats are together.
