### PR TITLE
Added package RemotePHPUnit

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -306,6 +306,7 @@
 			"details": "https://github.com/paza/RemotePHPUnit-for-Sublime-Text",
 			"releases": [
 				{
+					"sublime_text": ">2999",
 					"details": "https://github.com/paza/RemotePHPUnit-for-Sublime-Text/tags"
 				}
 			]


### PR DESCRIPTION
The plugin allows you to run PHPUnit tests on a remote server, e.g. if you are using Vagrant, on its virtual machine
