### PR TITLE
Update GitHub repo for Theme - Night

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -293,12 +293,12 @@
 		},
 		{
 			"name": "Theme - Night",
-			"details": "https://github.com/mishu91/sublime-text-theme-night",
+			"details": "https://github.com/amisarca/sublime-text-theme-night",
 			"labels": ["theme"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"details": "https://github.com/mishu91/sublime-text-theme-night/tree/master"
+					"details": "https://github.com/amisarca/sublime-text-theme-night/tree/master"
 				}
 			]
 		},


### PR DESCRIPTION
It appears mishu91 changed his GitHub username and failed to 
update Package Control with his new one (amisarca). 

GitHub has a redirect for HTTP requests but I'm guessing that 
Package Control doesn't follow redirects when attempting to fetch.
