### PR TITLE
Mark Dart compatible with ST3

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -27,7 +27,7 @@
 			"details": "https://github.com/dart-lang/dart-sublime-bundle",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/dart-lang/dart-sublime-bundle/tree/master"
 				}
 			]


### PR DESCRIPTION
Dart is compatible with ST3 as discussed in the following issues:
    \* https://github.com/dart-lang/dart-sublime-bundle/issues/27
    \* https://github.com/dart-lang/dart-sublime-bundle/issues/35
