### PR TITLE
CoffeeComplete Plus (Autocompletion) now ST3-compatible.

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -636,7 +636,7 @@
 			"details": "https://github.com/justinmahar/SublimeCSAutocompletePlus",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/justinmahar/SublimeCSAutocompletePlus/tree/master"
 				}
 			]


### PR DESCRIPTION
The plugin is now compatible with ST3. Thanks.
