### PR TITLE
Added Delete Current File

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -124,7 +124,7 @@
 			]
 		},
 		{
-			"name": "Delete File",
+			"name": "Delete Current File",
 			"details": "https://github.com/yaworsw/Sublime-DeleteCurrentFile",
 			"releases": [
 				{


### PR DESCRIPTION
I was getting annoyed with dialogs when deleting files using the command palette.

This plugin saves the file before deleting it so that sublime won't ask if you really want to delete the file.

If you know of a better way to avoid the confirmation dialog let me know. 
