### PR TITLE
Split SublimeIPythonNotebook into different trees for different versions of ST

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -222,9 +222,13 @@
 			"details": "https://github.com/maximsch2/SublimeIPythonNotebook",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3000",
 					"details": "https://github.com/maximsch2/SublimeIPythonNotebook/tags"
-				}
+				},
+				{
+					"sublime_text": "<3000",
+					"details": "https://github.com/maximsch2/SublimeIPythonNotebook/tree/st2"
+				}				
 			]
 		},
 		{


### PR DESCRIPTION
support for ST2 will be dropped from master going forward, point to ST2 branch for ST2
