### PR TITLE
Added Objective-C Autocompletion plugin

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -23,6 +23,16 @@
 			]
 		},
 		{
+			"name": "Objective-C Autocompletion",
+			"details": "https://github.com/oliverseal/objective-c-autocomplete-sublimetext",
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"details": "https://github.com/oliverseal/objective-c-autocomplete-sublimetext/tags"
+				}
+			]
+		},
+		{
 			"name": "Oblivion Color Scheme",
 			"details": "https://github.com/jbrooksuk/Oblivion",
 			"labels": ["color scheme"],


### PR DESCRIPTION
This plugin will probably expand in bursts over time. It's not meant to replace XCode. Just let us step out of the crowded XCode environment from time to time. :)
