### PR TITLE
Added the LineMessages package to the repository.

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -312,6 +312,17 @@
 			]
 		},
 		{
+			"name": "LineMessages",
+			"details": "https://github.com/nfaggian/SublimeLineMessages",
+			"labels": ["linting", "tool execution"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/nfaggian/SublimeLineMessages/tags"
+				}
+			]
+		},
+		{
 			"details": "https://github.com/perimosocordiae/LineProfiler",
 			"releases": [
 				{


### PR DESCRIPTION
LineMessages is a generic tool that allows parseable command line tools to report within the editor. Pep8 and Pylint are setup as examples, but the plugin can be used on any type of parseable command line tool. 
