### PR TITLE
Updated metadata for LoadFileToRepl package

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -476,6 +476,9 @@
 					"sublime_text": "*",
 					"details": "https://github.com/laughedelic/LoadFileToRepl/tree/master"
 				}
+			],
+			"previous_names": [
+				"LoadFileToRepl"
 			]
 		},
 		{


### PR DESCRIPTION
Just updated info. Important change is that the package works for ST2/ST3.
