### PR TITLE
Renamed Rails Go To Spec to RailsGoToSpec

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -53,24 +53,6 @@
 			]
 		},
 		{
-			"name": "RailsGoToSpec",
-			"details": "https://github.com/sporto/rails_go_to_spec",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"details": "https://github.com/sporto/rails_go_to_spec/tree/st2"
-				},
-				{
-					"sublime_text": ">=3000",
-					"details": "https://github.com/sporto/rails_go_to_spec/tree/master"
-				}
-			],
-			"previous_names": [
-				"rails_go_to_spec",
-				"Rails Go To Spec"
-			]
-		},
-		{
 			"name": "Rails I18n Helper",
 			"details": "https://github.com/Adeptus/rails-i18n-helper",
 			"releases": [
@@ -133,6 +115,24 @@
 					"sublime_text": "*",
 					"details": "https://github.com/tdm00/sublime-theme-railscasts/tree/master"
 				}
+			]
+		},
+		{
+			"name": "RailsGoToSpec",
+			"details": "https://github.com/sporto/rails_go_to_spec",
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"details": "https://github.com/sporto/rails_go_to_spec/tree/st2"
+				},
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/sporto/rails_go_to_spec/tree/master"
+				}
+			],
+			"previous_names": [
+				"rails_go_to_spec",
+				"Rails Go To Spec"
 			]
 		},
 		{


### PR DESCRIPTION
Plug in won't work when zip file was named 'Rails Go To Spec'
