### PR TITLE
Explicitly indicate Rake compatibility with all versions of SublimeText

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -150,6 +150,7 @@
 			"details": "https://github.com/SublimeText/Rake",
 			"releases": [
 				{
+					"sublime_text":"*",
 					"details": "https://github.com/SublimeText/Rake/tree/master"
 				}
 			]


### PR DESCRIPTION
As of pull request #5 on SublimeText/Rake, this package is now compatible with both ST2 and ST3. This minor change should make Rake visible on ST3.
