### PR TITLE
Changed support for GoToClass to show support for both ST2 and ST3

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -467,7 +467,7 @@
 			"details": "https://github.com/lazyguru/GoToClass",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/lazyguru/GoToClass/tree/master"
 				}
 			]


### PR DESCRIPTION
Changed version to \* so that package will show up in ST3.  I have been using it in ST3 without any modifications since ST3 first public beta
