### PR TITLE
Add EJS to ST3

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -118,7 +118,7 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/samholmes/EJS.tmLanguage/tree/master"
 				}
 			]


### PR DESCRIPTION
+1 to can be installed manually from @hustcer - https://github.com/samholmes/EJS.tmLanguage/issues/6

@samholmes - can you come comment/approve here for this request so we can install from the ST3 package control channel? Thanks!
