### PR TITLE
Updated Indent XML plugin to work with ST3

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -126,7 +126,7 @@
 			"details": "https://github.com/alek-sys/sublimetext_indentxml",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/alek-sys/sublimetext_indentxml/tree/master"
 				}
 			]


### PR DESCRIPTION
Sublime Text 3 is supported and plugin works fine there, however was
missed in list of available plugins due to config limitations
