### PR TITLE
Updated ColorConvert for Sublime Text 3 support

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1159,7 +1159,7 @@
 			"details": "https://github.com/TheDutchCoder/ColorConvert",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/TheDutchCoder/ColorConvert/tree/master"
 				}
 			]


### PR DESCRIPTION
It works. More details from @TheDutchCoder here:
See https://github.com/TheDutchCoder/ColorConvert/issues/7
