### PR TITLE
Remove RSpec TextMate bundle (unsupported in Sublime)

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -581,7 +581,7 @@
 			"details": "https://github.com/SublimeText/RSpec",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/SublimeText/RSpec/tree/master"
 				}
 			]


### PR DESCRIPTION
I found myself in the situation where you can't install the Sublime Text RSpec package in ST3, but you can install the RSpec TextMate bundle (which lacks features). So after upgrading to ST3 I found myself wondering why some snippets had disappeared.

I reported this in the `rspec/rspec-tmbundle` repo and the word from @pcasaretto is that the TextMate bundle is unsupported in Sublime Text and should be removed: https://github.com/rspec/rspec-tmbundle/issues/61
