### PR TITLE
Enable RSpec in all ST versions

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -235,7 +235,7 @@
 					"details": "https://github.com/felipeelias/sublime-text-2-rbenv/tree/master"
 				}
 			]
-		},		
+		},
 		{
 			"name": "Read Only Buffer",
 			"details": "https://github.com/crazybyte/SublimeReadOnlyBuffer",
@@ -581,7 +581,7 @@
 			"details": "https://github.com/SublimeText/RSpec",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/SublimeText/RSpec/tree/master"
 				}
 			]


### PR DESCRIPTION
It's a known issue in the RSpec package that it's flagged as only available to ST2 users: https://github.com/SublimeText/RSpec/issues/34

I can confirm @jarhart's experience that it works fine in ST3. Nothing has happened on this for a while so I thought I'd submit a pull request and see if anyone complains.

I've just submitted a pull request to remove the RSpec TextMate bundle from Package Control: https://github.com/wbond/package_control_channel/pull/2321 – so if this is also merged it will mean ST3 users see the correct package in the install list.
