### PR TITLE
Add Cheatsheets Rails package to repository

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -242,7 +242,7 @@
 			"details": "https://github.com/OrelSokolov/Cheatsheets-Rails",
 			"releases": [
 				{
-					"sublime_text": "2",
+					"sublime_text": "<3000",
 					"details": "https://github.com/OrelSokolov/Cheatsheets-Rails/tree/master"
 				}
 			]


### PR DESCRIPTION
`Cheatsheets Rails` contains some useful cheatsheets for Ruby on Rails developers. 
