### PR TITLE
Add DoxyDoc package

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -439,7 +439,7 @@
 		},
 		{
 			"name": "DoxyDoc",
-			"details": "https://github.com/Rapptz/doxydoc"
+			"details": "https://github.com/Rapptz/doxydoc",
 			"labels": ["auto-complete", "snippets"],
 			"releases": [
 				{


### PR DESCRIPTION
A package for Doxygen documentation aimed specifically for C++.

(sorry about the automatically generated pull request commit)
