### PR TITLE
Updated repo location for RTools (GitHub username change)

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -3,11 +3,11 @@
 	"packages": [
 		{
 			"name": "R Tools",
-			"details": "https://github.com/karthikram/Rtools",
+			"details": "https://github.com/karthik/Rtools",
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"details": "https://github.com/karthikram/Rtools/tree/master"
+					"details": "https://github.com/karthik/Rtools/tree/master"
 				}
 			]
 		},


### PR DESCRIPTION
My GitHub username changed from `karthikram` to `karthik` so I had to update the URL for the `RTools` repo. 
