### PR TITLE
Removed ST2 restriction for Composer plugin now that master supports ST3

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1026,6 +1026,7 @@
 			"details": "https://github.com/francodacosta/composer-sublime",
 			"releases": [
 				{
+					"sublime_text": "*",
 					"details": "https://github.com/francodacosta/composer-sublime/tree/master"
 				}
 			]


### PR DESCRIPTION
The package maintainer for Composer now supports ST3, it's on the same branch as ST2 support so the best way to make it available is to remove the ST2 only restriction.
