### PR TITLE
Added Snippet Destroyer

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -944,6 +944,21 @@
 			]
 		},
 		{
+			"name": "Snippet Destroyer",
+			"details": "https://github.com/twolfson/sublime-snippet-destroyer",
+			"labels": [
+				"snippet",
+				"delete",
+				"destroy"
+			],
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"details": "https://github.com/twolfson/sublime-snippet-destroyer/tags"
+				}
+			]
+		},
+		{
 			"name": "SnippetMaker",
 			"details": "https://github.com/jugyo/SublimeSnippetMaker",
 			"releases": [


### PR DESCRIPTION
`sublime-snippet-destroyer` is a plugin that finds and destroys all Sublime completions and snippets for Sublime Text 2. In this PR:
- Add `sublime-snippet-destroyer` to `s.json`

https://github.com/twolfson/sublime-snippet-destroyer
