### PR TITLE
Update ST Version Compatibility for Duplicate Lines plugin

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -546,7 +546,7 @@
 			"details": "https://github.com/wjthomas9/duplicate-lines",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/wjthomas9/duplicate-lines/tree/master"
 				}
 			]


### PR DESCRIPTION
Allow duplicate lines plugin to be installed on ST2 and 3.
