### PR TITLE
PythonTraceback supports ST-2

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1188,8 +1188,8 @@
 			"labels": ["file navigation"],
 			"releases": [
 				{
-					"sublime_text": ">3000",
-					"details": "https://github.com/kedder/sublime-python-traceback/tree/master"
+					"sublime_text": "*",
+					"details": "https://github.com/kedder/sublime-python-traceback/tags"
 				}
 			]
 		}


### PR DESCRIPTION
Also, use tags-based releases.
