### PR TITLE
Added To-Done package

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -636,6 +636,17 @@
 			]
 		},
 		{
+			"name": "To-Done",
+			"details": "https://github.com/tiffon/sublime-to-done",
+			"labels": ["todo", "productivity", "tasks"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/tiffon/sublime-to-done/tags"
+				}
+			]
+		},
+		{
 			"details": "https://github.com/rodrigoflores/today",
 			"releases": [
 				{
@@ -1114,16 +1125,6 @@
 				{
 					"sublime_text": "*",
 					"details": "https://bitbucket.org/danielsiepmann-team/sublime-text-typoscript/src/default"
-				}
-			]
-		},
-		{
-			"name": "To-Done",
-			"details": "https://github.com/tiffon/sublime-to-done",
-			"labels": ["todo", "productivity", "tasks"],
-			"releases": [
-				{
-					"details": "https://github.com/tiffon/sublime-to-done/tags"
 				}
 			]
 		}


### PR DESCRIPTION
To-Done is a simple tool for creating to do lists. To do lists are just text files with the extension "todo". The functionality of this package is based entirely on a language syntax.

![example-goto](https://f.cloud.github.com/assets/2304337/1650603/cd2e538a-5a9b-11e3-9bed-71f0bbd4b173.png)
