### PR TITLE
Add Better OCaml package

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -44,6 +44,18 @@
 			]
 		},
 		{
+			"name": "OCaml",
+			"description": "An improved version of default OCaml package",
+			"details": "https://github.com/whitequark/sublime-better-ocaml",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/whitequark/sublime-better-ocaml"
+				}
+			]
+		},
+		{
 			"name": "OCaml Autocompletion",
 			"details": "https://github.com/whitequark/sublime-ocp-index",
 			"releases": [


### PR DESCRIPTION
Name clash with the default OCaml package is deliberate. 

Explicit description field is deliberate, too.
