### PR TITLE
Update Vintage Escape url

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -146,11 +146,11 @@
 		},
 		{
 			"name": "Vintage Escape",
-			"details": "https://github.com/krussell/VintageEscape",
+			"details": "https://github.com/tonymagro/VintageEscape",
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/krussell/VintageEscape/tree/master"
+					"details": "https://github.com/tonymagro/VintageEscape/tree/master"
 				}
 			]
 		},


### PR DESCRIPTION
I had to change my current github username from 'krussell' to 'tonymagro' and create a new account for 'krussell'. My new https://github.com/krussell account will not be hosting VintageEscape. As a result, VintageEscape's location has changed along with my username and is now located at https://github.com/tonymagro/VintageEscape. This change updates v.json with the new url. Sorry for the inconvenience.
