### PR TITLE
add CoffeeSugar

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -838,6 +838,16 @@
 			]
 		},
 		{
+			"name": "CoffeeSugar",
+			"details": "https://github.com/benjycui/CoffeeSugar-Sublime-Plugin",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/benjycui/CoffeeSugar-Sublime-Plugin/tree/master"
+				}
+			]
+		},
+		{
 			"name": "ColdBox Platform",
 			"details": "https://github.com/lmajano/cbox-coldbox-sublime",
 			"releases": [


### PR DESCRIPTION
CoffeeScript plug-in was originally created by @Xavura. Unluckily, the original cannot support Sublime Text 3. So, it was forked and migrated to Sublime Text 3.

Some functionalities were also discarded, for Grunt can do it better:
- Syntax checking
- Commands / Shortcuts
- Compilation
