### PR TITLE
SassBeautify: use tags instead of master

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -85,7 +85,7 @@
 				{
 					"sublime_text": "*",
 					"platforms": "*",
-					"details": "https://github.com/badsyntax/SassBeautify/tree/master"
+					"details": "https://github.com/badsyntax/SassBeautify/tags"
 				}
 			]
 		},


### PR DESCRIPTION
The title says it all. I would like to start managing this plugin with tags.
