### PR TITLE
Add HighlightNonASCII plugin.

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -283,16 +283,6 @@
 			]
 		},
 		{
-			"name": "HighlightNonASCII",
-			"details": "https://github.com/isundaylee/sublime-highlight-non-ascii",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"details": "https://github.com/isundaylee/sublime-highlight-non-ascii/tags"
-				}
-			]
-		},
-		{
 			"name": "Highlight Whitespaces",
 			"details": "https://github.com/disq/HighlightWhitespaces",
 			"labels": ["formatting", "language syntax", "linting"],
@@ -323,6 +313,16 @@
 				}
 			],
 			"previous_names": ["Highlight-Mixed-Whitespace"	]
+		},
+		{
+			"name": "HighlightNonASCII",
+			"details": "https://github.com/isundaylee/sublime-highlight-non-ascii",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/isundaylee/sublime-highlight-non-ascii/tags"
+				}
+			]
 		},
 		{
 			"details": "https://github.com/seanliang/HighlightWords",


### PR DESCRIPTION
HighlightNonASCII is a simple plugin that highlights all non-ASCII characters in the current document. 
