### PR TITLE
Allow Theme - Night to be installed on ST3

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -335,7 +335,7 @@
 			"labels": ["theme"],
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/amisarca/sublime-text-theme-night/tree/master"
 				}
 			]


### PR DESCRIPTION
I've been using this theme with ST3 for months now and it works fine.
