### PR TITLE
Test against package names containing periods

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -187,6 +187,11 @@ class TestContainer(object):
                 # Invalid on OS X (or more precisely: hidden)
                 self.assertFalse(v.startswith('.'))
 
+        self.assertFalse(
+            '.' in data['name'],
+            'Package names should not contain .: %r' % data['name']
+        )
+
         if 'details' not in data:
             for key in ('name', 'homepage', 'author', 'releases'):
                 self.assertIn(key, data, '%r is required if no "details" URL '


### PR DESCRIPTION
The test rejects any package name containing a period because they will error in Sublime Text 3 if they define python modules.

When the packages are compiled into sublime-package bundles any filenames containing a period confuse the Sublime Text plugin loader. This is on account of python (sub)modules being separated by a period. It attempts to, for example, `importlib.import_module('Module.app Menu')`. This maps to looking for module "Module" and "app Menu" within for which the sublime-package would be Module.sublime-package but is not where our plugin is packaged to by Package Control.

I'm not sure whether this is the right way to solve this. Arguably Package Control or Sublime should handle the scenario I'm testing against here. Some examples of troublesome packages (you'll see an ImportError in the console when you load Sublime Text 3):
- Marked.app Menu (rename PR: #2525)
- Mou.app Menu

Currently failing tests, which do not all include python modules and therefore do not experience this error:

```
$ python tests/test.py 2>&1 | grep AssertionError
AssertionError: True is not false : Package names should not contain .: 'Apiary.io Blueprint'
AssertionError: True is not false : Package names should not contain .: 'Asp.Net File Switch'
AssertionError: True is not false : Package names should not contain .: 'Backbone.Marionette'
AssertionError: True is not false : Package names should not contain .: 'Backbone.js'
AssertionError: True is not false : Package names should not contain .: 'Chaplin.js'
AssertionError: True is not false : Package names should not contain .: 'Codepad.org Paste Plugin'
AssertionError: True is not false : Package names should not contain .: 'Conky.tmLanguage'
AssertionError: True is not false : Package names should not contain .: 'Dust.js'
AssertionError: True is not false : Package names should not contain .: 'Ember.js Snippets'
AssertionError: True is not false : Package names should not contain .: 'FakeImg.pl Image Placeholder Snippet'
AssertionError: True is not false : Package names should not contain .: 'jQuery Mobile 1.4 Snippets'
AssertionError: True is not false : Package names should not contain .: 'Kohana 2.x Snippets'
AssertionError: True is not false : Package names should not contain .: 'Lazy Backbone.js'
AssertionError: True is not false : Package names should not contain .: 'Marked.app Menu'
AssertionError: True is not false : Package names should not contain .: 'Mou.app Markdown'
AssertionError: True is not false : Package names should not contain .: 'objc .strings syntax language'
AssertionError: True is not false : Package names should not contain .: 'PEG.js'
AssertionError: True is not false : Package names should not contain .: 'Paste to friendpaste.com'
AssertionError: True is not false : Package names should not contain .: 'Paste to paste.pm'
AssertionError: True is not false : Package names should not contain .: 'Placehold.it Image Tag Generator'
AssertionError: True is not false : Package names should not contain .: 'Play 2.0'
AssertionError: True is not false : Package names should not contain .: 'Require Node.js Modules Helper'
AssertionError: True is not false : Package names should not contain .: 'Ruby 1.9 Hash Converter'
AssertionError: True is not false : Package names should not contain .: 'Simple Ember.js Navigator'
AssertionError: True is not false : Package names should not contain .: 'Snipt.net'
AssertionError: True is not false : Package names should not contain .: 'SourceTree.app Menu'
AssertionError: True is not false : Package names should not contain .: 'Theme - itg.flat'
AssertionError: True is not false : Package names should not contain .: 'Three.js Autocomplete'
AssertionError: True is not false : Package names should not contain .: 'Todo.txt Syntax'
AssertionError: True is not false : Package names should not contain .: 'Underscore.js Snippets'
AssertionError: True is not false : Package names should not contain .: 'wpseek.com WordPress Function Lookup'
```
