### PR TITLE
Add TabsShortcuts plugin

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -48,6 +48,16 @@
 			]
 		},
 		{
+			"name": "TabsShortcuts",
+			"details": "https://github.com/ejoubaud/SublimeTabsShortcuts",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/ejoubaud/SublimeTabsShortcuts/tree/master"
+				}
+			]
+		},
+		{
 			"details": "https://github.com/jbrooksuk/TabsToTable",
 			"releases": [
 				{


### PR DESCRIPTION
Adds command palette commands and keyboard shortcuts for `Close Other Tabs` and `Close Tabs to the Right` actions.

See https://github.com/ejoubaud/SublimeTabsShortcuts
