### PR TITLE
Adds Delete Lines plugin.

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -161,6 +161,7 @@
 			"labels": ["text manipulation"],
 			"releases": [
 				{
+					"sublime_text": "*",
 					"details": "https://github.com/harawata/sublime-delete-lines/tags"
 				}
 			]


### PR DESCRIPTION
Please see the README for how it's different from the built-in Delete Line macro (ctrl+shift+k).
https://github.com/harawata/sublime-delete-lines/
It would be nicer if you could change the built-in macro behavior, actually.
