### PR TITLE
Add csslisible release for st3

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1433,6 +1433,10 @@
 				{
 					"sublime_text": "<3000",
 					"details": "https://github.com/thierrylemoulec/Sublime-Csslisible/tree/master"
+				},
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/thierrylemoulec/Sublime-Csslisible/tree/st3"
 				}
 			]
 		},


### PR DESCRIPTION
Add a new release for compatibility with st3 of Csslisible

PS : Don't know if it's the right way to do it when there is no compatibility between the st2 and st3 version.
