### PR TITLE
migrate Cirru repo

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -406,12 +406,12 @@
 		},
 		{
 			"name": "Cirru",
-			"details": "https://github.com/jiyinyiyong/Sublime-Cirru",
+			"details": "https://github.com/cirru/sublime-cirru",
 			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/jiyinyiyong/Sublime-Cirru/tree/master"
+					"details": "https://github.com/cirru/sublime-cirru/tree/master"
 				}
 			]
 		},


### PR DESCRIPTION
Repo migrated from `jiyinyiyong/Sublime-Cirru` to `cirru/sublime-cirru`.
