### PR TITLE
Change PerlTidy to use semantic versioning/tags.

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -125,7 +125,6 @@
 		"https://raw.github.com/timonwong/sublime_packages/master/packages.json",
 		"https://raw.github.com/tmanderson/VintageLines/master/packages.json",
 		"https://raw.github.com/tomascayuelas/coolcodescheme/master/packages.json",
-		"https://raw.github.com/vifo/SublimePerlTidy/master/packages.json",
 		"https://raw.github.com/vkocubinsky/sublime_packages/master/packages.json",
 		"https://raw.github.com/wallysalami/QuickLook/master/packages.json",
 		"https://raw.github.com/weslly/sublime_packages/master/packages.json",

--- a/repository/p.json
+++ b/repository/p.json
@@ -315,6 +315,22 @@
 			]
 		},
 		{
+			"name": "PerlTidy",
+			"description": "perltidy/Perl::Tidy plugin - A Perl script indenter and reformatter.",
+			"details": "https://github.com/vifo/SublimePerlTidy",
+			"labels": [
+				"formatting",
+				"perl",
+				"tidy"
+			],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/vifo/SublimePerlTidy/tags"
+				}
+			]
+		},
+		{
 			"details": "https://github.com/skuroda/PersistentRegexHighlight",
 			"releases": [
 				{


### PR DESCRIPTION
Hi folks,

I've just changed PerlTidy package control channel settings to use semantic versioning/tags. Please accept.

Thanks and regards,
vifo.
