### PR TITLE
Added Tabs or Spaces plug-in

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -38,7 +38,7 @@
 			"details": "https://github.com/vitto/sublime-tabs-or-spaces",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "*",
 					"details": "https://github.com/vitto/sublime-tabs-or-spaces/tree/master"
 				}
 			]


### PR DESCRIPTION
A simple plugin to convert tabs to spaces or vice versa in Sublime Text 3 when saving.

Just set `translate_tab_to_spaces` inside your `Preferences.sublime-settings`:

**To convert tabs to spaces**

``` json
{
    "translate_tab_to_spaces": true
}
```

**To convert spaces to tabs**

``` json
{
    "translate_tab_to_spaces": false
}
```
