### PR TITLE
Add package info of Drupal Completion ST

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -548,7 +548,7 @@
 			]
 		},
 		{
-			"name": "Drupal Completion ST",
+			"name": "Drupal Completions",
 			"details": "https://github.com/flashvnn/Drupal-Completion-ST",
 			"releases": [
 				{


### PR DESCRIPTION
Add package info of Drupal Completion ST, support code completion for Drupal core and common module like ctools, views, token, entity, libraries, devel, bean...
