### PR TITLE
Add RubySyntaxGuard package

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -898,6 +898,16 @@
 			]
 		},
 		{
+			"name": "RubySyntaxGuard",
+			"details": "https://github.com/jalkoby/RubySyntaxGuard",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/jalkoby/RubySyntaxGuard/tree/master"
+				}
+			]
+		},
+		{
 			"name": "RubyTest",
 			"details": "https://github.com/maltize/sublime-text-2-ruby-tests",
 			"releases": [


### PR DESCRIPTION
This package is a fork from https://github.com/edgar/RubyCheckOnSave . A month ago I forked it and changed default notification from opening ST console and put raw error from ruby interpreter to showing a popup window. The popup window includes a number of a line with error and a reason. After one month didn't got any feedback from author of original plugin, so I decided to publish it like a standalone plugin.
