### PR TITLE
added SublimeBrowse plugin

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -196,7 +196,7 @@
 			"labels": ["file navigation","file creation", "file open"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "*",
 					"details": "https://github.com/aziz/SublimeFileBrowser/tags"
 				}
 			]


### PR DESCRIPTION
I want to name this plugin "SublimeBrowse" not just Browse, so I intentionally did not remove sublime from the beginning.
