### PR TITLE
Added Pandoc Referencer

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -69,7 +69,7 @@
 			]
 		},
 		{
- 			"name": "Pandoc Referencer",
+			"name": "Pandoc Referencer",
 			"details": "https://github.com/scotartt/PandocReferencr",
 			"releases": [
 				{


### PR DESCRIPTION
This plugin allows for the insertion and checking of Pandoc/Markdown Footnotes
