### PR TITLE
Add sublime-google-sublime plugin

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -494,6 +494,16 @@
 			]
 		},
 		{
+			"name": "Google Sublime",
+			"details": "https://github.com/clarkema/sublime-google-sublime",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/clarkema/sublime-google-sublime/tags"
+				}
+			]
+		},
+		{
 			"name": "Google Translate",
 			"details": "https://github.com/lfont/Sublime-Text-2-GoogleTranslate-Plugin",
 			"releases": [


### PR DESCRIPTION
Add a trivial new plugin that makes it easy to open a browser on a Sublime-specific Google search, because I got bored of doing it by hand.

This is my first Sublime plugin, so any feedback gratefully accepted.
