### PR TITLE
allow Hyperion for Gettext in Sublime Text 3

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -693,7 +693,7 @@
 			"details": "https://github.com/thie1210/hyperion",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/thie1210/hyperion/tags"
 				}
 			]


### PR DESCRIPTION
I have installed Hyperion for Gettext manually inside Sublime Text 3 (build 3059) and it appears to work fine.
