### PR TITLE
adds CopyToHipChat

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1233,7 +1233,7 @@
 			]
 		},
 		{
-		"name": "Copy to HipChat",
+			"name": "Copy to HipChat",
 			"details": "https://github.com/phlco/CopyToHipChat",
 			"author": "philco",
 			"labels": ["language syntax", "text manipulation", "formatting", "utilities", "code sharing", "hipchat", "remote collaboration"],


### PR DESCRIPTION
Plugin to append `/code #path/to/filename` to selected text to paste into HipChat
