### PR TITLE
Update plugin name for csscomb.js

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1482,7 +1482,7 @@
 			]
 		},
 		{
-			"name": "CSScomb.js",
+			"name": "CSScomb JS",
 			"details": "https://github.com/csscomb/csscomb.js-for-sublime",
 			"releases": [
 				{


### PR DESCRIPTION
Apparently having a dot in package name is not a good idea.
I think it's worth mentioning somewhere in readme.
