### PR TITLE
Added 'Missing Palette Commands (Sublime Text 3)'

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -542,6 +542,16 @@
 			]
 		},
 		{
+			"name": "Missing Palette Commands (Sublime Text 3)",
+			"details": "https://github.com/briangordon/sublime-3-missing-palette-commands",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/briangordon/sublime-3-missing-palette-commands/tags"
+				}
+			]
+		},
+		{
 			"name": "MivaScript",
 			"details": "https://github.com/zquintana/SublimeMivaScript",
 			"releases": [


### PR DESCRIPTION
I created a new 'Missing Palette Commands' based on the commands available in ST3. This adds a LOT of stuff not present in the original, which is targeted to ST2.
