### PR TITLE
Added sublime-codec (https://github.com/furikake/sublime-codec) entry

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -700,22 +700,22 @@
 			]
 		},
 		{
-			"name": "Codechef",
-			"details": "https://github.com/prongs/SublimeCodechef",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"details": "https://github.com/prongs/SublimeCodechef/tree/master"
-				}
-			]
-		},
-		{
 			"name": "Codec",
 			"details": "https://github.com/furikake/sublime-codec",
 			"releases": [
 				{
 					"sublime_text": ">=3000",
 					"details": "https://github.com/furikake/sublime-codec/tags"
+				}
+			]
+		},
+		{
+			"name": "Codechef",
+			"details": "https://github.com/prongs/SublimeCodechef",
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"details": "https://github.com/prongs/SublimeCodechef/tree/master"
 				}
 			]
 		},


### PR DESCRIPTION
Please add the Sublime-Codec plugin to Package Control.

It allows the user to run various codec over the selection.  Currently supports:
- SHA1, SHA-224, SHA-256, SHA-384, SHA-512, MD5
- URL encode / URL encode plus
- Base64, Base64 URL safe, Base32, Base16

I find it helpful for my API work as I'm lazy and don't want to drop into CLI, IDE or websites to do common codec related functions. Hopefully others will find it useful too.
