### PR TITLE
Codec plugin supports all Sublime Text versions

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -704,7 +704,7 @@
 			"details": "https://github.com/furikake/sublime-codec",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "*",
 					"details": "https://github.com/furikake/sublime-codec/tags"
 				}
 			]


### PR DESCRIPTION
Hi again.  I didn't realise it was going to be so easy to make the plugin support ST2 and ST3.
