### PR TITLE
Levels plugin works at st2 and st3!

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -302,7 +302,7 @@
 			"details": "https://github.com/mazurov/sublime-levels",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/mazurov/sublime-levels/tree/master"
 				}
 			]


### PR DESCRIPTION
Bug: Levels  plugin appears only at ST2 Package Control, but works also at ST3.
Fixes mazurov/sublime-levels#12
