### PR TITLE
added plugin https://github.com/cbumgard/GitCommitMsg

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -184,17 +184,7 @@
 					"details": "https://github.com/kemayo/sublime-text-git/tree/python3"
 				}
 			]
-		},
-		{
-			"name": "GitCommitMsg",
-			"details": "https://github.com/cbumgard/GitCommitMsg",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"details": "https://github.com/cbumgard/GitCommitMsg/tree/master"
-				}
-			]
-		},		
+		},	
 		{
 			"name": "Git Config",
 			"details": "https://github.com/robballou/gitconfig-sublimetext",
@@ -225,6 +215,16 @@
 				}
 			]
 		},
+		{
+			"name": "GitCommitMsg",
+			"details": "https://github.com/cbumgard/GitCommitMsg",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/cbumgard/GitCommitMsg/tree/master"
+				}
+			]
+		},			
 		{
 			"name": "GitGrep",
 			"details": "https://github.com/jugyo/SublimeGitGrep",


### PR DESCRIPTION
A plugin that shows the git commit history for one or more lines of code. Essentially it performs a git blame on the selected line(s) of code, and then performs a git show on the resulting commit(s). Inspired by "Every line of code is always documented" (http://mislav.uniqpath.com/2014/02/hidden-documentation/)
