### PR TITLE
Make FileZilla SFTP Import available in ST3

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -288,7 +288,7 @@
 			"details": "https://github.com/ment4list/SublimeZilla",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/ment4list/SublimeZilla/tree/master"
 				}
 			]


### PR DESCRIPTION
I was not seeing FileZilla SFTP Import in the list of plugins using Package Control in ST3 so I changed the "sublime_text" parameter to include all versions. 

I have tested this in ST2 & 3 and it's working as expected.
