### PR TITLE
Adding Phabricator package

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -406,6 +406,20 @@
 			]
 		},
 		{
+			"name": "Phabricator",
+			"details": "https://github.com/uber/sublime-phabricator",
+			"labels": [
+				"browser integration",
+				"code sharing"
+			],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/uber/sublime-phabricator/tags"
+				}
+			]
+		},
+		{
 			"name": "Phaser Snippets",
 			"details": "https://github.com/Arlefreak/Phaser-Snippets",
 			"labels": ["snippets"],


### PR DESCRIPTION
We have created `sublime-phabricator`, a Sublime plugin that allows opening code inside of its Phabricator instance. In this PR:
- Add `Phabricator` package inside of `p.json`

More information can be found at:

https://github.com/uber/sublime-phabricator
