### PR TITLE
[sparql-runner] Changed details and min version

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1221,8 +1221,8 @@
 			"details": "https://github.com/cezarsa/sublime-sparql-runner",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"details": "https://github.com/cezarsa/sublime-sparql-runner/tree/master"
+					"sublime_text": "*",
+					"details": "https://github.com/cezarsa/sublime-sparql-runner/tags"
 				}
 			]
 		},


### PR DESCRIPTION
It supports both sublime 2 and 3, also using tags path instead of master for versioning.
