### PR TITLE
OmniDocs now supports ST2

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -114,7 +114,7 @@
 			"labels": ["search", "documentation"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "*",
 					"details": "https://github.com/bordaigorl/sublime-omnidocs/tags"
 				}
 			]


### PR DESCRIPTION
OmniDocs 1.1.0 (just released) offers support for ST2 as well as ST3
