### PR TITLE
Added Craft-Twig to Package Control

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1328,6 +1328,16 @@
 			]
 		},
 		{
+			"name": "Craft-Twig",
+			"details": "https://github.com/BarrelStrength/Craft-Twig.tmbundle",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/BarrelStrength/Craft-Twig.tmbundle/tags"
+				}
+			]
+		},
+		{
 			"details": "https://github.com/Siddley/Creole",
 			"labels": ["language syntax"],
 			"releases": [


### PR DESCRIPTION
Craft-Twig is a fork of PHP-Twig that adds support for Craft CMS specific uses of Twig.
