### PR TITLE
Update version requirement for Revert All Files

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -549,7 +549,7 @@
 			"details": "https://github.com/AllStruck/Sublime-Text-2-Revert-All-Files",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/AllStruck/Sublime-Text-2-Revert-All-Files/tree/master"
 				}
 			]


### PR DESCRIPTION
The plugin is working without any issues on build 3059 currently and should work on future builds given how trivial it is.
