### PR TITLE
added LineJumper

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -411,17 +411,6 @@
 			]
 		},
 		{
-			"name": "BlockJumper",
-			"details": "https://github.com/hypebeast/BlockTravel",
-			"labels": ["editor"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"details": "https://github.com/hypebeast/BlockTravel/tags"
-				}
-			]
-		},
-		{
 			"name": "Block Nav",
 			"details": "https://github.com/jmm/Sublime-Text-Block-Nav/tree/package-control",
 			"releases": [


### PR DESCRIPTION
LineJumper is a Sublime Text 3 plugin that adds commands to move your cursor and select 10 lines (or less or more) at a time.
