### PR TITLE
Add Salesforce Reference plugin

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -33,7 +33,7 @@
 		},
 		{
 			"name": "Salesforce Reference",
-			"details": "https://github.com/Oblongmana/sublime-salesforce-reference/",
+			"details": "https://github.com/Oblongmana/sublime-salesforce-reference",
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
Salesforce Reference gives quick access to specific locations in Salesforce Documentation from within Sublime Text
