### PR TITLE
Moving Sublemacs2 support to a different branch

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1621,7 +1621,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/grundprinzip/sublemacspro/tree/master"
+					"details": "https://github.com/grundprinzip/sublemacspro/tree/release/st2/current"
 				}
 			]
 		},


### PR DESCRIPTION
For upcoming version tagging of our plugin we have to move the Sublemacs support for Sublime Text 2 to a different branch.

Thanks
Martin
