### PR TITLE
Typewriter, multiple builds

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -1333,7 +1333,11 @@
 			"details": "https://github.com/alehandrof/Typewriter",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<3000",
+					"details": "https://github.com/alehandrof/Typewriter/st2"
+				},
+				{
+					"sublime_text": ">=3000",
 					"details": "https://github.com/alehandrof/Typewriter/tags"
 				}
 			]


### PR DESCRIPTION
I want to separate this plugin into two builds, one for ST2 and one for ST3. I am not planning to continue development of the ST2 build; it will be moved to its own branch (st2). I've been using the tags versioning method, which I would like to retain for ST 3 branch, which I will relocate to master (it's in the devel branch currently).

Give the above, does this PR make sense? 
