### PR TITLE
Moving Hayaku to tag releases

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -144,7 +144,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/hayaku/hayaku/tree/master"
+					"details": "https://github.com/hayaku/hayaku/tags"
 				}
 			]
 		},


### PR DESCRIPTION
Also, it would be nice if you'd look at the [`messages.json`](https://github.com/hayaku/hayaku/blob/rc-1.4/messages.json) in our `rc-1.4` branch, there are a few things left to do and we plan to push the new release somewhere after the support for messaging would be added to PC.
