### PR TITLE
Rename SublimePythonIDE. Add labels.

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1361,6 +1361,17 @@
 			]
 		},
 		{
+			"name": "Python IDE",
+			"details": "https://github.com/JulianEberius/SublimePythonIDE",
+			"labels": ["auto-complete", "linting"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/JulianEberius/SublimePythonIDE/tree/master"
+				}
+			],
+		},
+		{
 			"name": "Python Import Magic",
 			"details": "https://github.com/alecthomas/SublimePythonImportMagic",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -2049,18 +2049,6 @@
 			]
 		},
 		{
-			"details": "https://github.com/JulianEberius/SublimePythonIDE",
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"details": "https://github.com/JulianEberius/SublimePythonIDE/tree/master"
-				}
-			],
-			"previous_names": [
-				"Python IDE"
-			]
-		},
-		{
 			"details": "https://github.com/ostinelli/SublimErl",
 			"releases": [
 				{


### PR DESCRIPTION
This removes the 'Sublime' part from SublimePythonIDE and adds appropriate labels.
This is pending approval from @JulianEberius, see related issue JulianEberius/SublimePythonIDE#54
