### PR TITLE
doTjs Template Syntax Highlighting

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -504,7 +504,7 @@
 			]
 		},
 		{
-			"name": "doT.js Template Syntax Highlighting",
+			"name": "doTjs Template Syntax Highlighting",
 			"details": "https://github.com/ZombieHippie/dotjs.tmLanguage",
 			"labels": ["language syntax"],
 			"releases": [


### PR DESCRIPTION
Adds the doTjs template engine — [homepage](http://olado.github.io/doT/index.html) — syntax highlighting.
![Imgur](http://i.imgur.com/0zIYcqc.png)
