### PR TITLE
Adding the new Evernote plugin for ST3

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -435,6 +435,17 @@
 			]
 		},
 		{
+			"name": "Evernote",
+			"details": "https://github.com/bordaigorl/sublime-evernote",
+			"labels": ["evernote", "markdown"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/bordaigorl/sublime-evernote/tags"
+				}
+			]
+		},
+		{
 			"name": "Everything Search",
 			"details": "https://github.com/XuefengWu/EverythingSearch-sublime2",
 			"releases": [


### PR DESCRIPTION
The old SublimeEvernote plugin is not supported by ST3.
This is a fork which is _only_ supported by ST3 and adds lots of features.
The fact that the two plugins target disjoint versions of ST and this version adds substantially new features, I am submitting this as a separate plugin (I attempted in contacting the author of the ST2 version with no luck).
