### PR TITLE
Updated Super Calculator compatibility

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2281,7 +2281,7 @@
 			"details": "https://github.com/Pephers/Super-Calculator",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/Pephers/Super-Calculator/tree/master"
 				}
 			]


### PR DESCRIPTION
I've changed the sublime_text version to allow for any version as the Super Calculator plugin now supports both Sublime Text 2 and Sublime Text 3.
