### PR TITLE
Add BuildAntTarget plugin to repository.

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -629,17 +629,6 @@
 			]
 		},
 		{
-			"name": "Build Next",
-			"details": "https://github.com/albertosantini/sublimetext-buildnext",
-			"labels": ["build system"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"details": "https://github.com/albertosantini/sublimetext-buildnext/tags"
-				}
-			]
-		},
-		{
 			"name": "Build Ant Target",
 			"details": "https://github.com/ryanhefner/BuildAntTarget",
 			"labels": ["ant", "building", "build system"],
@@ -647,6 +636,17 @@
 				{
 					"sublime_text": "*",
 					"details": "https://github.com/ryanhefner/BuildAntTarget/tags"
+				}
+			]
+		},
+		{
+			"name": "Build Next",
+			"details": "https://github.com/albertosantini/sublimetext-buildnext",
+			"labels": ["build system"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/albertosantini/sublimetext-buildnext/tags"
 				}
 			]
 		},


### PR DESCRIPTION
A more flexible system for Ant builds, allowing for build files to be named whatever you like and located anywhere in a project, and offers access to individual targets in the build file.
