### PR TITLE
Added cfpExt

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -250,6 +250,16 @@
 			]
 		},
 		{
+			"details": "https://github.com/gravejester/cfpExt",
+			"labels": ["clipboard"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/gravejester/cfpExt/tree/master"
+				}
+			]
+		},
+		{
 			"name": "Chai Completions",
 			"details": "https://github.com/seethroughtrees/sublime-chai-full-completions",
 			"releases": [


### PR DESCRIPTION
cfpExt (Copy File Path Extension) is a simple plugin that adds the option to copy the filename, path or both of the current file, to the clipboard.
