### PR TITLE
Add Panezr plugin

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -112,7 +112,7 @@
 			"details": "https://github.com/jpellerin/Panezr",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=3033",
 					"details": "https://github.com/jpellerin/Panezr/tags"
 				}
 			]


### PR DESCRIPTION
This is a simple plugin that automatically limits the number of open tabs in a pane. It is ST3 only as it uses the new `view.close()` api that was added in build 3033.
