### PR TITLE
Theme - HueAccent fixed tag versioning

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -405,7 +405,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/Gliptal/Theme-HueAccent/tree/master"
+					"details": "https://github.com/Gliptal/Theme-HueAccent/tags"
 				}
 			]
 		},


### PR DESCRIPTION
I previously connected my repository through the master branch. Thank you FichteFoll for pointing out the correct way to use tag versioning.
