### PR TITLE
Adding ATS Syntax Highlight

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -74,17 +74,6 @@
 			]
 		},
 		{
-			"name": "ATS Syntax Highlight",
-			"labels": ["language syntax"],
-			"details": "https://github.com/steinwaywhw/ats-mode-sublimetext",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"details": "https://github.com/steinwaywhw/ats-mode-sublimetext/tags"
-				}
-			]
-		},
-		{
 			"name": "ActionScript 3",
 			"details": "https://github.com/skoch/Sublime-ActionScript-3",
 			"labels": ["language syntax"],
@@ -799,6 +788,17 @@
 				{
 					"sublime_text": "<3000",
 					"details": "https://github.com/toin0u/Sublime-atoum/tree/master"
+				}
+			]
+		},
+		{
+			"name": "ATS Syntax Highlight",
+			"labels": ["language syntax"],
+			"details": "https://github.com/steinwaywhw/ats-mode-sublimetext",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/steinwaywhw/ats-mode-sublimetext/tags"
 				}
 			]
 		},


### PR DESCRIPTION
Dear ST team, 

This is a syntax highlight file for Applied Type System, http://www.ats-lang.org/. We are doing research on it. The language currently has emacs/vim mode, but missing sublimetext ones. 

Please consider merging this. Thanks for your consideration.
