### PR TITLE
Avoiding Bug #2975 and switching back to a simpler path spec

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1696,7 +1696,7 @@
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"details": "https://github.com/grundprinzip/sublemacspro/tree/release/st2/current"
+					"details": "https://github.com/grundprinzip/sublemacspro/tree/st2"
 				},
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
To avoid #2975 and still separate out ST2 and ST3 releases, I'm changing the path spec to something simpler.
