### PR TITLE
HTML Underscore Syntax compatiblity change

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -561,7 +561,7 @@
 			"details": "https://github.com/johnrork/ST3-HTML-Underscore-Syntax",
 			"releases": [
 				{
-					"sublime_text":">=3000",
+					"sublime_text":"*",
 					"details": "https://github.com/johnrork/ST3-HTML-Underscore-Syntax/tags"
 				}
 			]


### PR DESCRIPTION
Now tested in Sublime Text 2 and 3
