### PR TITLE
Update the Sublime Text version compatibility for Build Ant Target.

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -665,7 +665,7 @@
 			"labels": ["ant", "building", "build system"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3000",
 					"details": "https://github.com/ryanhefner/BuildAntTarget/tags"
 				}
 			]


### PR DESCRIPTION
Updated the compatible Sublime Text version due to the `ImportError: no module named pyexpat` error in Sublime Text 2.
