### PR TITLE
Add sublime test 2 support and add labels for KeyboardSpellCheck

### DIFF
--- a/repository/k.json
+++ b/repository/k.json
@@ -50,9 +50,10 @@
 		{
 			"name": "KeyboardSpellCheck",
 			"details": "https://github.com/jlknuth/KeyboardSpellCheck",
+			"labels": ["spell check", "vintage", "vi", "google"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "*",
 					"details": "https://github.com/jlknuth/KeyboardSpellCheck/tags"
 				}
 			]


### PR DESCRIPTION
Modified k.json to indicate sublime test 2/3 support and added label to KeyboardSpellCheck. 
