### PR TITLE
Adding Clang Format package.

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -471,6 +471,17 @@
 			]
 		},
 		{
+			"name": "Clang Format",
+			"details": "https://github.com/rosshemsley/SublimeClangFormat",
+			"labels": ["Clang", "Format", "Beautifier", "Formatter", "C", "C++"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/rosshemsley/SublimeClangFormat/tags"
+				}
+			]
+		},
+		{
 			"name": "Clarion",
 			"details": "https://github.com/fushnisoft/SublimeClarion",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Clang format is a package that enables the running of clang-format from with ST3.

A simple plugin already exists to do this, (and is bundled with llvm). 
But it has a few bugs, is very simple, and is not available through package control.
