### PR TITLE
New package: SuperPython

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2475,6 +2475,16 @@
 			]
 		},
 		{
+			"name": "SuperPython",
+			"details": "https://github.com/rubyruy/SuperPython",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/rubyruy/SuperPython/tags"
+				}
+			]
+		},
+		{
 			"name": "SuperSelect",
 			"details": "https://github.com/codecarson/SublimeSuperSelect",
 			"releases": [


### PR DESCRIPTION
There isn't really a monolithic python package to add this into. Personally I don't mind tiny little does-one-thing packages like this at all. 

From the Readme:
# SuperPython

Adds tab-completion to Python's somewhat verbose `super()` construct. Just hit `tab` after a `super` keyword and a snippet will be inserted contained the likely current class and method name, with the existing arguments already filled.

Example:

``` python
class AHappyClass(JustSwellBase):
    def __init__(self, required_arg, and_another, *anything_else, **enough_already):
        super#<tab>

# Becomes:

class AHappyClass(JustSwellBase):
    def __init__(self, required_arg, and_another, *anything_else, **enough_already):
        super(AHappyClass, self).__init__(required_arg, and_another, *anything_else, **enough_already)

```

SubleText's own parsing is used to guess the "current" class name, method name and arguments, which should be fine almost all the time, but may in rare cases pick up the wrong thing, say, if there's an innter class or method definition between the call to `super` and the real method signature. 
