### PR TITLE
Bump ST dependency for the Github Tools plugin

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -272,8 +272,8 @@
 			"details": "https://github.com/temochka/sublime-text-2-github-tools",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"details": "https://github.com/temochka/sublime-text-2-github-tools/tree/master"
+					"sublime_text": "*",
+					"details": "https://github.com/temochka/sublime-text-2-github-tools/tags"
 				}
 			]
 		},


### PR DESCRIPTION
Bumped ST dependency for the Github Tools plugin, also enabled tags-based versioning strategy.
