### PR TITLE
Adding SourceDown plugin

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1239,6 +1239,17 @@
 			]
 		},
 		{
+			"name": "SourceDown",
+			"details": "https://github.com/bordaigorl/sublime-sourcedown",
+			"labels": ["markdown", "blog"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/bordaigorl/sublime-sourcedown/tags"
+				}
+			]
+		},
+		{
 			"name": "SourcePawn Syntax Highlighting",
 			"details": "https://github.com/Dillonb/SublimeSourcePawn",
 			"labels": ["language syntax"],


### PR DESCRIPTION
A plugin to convert any source code into readable Markdown.
Comments are converted into normal text, sourcecode into raw markdown snippets.
By writing comments using Markdown one can use this as a quick documentation generation script for quick and easy publishing in blogs/tutorials/lessons.
