### PR TITLE
Added SublimeGerrit repository URL

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -7,6 +7,7 @@
 		"http://release.sublimegit.net/packages.json",
 		"http://wuub.net/packages.json",
 		"http://www.sublimerge.com/packages.json",
+		"http://www.sublimegerrit.com/packages.json",
 		"https://bitbucket.org/fnkr/sublimerepo/raw/master/repository.json",
 		"https://bitbucket.org/jjones028/p4sublime/raw/tip/packages.json",
 		"https://bitbucket.org/klorenz/sublime_packages/raw/tip/packages.json",


### PR DESCRIPTION
Added URL to SublimeGerrit repository. Currently the 'releases' array in response JSON is empty. It will be automatically filled as soon as package is released to the public.
