### PR TITLE
Bind Zone File package is ST3 compatible

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -315,7 +315,7 @@
 			"details": "https://github.com/sixty4k/st2-zonefile",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/sixty4k/st2-zonefile/tags"
 				}
 			]


### PR DESCRIPTION
Tested that Bind Zone File package works in ST3, confirmed and ready to let the world know.
