### PR TITLE
Add rdio to r.json

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -269,13 +269,13 @@
 		},
 		{
 			"details": "https://github.com/jamesfzhang/rdio",
-		      	"releases": [
-		        	{
-		          		"sublime_text": ">=3000",
-		          		"platforms": ["osx"],
-		          		"details": "https://github.com/jamesfzhang/rdio/tags"
-		        	}
-		      	]
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["osx"],
+					"details": "https://github.com/jamesfzhang/rdio/tags"
+				}
+			]
 		},
 		{
 			"name": "ReactJS",


### PR DESCRIPTION
This package provides Rdio for Mac controls in ST3. Inspired by [Atom's Rdio plugin](https://github.com/EtienneLem/atom-rdio).

Quick link: https://github.com/jamesfzhang/rdio

Thanks!
