### PR TITLE
Please rename 'PeopleCode Tools' package to 'PeopleCodeTools'

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -387,6 +387,7 @@
 		{
 			"name": "PeopleCodeTools",
 			"details": "https://github.com/Jatz/PeopleCodeTools",
+			"previous_names": ["PeopleCode Tools"]
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
I have added a previous_names array this time around.
