### PR TITLE
Change details address

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -421,7 +421,7 @@
 		},
 		{
 			"name": "RemoteCollab",
-			"details": "https://github.com/TeamRemote/remote-sublime",
+			"details": "http://teamremote.github.io/remote-sublime",
 			"releases": [
 				{
 					"sublime_text": ">3000",


### PR DESCRIPTION
I changed the 'details' address from the URL of the main repo page to our github.io page.
