### PR TITLE
PHPTools sublime plugin

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1620,6 +1620,6 @@
 					"details": "https://github.com/facelessuser/Pywin32/tree/master"
 				}
 			]
-		}`
+		}
 	]
 }


### PR DESCRIPTION
Adds a plugin to support php.tools in order to format php files (same as `go fmt`)
