### PR TITLE
Added Print to HTML3

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1129,9 +1129,14 @@
 		{
 			"name": "Print to HTML",
 			"details": "https://github.com/jchampy/sublimetext-print-to-html",
+			"labels": ["tasks","printing","utilities","utils","browser"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<3000",
+					"details": "https://github.com/joelpt/sublimetext-print-to-html/tree/master"
+				},
+				{
+					"sublime_text": ">=3000",
 					"details": "https://github.com/jchampy/sublimetext-print-to-html/tree/master"
 				}
 			]


### PR DESCRIPTION
Added Print to HTML for ST3 from fork.

While, [joelpt](https://github.com/joelpt) has the ST2 branch, there have been pull requests and issue requests dating 6+ months for a ST3 branch. 
This PR adds a ST3 package for the print_to_html package. 

Signed-off-by: "Jake Champlin" jake.champlin.27@gmail.com
