### PR TITLE
Updates to GitGutter

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -248,16 +248,6 @@
 			]
 		},
 		{
-			"name": "GitGutter-Release-Candidate",
-			"details": "https://github.com/jisaacks/GitGutter",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"details": "https://github.com/jisaacks/GitGutter/tree/release-candidate"
-				}
-			]
-		},
-		{
 			"name": "Github Color Theme",
 			"details": "https://github.com/AlexanderEkdahl/github-sublime-theme",
 			"releases": [


### PR DESCRIPTION
- Change to use tags for releases
- Point a new _Edge_ version to master
- Pointer a new _Release-Candidate_ version to the release-candidate branch

This will allow users to easily install and test out new features before pushed onto the masses.

Wanted to make it much easier for uses to beta test new releases. If there is a better way in the Package Control Ecosystem to achieve this, please let me know.
