### PR TITLE
Update v.json

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -178,7 +178,7 @@
 			]
 		},
 		{
-			"name": "VHDL",
+			"name": "VHDL ST3",
 			"details": "https://github.com/leoheck/sublime-vhdl",
 			"releases": [
 				{


### PR DESCRIPTION
VHDL in Sublime Text 3.

Since there are no updates from the past 5 mounths, I forked yangsu/sublime-vhdl/ and updated   packages.json to include Sublime Text 3. When @yangsu appears, I will move VHDL back to default github reference.
