### PR TITLE
added vhdl_testbench package information to package_control_channel

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -33,6 +33,7 @@
 		"https://raw.github.com/colinta/sublime_packages/master/packages.json",
 		"https://raw.github.com/connec/Open-in-ConEmu/master/packages.json",
 		"https://raw.github.com/corbinian/GrowlNotifier/master/packages.json",
+		"https://raw.github.com/cosgroma/VHDL_TestBench/master/packages.json",
 		"https://raw.github.com/cryz/sublime-i18n-and-l10n-helper/master/packages.json",
 		"https://raw.github.com/csch0/SublimeText-Packages/master/packages.json",
 		"https://raw.github.com/csytan/sublime-text-2-github/master/packages.json",
@@ -134,7 +135,6 @@
 		"https://raw.github.com/yangsu/sublime-vhdl/master/packages.json",
 		"https://raw.github.com/zfkun/sublime-kissy-snippets/master/packages.json",
 		"https://raw.githubusercontent.com/thecotne/smart_less_build/master/package.json",
-		"https://github.com/cosgroma/VHDL_TestBench/blob/master/packages.json",
 		"https://sublime.wbond.net/packages_2.json"
 	]
 }

--- a/repository/v.json
+++ b/repository/v.json
@@ -178,15 +178,6 @@
 			]
 		},
 		{
-			"details": "https://github.com/cosgroma/VHDL_TestBench",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"details": "https://github.com/cosgroma/VHDL_TestBench/master"
-				}
-			]
-		},
-		{
 			"name": "View In Browser",
 			"details": "https://github.com/adampresley/sublime-view-in-browser",
 			"releases": [


### PR DESCRIPTION
I have added a package that creates a VHDL testbench given an open VHDL source. I would like this to be searchable by the Sublime Text community.
