### PR TITLE
Update Require Helper, add support for ST3 update channel

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -530,7 +530,7 @@
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"details": "https://github.com/spadgos/sublime-require-helper/tree/0.1.0"
+					"details": "https://github.com/spadgos/sublime-require-helper/tree/st2"
 				},
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
The 0.1.0 tag has been created to handle ST2.

Currently the helper will support both ST2 and ST3 on one development branch, using tags for each release. 0.2.0 is the latest tag.
