### PR TITLE
Make "Resize Group with Keyboard" work in ST3

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -559,7 +559,7 @@
 			"details": "https://github.com/VPashkov/SublimeResizeGroupWithKeyboard",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/VPashkov/SublimeResizeGroupWithKeyboard/tree/master"
 				}
 			]


### PR DESCRIPTION
Make "Resize Group with Keyboard" plugin work with any Sublime Text verion
