### PR TITLE
Add Google Translate Pro to g.json

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -569,16 +569,6 @@
 			]
 		},
 		{
-			"name": "Google Translate Pro",
-			"details": "https://github.com/MtimerCMS/SublimeText-Google-Translate-Plugin",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"details": "https://github.com/MtimerCMS/SublimeText-Google-Translate-Plugin/tags"
-				}
-			]
-		},
-		{
 			"details": "https://github.com/SublimeText/GoogleTesting",
 			"releases": [
 				{

--- a/repository/i.json
+++ b/repository/i.json
@@ -266,6 +266,16 @@
 			]
 		},
 		{
+			"name": "Inline Google Translate",
+			"details": "https://github.com/MtimerCMS/SublimeText-Google-Translate-Plugin",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/MtimerCMS/SublimeText-Google-Translate-Plugin/tags"
+				}
+			]
+		},
+		{
 			"name": "Inline Python",
 			"details": "https://github.com/apiad/Sublime-InlinePython",
 			"releases": [


### PR DESCRIPTION
I know there is already a Google Tranlate plugin for github.
But it just redirect user to google website. Useless I guess. 
And the author has abandoned it.

I made a pull request last year, but you didn't accept. The author said he would update his plugin but never did.

So hopfully you can approve this commit.

It works on ST2 & ST3 with proxy support.
