### PR TITLE
Extended Tab Switcher plugin for sublime

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -695,6 +695,17 @@
 			]
 		},
 		{
+			"name": "ExtendedTabSwitcher",
+			"author": "Rajesh Vaya",
+			"details": "https://github.com/rajeshvaya/Sublime-Extended-Tab-Switcher",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/rajeshvaya/Sublime-Extended-Tab-Switcher/tags"
+				}
+			]
+		},
+		{
 			"name": "ExtendScript",
 			"details": "https://github.com/seblavoie/sublime-extendscript",
 			"releases": [


### PR DESCRIPTION
**This plugin is inspired by the default tab switcher in netbeans**  which displays the open files to choose from on pressing `ctrl+alt+tab`.
