### PR TITLE
Added Blade Spacer plugin

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -413,6 +413,16 @@
 			]
 		},
 		{
+			"name": "Blade Spacer",
+			"details": "https://github.com/austenc/blade-spacer",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/austenc/blade-spacer/tree/master"
+				}
+			]
+		},
+		{
 			"name": "BlameHighlighter",
 			"details": "https://github.com/skyronic/BlameHighlighter",
 			"releases": [


### PR DESCRIPTION
This package simply adds (two) spaces between double curly brackets as used in laravel's blade syntax.

So typing `{{` becomes `{{ | }}` -- the `|` represents cursor location. The ending brackets are handled as auto-closing the same way sublime text does it by default. All the plugin does is add the nice spacing automatically. Thanks for consideration!
