### PR TITLE
Online search

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -131,6 +131,18 @@
 			]
 		},
 		{
+			"name": "OnlineSearch",
+			"author": "Rajesh Vaya",
+			"details": "https://github.com/rajeshvaya/sublime-online-searcher",
+			"labels": ["search", "documentation"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/rajeshvaya/sublime-online-searcher/tags"
+				}
+			]
+		},
+		{
 			"name": "OOJS",
 			"details": "https://github.com/avenauche/OOJS",
 			"labels": ["language syntax"],


### PR DESCRIPTION
This plugin enables the user to search online right from the sublime text editor. User can search through input, right-clicking the selected text and through general key-bindings.

You can also add your own custom domains, search engines and other documentations which are not included by default in this plugin

Defaults
- google (e.g. `google: best css practices`)
- stackOverflow  (e.g. `stackoverflow: jquery animate not working`)
- github  (e.g. `github: noSQL databases`)
- php  (e.g. `php: in_array`)
- jquery  (e.g. `jquery: fadeIn`)
- youtube  (e.g. `youtube: node.js tutorials`)
- image  (e.g. `image: facebook icon`)
