### PR TITLE
Update to Jekyll

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -253,11 +253,14 @@
 			"labels": [
 				"language syntax",
 				"snippets",
-				"auto-complete"
+				"auto-complete",
+				"build system",
+				"file creation",
+				"file navigation"
 			],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3000",
 					"details": "https://github.com/23maverick23/sublime-jekyll/tags"
 				}
 			]


### PR DESCRIPTION
Updated Jekyll to v2.0.0 which now requires ST3 compatibility.
