### PR TITLE
Added 'Fold Comments' plugin to f.json

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -597,6 +597,17 @@
 			]
 		},
 		{
+			"name": "Fold Comments",
+			"details": "https://github.com/oskarols/foldcomments",
+			"labels": ["formatting"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/oskarols/foldcomments/tags"
+				}
+			]
+		},
+		{
 			"name": "Fold Python",
 			"details": "https://github.com/svenfraeys/SublimeFoldPython",
 			"releases": [


### PR DESCRIPTION
A small plugin which provides a command to toggle folding of all comments in a document.
Provides fixes for strange fold locations in some cases, where the fold indicator was merged with subsequent lines of code. Also does concatenation of adjacent single line comments and block comments.

Works on ST2/3, tested in Python, Ruby, JS, CS & C++.

More details on the [repository page](https://github.com/oskarols/foldcomments).
