### PR TITLE
Add SublimeHoogle

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2192,14 +2192,14 @@
 			]
 		},
 		{
-                        "details": "https://github.com/saclark/SublimeHoogle",
-                        "releases": [
-                                {
-                                        "sublime_text": "*",
-                                        "details": "https://github.com/saclark/SublimeHoogle/tree/master"
-                                }
-                        ]
-                },
+			"details": "https://github.com/saclark/SublimeHoogle",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/saclark/SublimeHoogle/tree/master"
+				}
+			]
+		},
 		{
 			"details": "https://github.com/lunixbochs/sublimelint",
 			"labels": ["linting"],


### PR DESCRIPTION
I recognize "SublimeHoogle" is dangerously close to the name of the existing package "SublimeGoogle," but this name was not chosen to confuse or mislead users -- it was chosen simply to reflect the purpose of this package.
