### PR TITLE
Added Replacer package

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -532,6 +532,16 @@
 			]
 		},
 		{
+			"name": "Replacer",
+			"details": "https://github.com/pjlamb12/ReplacerSublimeText3",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/pjlamb12/ReplacerSublimeText3/tree/master"
+				}
+			]
+		},
+		{
 			"name": "Request",
 			"details": "https://github.com/twolfson/sublime-request",
 			"labels": [


### PR DESCRIPTION
This is a package to replace Word characters such as apostrophes and quotation marks with plain text versions. It also replaces ampersands with &amp;amp; so that those are displayed properly as well in an HTML file. It only replaces ampersands if immediately followed by a space, so that if one appears in a URL it isn't touched.
