### PR TITLE
Adding syntax highlight for CQ clientlibs

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1643,23 +1643,23 @@
 			]
 		},
 		{
-			"name": "CQ5Saver",
-			"details": "https://bitbucket.org/mavendc/cq5-sublimetext",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"details": "https://bitbucket.org/mavendc/cq5-sublimetext/src/master"
-				}
-			]
-		},
-		{
 			"name": "CQ Clientlibs Syntax Highlight",
 			"details": "https://github.com/diestrin/cq-clienltib-sublime-language",
 			"labels": ["cq", "clientlib"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/diestrin/cq-clienltib-sublime-language/tree/master"
+					"details": "https://github.com/diestrin/cq-clienltib-sublime-language/tags"
+				}
+			]
+		},
+		{
+			"name": "CQ5Saver",
+			"details": "https://bitbucket.org/mavendc/cq5-sublimetext",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://bitbucket.org/mavendc/cq5-sublimetext/src/master"
 				}
 			]
 		},


### PR DESCRIPTION
CQ Clientlibs files (js.txt and css.txt) needs an special syntax highlight
