### PR TITLE
Add Jasmine Syntax

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -103,7 +103,7 @@
 				}
 			]
 		},
-          	{
+		{
 			"name": "Jasmine Syntax",
 			"details": "https://github.com/NicoSantangelo/jasmine-syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Adds a simple syntax highlighter for Jasmine.

Extracted from the work done on [Jasmine BDD](https://github.com/caiogondim/jasmine-sublime-snippets) (caiogondim/jasmine-sublime-snippets#12)
