### PR TITLE
Add ShellExec plugin

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -710,6 +710,17 @@
 			]
 		},
 		{
+			"name": "Shell Exec",
+			"details": "https://github.com/creativej/SublimeShellExec",
+			"labels": ["shell"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/creativej/SublimeShellExec"
+				}
+			]
+		},
+		{
 			"name": "Shell Turtlestein",
 			"details": "https://github.com/misfo/Shell-Turtlestein",
 			"releases": [


### PR DESCRIPTION
This plugin enables Sublime users to define shell commands in the setting file and make it available as a sublime command. 

![Sublime command menu](http://i.imgur.com/hKhp1m1.png =200x)
## What so different about this package?

What makes this package different to other shell plugins is the event hook feature that allows user to auto execute a predefined command on sublime event. E.g. After file save. 

This is especially useful for working with tests and projects that requires auto builds.

More details in the [repo](https://github.com/creativej/SublimeShellExec)
