### PR TITLE
Added Goto Bootstrap plugin

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -598,6 +598,16 @@
 			]
 		},
 		{
+			"name": "Goto Bootstrap",
+			"details": "https://github.com/austenc/goto-bootstrap",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/austenc/goto-bootstrap/tree/master"
+				}
+			]
+		},
+		{
 			"name": "Goto Documentation",
 			"details": "https://github.com/kemayo/sublime-text-2-goto-documentation",
 			"releases": [


### PR DESCRIPTION
Super simple -- just a few commands to open up to the bootstrap documentation pages. Thought it might be useful to others as well. I looked at a few bootstrap-related plugins but this didn't really seem appropriate to include in any of those. 
