### PR TITLE
Add CodeToHipChat package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -827,9 +827,9 @@
 					"details": "https://github.com/taylon/CodeToHipChat/tags"
 				}
 			],
-            "previous_names": [
-                "Copy to HipChat"
-            ]
+			"previous_names": [
+				"Copy to HipChat"
+			]
 		},
 		{
 			"name": "Code2Docs Documentation Generator (docco)",


### PR DESCRIPTION
Simple package that allows you to send code with syntax highlight to a HipChat (https://www.hipchat.com/) room without leaving SublimeText.
