### PR TITLE
ST3 support for 'Goto Drupal API'

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -633,7 +633,7 @@
 			"details": "https://github.com/BrianGilbert/Sublime-Text-2-Goto-Drupal-API",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/BrianGilbert/Sublime-Text-2-Goto-Drupal-API/tree/master"
 				}
 			]


### PR DESCRIPTION
The plugin supports ST3 (BrianGilbert/Sublime-Text-2-Goto-Drupal-API#4), the author just hasn't submitted a PR to get it updated in the repository. This should fix that.
