### PR TITLE
Added the `Flashback` plugin

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -529,6 +529,10 @@
 			]
 		},
 		{
+			"name": "Flashback",
+			"details": "https://github.com/apiad/sublime-flashback"
+		},
+		{
 			"name": "Flatron",
 			"details": "https://github.com/NoahBuscher/Flatron",
 			"labels": ["theme"],
@@ -538,10 +542,6 @@
 					"details": "https://github.com/NoahBuscher/Flatron/tree/master"
 				}
 			]
-		},
-		{
-			"name": "Flashback",
-			"details": "https://github.com/apiad/sublime-flashback"
 		},
 		{
 			"name": "Flex",


### PR DESCRIPTION
It is basically a replacement for `git log` (in a different key binding, of course) which shows the log for the current file, but as you highlight entries, the content of your view is replaced with the content of the file as stored in the respective commit. This way you can easily browse back and forth in history **one single file** and see how it developed.
