### PR TITLE
CSScomb: Remove deprecated version

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1881,11 +1881,12 @@
 		},
 		{
 			"name": "CSScomb",
-			"details": "https://github.com/csscomb/CSScomb-for-Sublime",
+			"details": "https://github.com/csscomb/sublime-csscomb",
+			"previous_names": ["CSScomb.js", "CSScomb JS"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/csscomb/CSScomb-for-Sublime/tree/master"
+					"details": "https://github.com/csscomb/sublime-csscomb/tree/master"
 				}
 			]
 		},
@@ -1896,17 +1897,6 @@
 				{
 					"sublime_text": "<3000",
 					"details": "https://github.com/psyrendust/CSScomb-Alpha-Sort-for-Sublime/tree/master"
-				}
-			]
-		},
-		{
-			"name": "CSScomb JS",
-			"details": "https://github.com/csscomb/sublime-csscomb",
-			"previous_names": ["CSScomb.js"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"details": "https://github.com/csscomb/sublime-csscomb/tree/master"
 				}
 			]
 		},


### PR DESCRIPTION
Remove deprecated php-version.
Use name "CSScomb" for js-version, previously known as "CSScomb JS".
