### PR TITLE
Add CSS3 package for ST3. Change CSS3_Syntax to ST2 only.

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1872,7 +1872,7 @@
 		{
 			"name": "CSS3",
 			"details": "https://github.com/y0ssar1an/CSS3",
-			"labels": ["language syntax", "completions", "auto-complete", "reset", "linting"]
+			"labels": ["language syntax", "completions", "auto-complete", "reset", "linting"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
I'm the author of both packages. CSS3_Syntax was just a syntax highlighter. CSS3 is a full language bundle with an improved highlighter and a full set of completions.
