### PR TITLE
Added "Unity Completions Light", a light version of "Unity Completions"

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -191,6 +191,17 @@
 			]
 		},
 		{
+			"name": "Unity Completions Light",
+			"details": "https://github.com/oferei/sublime-unity-completions-light",
+			"labels": ["auto-complete"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/oferei/sublime-unity-completions-light/tags"
+				}
+			]
+		},
+		{
 			"details": "https://github.com/UnicornForest/Unity3D",
 			"releases": [
 				{


### PR DESCRIPTION
There is a justification for two versions of my package. Different users may prefer different versions.

The original version adds several seconds to ST loading time as the package contains thousands of 'snippet' files. The new, light version uses 'completions' files to accomplish the same goal, which results in a lighter package, but does not provide the same experience - the auto-completions pop-up menu it shows is not as friendly and informative.
