### PR TITLE
Add GoAutoDeclare

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -418,16 +418,6 @@
 			]
 		},
 		{
-			"name": "GoAutoDeclare",
-			"details": "https://github.com/waigani/GoAutoDeclare",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"details": "https://github.com/waigani/GoAutoDeclare/tags"
-				}
-			]
-		},
-		{
 			"name": "Go Build",
 			"details": "https://github.com/cthackers/SublimeGoBuild",
 			"releases": [
@@ -454,6 +444,16 @@
 				{
 					"sublime_text": "*",
 					"details": "https://github.com/waigani/sublime_go_toggle_declare/tags"
+				}
+			]
+		},
+		{
+			"name": "GoAutoDeclare",
+			"details": "https://github.com/waigani/GoAutoDeclare",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/waigani/GoAutoDeclare/tags"
 				}
 			]
 		},


### PR DESCRIPTION
GoAutoDeclare is a Sublime Text plugin which automatically corrects short variable declaration ':=' and assignment operator '=' mistakes on save.

See the [repo](https://github.com/waigani/GoAutoDeclare) for details.
