### PR TITLE
Adding CloseCommentTag Package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -692,7 +692,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/Satoh-D/CloseCommentTag/tree/master"
+					"details": "https://github.com/Satoh-D/CloseCommentTag/tags"
 				}
 			]
 		},


### PR DESCRIPTION
CloseCommentTag is a Sublime Text package that insert comment tag ike a "<!-- /#id.classname -->" before closing tag.

See the [repository](https://github.com/Satoh-D/CloseCommentTag) for details
