### PR TITLE
add SaveCopyAs package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1550,8 +1550,6 @@
 		{
 			"name": "Copy Filepath With Line Numbers",
 			"details": "https://github.com/theskyliner/CopyFilepathWithLineNumbers",
-			"issues": "https://github.com/theskyliner/CopyFilepathWithLineNumbers/issues",
-			"readme": "https://github.com/theskyliner/CopyFilepathWithLineNumbers/master/readme.md",
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/s.json
+++ b/repository/s.json
@@ -132,8 +132,6 @@
 		{
 			"name": "Save Copy As",
 			"details": "https://github.com/theskyliner/SaveCopyAs",
-			"issues": "https://github.com/theskyliner/SaveCopyAs/issues",
-			"readme": "https://raw.githubusercontent.com/theskyliner/SaveCopyAs/master/readme.md",
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
I used to use Notepad++ and I often used the command "Save Copy As" in order to create a duplicate of the current file without opening the created file.

I wanted to have the same feature in Sublime Text, so I wrote this plugin.
