### PR TITLE
add CopyFilepathWithLineNumbers package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1548,6 +1548,18 @@
 			"previous_names": ["copy-file-name"]
 		},
 		{
+			"name": "Copy Filepath With Line Numbers",
+			"details": "https://github.com/theskyliner/CopyFilepathWithLineNumbers",
+			"issues": "https://github.com/theskyliner/CopyFilepathWithLineNumbers/issues",
+			"readme": "https://github.com/theskyliner/CopyFilepathWithLineNumbers/master/readme.md",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/theskyliner/CopyFilepathWithLineNumbers/tags"
+				}
+			]
+		},
+		{
 			"name": "Copy PHP Namespace",
 			"details": "https://github.com/FrenkyNet/CopyNamespace",
 			"releases": [


### PR DESCRIPTION
At work I really often copy the filepath and write down the line numbers, where I change some code. With this package numbers of the selected line(s) are automatically saved to clipboard along filepath.

```
/home/readme.md:5
/home/readme.md:5-10
```
