### PR TITLE
Added missing label for AMD Snippets

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -244,6 +244,7 @@
 		{
 			"name": "AMD Snippets",
 			"details": "https://github.com/pierceray/AMDsnippets",
+			"labels": ["snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
It wasn't in the instructions for submitting a package.
