### PR TITLE
added `npm` package to n.json

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -304,7 +304,7 @@
 			"labels": ["npm", "node", "javascript", "commands"],
 			"releases": [
 				{
-					"sublime_text": "<=3000",
+					"sublime_text": ">=3000",
 					"details": "https://github.com/PixnBits/sublime-text-npm/tags"
 				}
 			]


### PR DESCRIPTION
npm is intended to be an easy way to issue npm commands w/o having to switch to the console

proper data (tags) this time, sorry :(
