### PR TITLE
add Sourcegraph plugin

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1365,6 +1365,16 @@
 			]
 		},
 		{
+			"name": "Sourcegraph",
+			"details": "https://github.com/sourcegraph/sourcegraph-sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/sourcegraph/sourcegraph-sublime/tags"
+				}
+			]
+		},
+		{
 			"name": "SourcePawn Syntax Highlighting",
 			"details": "https://github.com/Dillonb/SublimeSourcePawn",
 			"labels": ["language syntax"],


### PR DESCRIPTION
This adds a plugin that offers find usages example, show documentation, show types, and search on Sourcegraph for several languages (Go, Python, JavaScript, and Ruby).
