### PR TITLE
remove donate link from Sourcegraph

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1366,6 +1366,7 @@
 		},
 		{
 			"name": "Sourcegraph",
+			"donate": null,
 			"details": "https://github.com/sourcegraph/sourcegraph-sublime",
 			"releases": [
 				{


### PR DESCRIPTION
we love gittip, but we're a company, so don't need donations for this plugin
