### PR TITLE
Slack Chat integration

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2550,6 +2550,16 @@
 			]
 		},
 		{
+			"name": "SubSlack",
+			"details": "https://github.com/noma4i/subslack",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/noma4i/subslack/tags"
+				}
+			]
+		},
+		{
 			"name": "Subtitle Sync",
 			"details": "https://github.com/apiad/sublime-subtitle-sync"
 		},


### PR DESCRIPTION
Adding Slack(https://slack.com/) integration for SublimeText.

repo: https://github.com/noma4i/SubSlack

Ability to send selected text directly to chat.
