### PR TITLE
added ST3 branch to missing palette commands

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -685,8 +685,12 @@
 			"details": "https://github.com/fjl/Sublime-Missing-Palette-Commands",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<3000",
 					"details": "https://github.com/fjl/Sublime-Missing-Palette-Commands/tree/master"
+				},
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/fjl/Sublime-Missing-Palette-Commands/tree/st3"
 				}
 			]
 		},


### PR DESCRIPTION
Previously at #2730 @FichteFoll said that the ST3 Missing Palette Commands package should be merged with the ST2 Missing Palette Commands package. 

With @fjl's blessing, here is the change necessary to combine the packages. This adds ST3-specific palette commands for users using ST3.
