### PR TITLE
Update ST version for Markdown to Clipboard

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -193,7 +193,7 @@
 			"details": "https://github.com/fanzheng/Sublime.Markdown2Clipboard",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/fanzheng/Sublime.Markdown2Clipboard/tree/master"
 				}
 			]


### PR DESCRIPTION
Markdown to Clipboard supports ST3 now
