### PR TITLE
Add a .editorconfig file to help contributors keep code styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+ident_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.json]
+indent_style = tab
+
+[*.py]
+ident_style = space


### PR DESCRIPTION
Hey guys,

I did a pull request for a package a couple of minutes ago and my build failed twice because my sublime was setup for using spaces instead of tabs for indentation.

So I added a .editorconfig file to try to avoid that in the future.

EditorConfig (http://editorconfig.org/):

EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems.

So I think it is a powerful way to make sure that all contributors keep the same code style. We can change the configuration to match the style guide of the project, I just suggested some configurations that I think are currently used in the project.

It should also be added to the documentation, I didn't add it myself because Im not good with that and I'm not sure where is the best way to add it.
