### PR TITLE
added anaconda_php (PHP plugin for Anaconda)

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -315,6 +315,16 @@
 			]
 		},
 		{
+			"details": "https://github.com/DamnWidget/anaconda_php",
+			"labels": ["linting", "language syntax", "php"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/DamnWidget/anaconda_php/tags"
+				}
+			]
+		},
+		{
 			"details": "https://github.com/Korcholis/Andrew",
 			"releases": [
 				{
@@ -841,7 +851,7 @@
 				}
 			],
 			"previous_names": [
-				"Replacer"	
+				"Replacer"
 			]
 		},
 		{


### PR DESCRIPTION
Anaconda now support a pluggable interface to add new linters or languages, this is the first one just for linting PHP using Anaconda's asynchronous engine.
