### PR TITLE
Added "Table of comments" plugin

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -26,6 +26,17 @@
 			]
 		},
 		{
+			"name": "Table of comments",
+			"details": "https://github.com/kizza/Table-of-comments",
+			"labels": ["comments", "documentation", "utils"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/kizza/Table-of-comments/tags"
+				}
+			]
+		},
+		{
 			"name": "Tabright",
 			"details": "https://github.com/stylishmedia/Tabright",
 			"homepage": "https://github.com/stylishmedia/Tabright",


### PR DESCRIPTION
New ST2&3 plugin creating a quick-jump panel to jump between headings within comments (and to output a live updated table of contents within documents also)
