### PR TITLE
Add "Autotools" package

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1127,6 +1127,17 @@
 			]
 		},
 		{
+			"name": "Autotools",
+			"details": "https://github.com/ptomato/sublime_autotools",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/ptomato/sublime_autotools/tags"
+				}
+			]
+		},
+		{
 			"name": "AutoUpdateSourceHeader",
 			"details": "https://github.com/Harurow/sublime_autoupdatesourceheader",
 			"releases": [


### PR DESCRIPTION
This is a syntax highlighting package for Autoconf M4 and Automake,
collectively known as Autotools. It also includes an improved Makefile
highlighter.
