### PR TITLE
Add Markdown HTML Preview Plug-In

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -180,6 +180,17 @@
 			]
 		},
 		{
+			"name": "Markdown HTML Preview",
+			"details": "https://github.com/zeyon/MarkdownHtmlPreview",
+			"labels": ["markdown", "preview", "build", "html"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/zeyon/MarkdownHtmlPreview/tags"
+				}
+			]
+		},
+		{
 			"name": "Markdown Preview",
 			"details": "https://github.com/revolunet/sublimetext-markdown-preview",
 			"labels": ["markdown", "preview", "build"],


### PR DESCRIPTION
I require a plugin that allows me to base the markdown preview on JavaScript - note that this plugin also allows users to create their own HTML templates and modify the layout.
