### PR TITLE
Renamed NLF package

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -375,7 +375,7 @@
 			]
 		},
 		{
-			"name": "NSIS Language File Syntax",
+			"name": "NSIS for Translators",
 			"details": "https://github.com/idleberg/NSIS-Language-File-Sublime-Text",
 			"labels": ["language syntax","nsis"],
 			"releases": [
@@ -383,6 +383,9 @@
 					"sublime_text": "*",
 					"details": "https://github.com/idleberg/NSIS-Language-File-Sublime-Text/tree/master"
 				}
+			],
+			"previous_names": [
+				"NSIS Language File Syntax"
 			]
 		},
 		{


### PR DESCRIPTION
I preferred the old name, but obviously most people install this mistaking it for the "NSIS" syntax package.
