### PR TITLE
Marking package for ST3 support only

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1142,7 +1142,7 @@
 			"details": "https://github.com/wburningham/AutoSpell",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3000",
 					"details": "https://github.com/wburningham/AutoSpell/tags"
 				}
 			]


### PR DESCRIPTION
Missed restricting the version in my last pull request
