### PR TITLE
Update URL for the “Soy” package repository.

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1531,12 +1531,12 @@
 		},
 		{
 			"name": "Soy",
-			"details": "https://github.com/Obvious/soy-sublime",
+			"details": "https://github.com/Medium/soy-sublime",
 			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/Obvious/soy-sublime/tags"
+					"details": "https://github.com/Medium/soy-sublime/tags"
 				}
 			]
 		},


### PR DESCRIPTION
We changed our GitHub organization username from “Obvious” to “Medium” — the old URLs still redirect, but the package control website reports the repository as missing. This fixes the URL.

![screen shot 2014-09-29 at 3 26 34 pm](https://cloud.githubusercontent.com/assets/301442/4450635/c5f51f52-4827-11e4-8916-8552dd9d60e8.png)
