### PR TITLE
Add Grace syntax highlighting package

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -867,6 +867,17 @@
 			]
 		},
 		{
+			"name": "Grace",
+			"details": "https://github.com/zmthy/grace-tmbundle",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/zmthy/grace-tmbundle/tags"
+				}
+			]
+		},
+		{
 			"name": "Gradle_Language",
 			"details": "https://github.com/kingofmalkier/sublime-gradle",
 			"releases": [


### PR DESCRIPTION
This PR overrides #3521, pointing to the original (and now updated) repository, with appropriate tags and labels.
