### PR TITLE
Add CMSSWLookup to c.json.

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -762,6 +762,17 @@
 			]
 		},
 		{
+			"name": "CMSSWLookup",
+			"details": "https://github.com/riga/CMSSWLookup",
+			"labels": ["cern","cmssw"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/riga/CMSSWLookup/tags"
+				}
+			]
+		},
+		{
 			"name" : "COBOL Syntax",
 			"details": "https://bitbucket.org/bitlang/sublime_cobol",
 			"labels": ["language syntax","completion"],


### PR DESCRIPTION
CMSSW is the software framework used by the CMS collaboration at CERN, Geneva.
This plugin enables easy code lookup within the quite large framework code.
