### PR TITLE
Add Morse Code for Foundation

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1018,6 +1018,16 @@
 			]
 		},
 		{
+			"name": "Morse Code for Foundation",
+			"details": "https://github.com/zurb/foundation-sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/zurb/foundation-sublime/tags"
+				}
+			]
+		},
+		{
 			"name": "Moscow ML",
 			"details": "https://github.com/mradam/MoscowML",
 			"releases": [


### PR DESCRIPTION
Emmet-style plugin for the Foundation framework's grid system which expands shorthand code into HTML.
