### PR TITLE
Add "Fix Mac Path" package to package list

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -564,6 +564,18 @@
 			]
 		},
 		{
+			"name": "Fix Mac Path",
+			"details": "https://github.com/int3h/SublimeFixMacPath",
+			"labels": ["terminal/shell/repl", "terminal", "shell", "os x", "osx", "mac"],
+			"releases": [
+				{
+					"platforms": ["osx", "osx-x64"],
+					"sublime_text": "*",
+					"details": "https://github.com/int3h/SublimeFixMacPath/tags"
+				}
+			]
+		},
+		{
 			"name": "FixMyJS",
 			"details": "https://github.com/addyosmani/sublime-fixmyjs",
 			"labels": ["formatting"],


### PR DESCRIPTION
This adds the "Fix Mac Path" package to the package channel. This package was previously in package control, but was removed due to incompatibilities with the new package control format, which are now fixed.

This package correctly sets the the $PATH environmental variable in Sublime Text for Mac OS X to match what you see in the terminal. Normally, GUI apps only see the paths defined in `/etc/paths` and `/etc/paths.d` in their $PATH. Any changes you set in, e.g., `.bash_profile` are not reflected in GUI apps' $PATH (including Sublime Text's).

This causes the $PATH you see in your terminal to be different from that seen in Sublime Text, and can lead to programs not being found when trying to be run by Sublime Text (or a build system, plugin, or command therein). This package fixes that problem.
