### PR TITLE
Added Monocyanide Colorscheme.

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -926,10 +926,7 @@
 		},
 		{
 			"name": "Monocyanide Colorscheme",
-			"description": "Monocyanide is cyanide-ified Monokai Extended: darker background & lighter foregrounds.",
-			"author": "Centril",
 			"details": "https://github.com/Centril/sublime-monocyanide-colorscheme",
-			"homepage": "https://github.com/Centril/sublime-monocyanide-colorscheme",
 			"labels": ["monokai", "cyanide", "colorscheme"],
 			"releases": [
 				{


### PR DESCRIPTION
Monocyanide is cyanide-ified Monokai Extended: darker background & lighter foregrounds.
A fork of the Cyanide theme will be developed to work well with this.
