### PR TITLE
Update location of Tabright

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -38,13 +38,13 @@
 		},
 		{
 			"name": "Tabright",
-			"details": "https://github.com/stylishmedia/Tabright",
-			"homepage": "https://github.com/stylishmedia/Tabright",
+			"details": "https://github.com/mgussekloo/Tabright",
+			"homepage": "https://github.com/mgussekloo/Tabright",
 			"author": "Martijn Gussekloo",
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/stylishmedia/Tabright/tree/master"
+					"details": "https://github.com/mgussekloo/Tabright/tree/master"
 				}
 			]
 		},


### PR DESCRIPTION
Tabright is located at a different Github URL now.
