### PR TITLE
GithubLink

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -351,7 +351,7 @@
 			]
 		},
 		{
-			"name": "GithubLink",
+			"name": "GitHubLink",
 			"details": "https://github.com/rscherf/GithubLink",
 			"releases": [
 				{


### PR DESCRIPTION
Changed name to GithubLink to be more explicit. I think it still makes sense to have this simpler plugin apart from the more complicated plugins like Githubinator.
