### PR TITLE
Removing unmaintained package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -884,15 +884,6 @@
 			]
 		},
 		{
-			"details": "https://github.com/rockerest/Signatori",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"details": "https://github.com/rockerest/Signatori/tree/master"
-				}
-			]
-		},
-		{
 			"name": "Silex Snippets",
 			"details": "https://github.com/franciscosantamaria/sublime-silex",
 			"labels": ["snippets"],


### PR DESCRIPTION
Signatori (ST < 3000) is superceded by registered package at fork https://github.com/fnkr/ST-Sign
