### PR TITLE
Marking "Markup Jira Confluence" plugin compatible with ST3

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -343,7 +343,7 @@
 			"details": "https://github.com/mlf4aiur/sublimetext-markup-jira-confluence",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"details": "https://github.com/mlf4aiur/sublimetext-markup-jira-confluence/tree/master"
 				}
 			]


### PR DESCRIPTION
Markup Jira Confluence plugin is compatible with ST3 (see https://github.com/mlf4aiur/sublimetext-markup-jira-confluence/issues/1 , this was fixed about a year ago)

cc @mlf4aiur
