### PR TITLE
Add VIM Navigation SublimeText package

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -241,6 +241,16 @@
 			]
 		},
 		{
+			"name": "VIM Navigation",
+			"details": "https://github.com/demisx/sublime-vim-navigation",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/demisx/sublime-vim-navigation/tree/master"
+				}
+			]
+		},
+		{
 			"name": "VimL",
 			"details": "https://github.com/SalGnt/Sublime-VimL",
 			"releases": [


### PR DESCRIPTION
This package lets SublimeText users to use native VIM navigation shortcuts. Speed up your file contents navigation without moving your hand over to the cursor keys.
