### PR TITLE
add "Theme - Centurion Blue" as previous_name of "Theme - Centurion"

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -431,7 +431,8 @@
 					"sublime_text": "*",
 					"details": "https://github.com/allanhortle/Centurion/tags"
 				}
-			]
+			],
+			"previous_names": ["Theme - Centurion Blue"]
 		},
 		{
 			"name": "Theme - Cobalt2",


### PR DESCRIPTION
I removed [my fork](https://github.com/fnkr/ST-Centurion-Blue) from package control because the original theme now [can be configured](https://github.com/allanhortle/Centurion#customisation) to use blue instead of green. I think it makes sense to automatically switch the users to the original theme.

https://github.com/fnkr/ST-Repository/commit/9ea68d6e748a13402b852c0157698272273bf905

@allanhortle
