### PR TITLE
Theme Missing from repo after change from commit to tag based releases

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -441,7 +441,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/wesbos/cobalt2/tree/master"
+					"details": "https://github.com/wesbos/cobalt2/tags"
 				}
 			]
 		},


### PR DESCRIPTION
Just updated my themes and changed from commit to tag based releases and now my theme is showing up as "removed" on the package control site. Any chance I can get a quick merge on this? Lots of people are asking how to install it.
