### PR TITLE
Update RSpec lables and releases

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -821,6 +821,10 @@
 			"labels": ["snippets", "build system", "language syntax"],
 			"releases": [
 				{
+					"sublime_text": "<3000",
+					"details": "https://github.com/SublimeText/RSpec/tree/st2"
+				},
+				{
 					"sublime_text": ">=3000",
 					"details": "https://github.com/SublimeText/RSpec/tags"
 				}


### PR DESCRIPTION
Update to use tags so I can add messages.
Update to specific to ST3 because I used `yield from` in the code in a refactor.
Added some labels.
