### PR TITLE
Add Sync File to Repository

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3025,6 +3025,16 @@
 			]
 		},
 		{
+			"name": "Sync File",
+			"details": "https://github.com/Lanceshi2/SyncFile",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/Lanceshi2/SyncFile"
+				}
+			]
+		},
+		{
 			"name": "Sync View Scroll",
 			"details": "https://github.com/zzjin/syncViewScroll",
 			"releases": [


### PR DESCRIPTION
Although there is already a plugin called FileSync, I do find in many situations, people do not want the files in two directories completely sync with each other due to version/experiment reason. So this is a relatively manual version of file sync.
