### PR TITLE
Adding plugin ToggleExclude.

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -1219,6 +1219,16 @@
 			]
 		},
 		{
+			"name": "ToggleExclude",
+			"details": "https://github.com/henvic/ToggleExclude",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/henvic/ToggleExclude/tree/master"
+				}
+			]
+		},
+		{
 			"name": "ToggleMinimapOnScroll",
 			"details": "https://github.com/djjcast/sublime-ToggleMinimapOnScroll",
 			"releases": [


### PR DESCRIPTION
ToggleExclude is a plugin that adds conditional excluded file / folder list to Sublime Text 3, allowing you to browse / search code faster.
