### PR TITLE
Changed Django click repository

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -456,11 +456,11 @@
 		},
 		{
 			"name": "Django Click",
-			"details": "https://github.com/kahi/sublime-django-click",
+			"details": "https://github.com/Proyecto513/sublime-django-click",
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/kahi/sublime-django-click/tree/master"
+					"details": "https://github.com/Proyecto513/sublime-django-click/tree/master"
 				}
 			]
 		},


### PR DESCRIPTION
The old repository mantainer told me to change te repo from his repository to my own to keep mantaining the plugin as he cannot longer do it, here's the message where we kinda talk about that 
