### PR TITLE
Add RailsMagicClipboard plugin.

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -84,6 +84,16 @@
 			]
 		},
 		{
+			"name": "Rails Magic Clipboard",
+			"details": "https://github.com/nickdowse/RailsMagicClipboard",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/nickdowse/RailsMagicClipboard/tags"
+				}
+			]
+		},
+		{
 			"name": "Rails Migrations List",
 			"details": "https://github.com/KELiON/RailsMigrationsList",
 			"releases": [


### PR DESCRIPTION
A new plugin for rails developers that converts HTML, CSS and JavaScript in the clipboard to Haml, Sass, and CoffeeScript.
