### PR TITLE
Automatic outliner and highlighter for words while you are moving the cursor

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2366,6 +2366,16 @@
 			]
 		},
 		{
+			"name": "CursorWordHighlighter",
+			"details": "https://github.com/ownself/CursorWordHighlighter",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"details": "https://github.com/ownself/CursorWordHighlighter/tags"
+				}
+			]
+		},
+		{
 			"name": "Custom Builder",
 			"details": "https://github.com/sneakypete81/sublime_custom_builder",
 			"releases": [


### PR DESCRIPTION
This is a ST3 plugin, it will automatically outline the word your
cursor selected, also you can use hot key to highlight a word
persistently, with 8 different color word highlight supported, and you can disable them
one by one or all together with hot key. This plugin would help your for reading the code.
