### PR TITLE
add NotSoNeon-color-scheme

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -356,6 +356,17 @@
 			]
 		},
 		{
+			"name": "NotSoNeon Color Scheme",
+			"details": "https://github.com/jdiaz5513/NotSoNeon-color-scheme",
+			"readme": "https://github.com/jdiaz5513/NotSoNeon-color-scheme/blob/master/README.md",
+			"releases": [
+				{
+					"sublime_text": ">3000",
+					"details": "https://github.com/jdiaz5513/NotSoNeon-color-scheme/tree/master"
+				}
+			]
+		},
+		{
 			"name": "Npackd",
 			"details": "https://github.com/idleberg/Npackd-Sublime-Text",
 			"labels": ["completions", "snippets"],


### PR DESCRIPTION
This is forked from [Neon-color-scheme](https://github.com/MattDMo/Neon-color-scheme); just a subtle but important tweak that desaturates the colors.

Given that Neon is the only(!) color scheme out there that works with the wonderful PythonImproved syntax, I think it's worth adding.
