### PR TITLE
Add FileActions

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -278,6 +278,16 @@
 			]
 		},
 		{
+			"name": "FileActions",
+			"details": "https://github.com/cnlevy/sublimetext-file-actions",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/cnlevy/sublimetext-file-actions/tags"
+				}
+			]
+		},
+		{
 			"name": "FileBinder",
 			"details": "https://github.com/JeroenVdb/FileBinder",
 			"labels": ["file navigation"],


### PR DESCRIPTION
3 useful file actions that weren't in the default side bar menu 
(duplicate file, move file and copy filename relative to open folder)
