### PR TITLE
Submit Haroopad Markdown plugin

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -101,7 +101,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/liuhewei/haroopad-markdown-sublime/tree/master"
+					"details": "https://github.com/liuhewei/haroopad-markdown-sublime/tags"
 				}
 			]
 		},


### PR DESCRIPTION
Add command and menu item for opening current markdown file with [Haroopad](http://pad.haroopress.com/) markdown editor.
