### PR TITLE
Locate plugin

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -686,6 +686,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
+					"platforms": ["osx", "linux"],
 					"details": "https://github.com/sergey-kucher/SublimeLocate/tags"
 				}
 			]


### PR DESCRIPTION
Plugin allows to quick open almost any file on file system. It using unix command locate with -A option. Second feature of plugin is update files database for locate by updatedb command (sudo password required)
