### PR TITLE
Switch GithubLink name to GitLink due to Bitbucket suport

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -373,16 +373,6 @@
 			]
 		},
 		{
-			"name": "GitLink",
-			"details": "https://github.com/rscherf/GitLink",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"details": "https://github.com/rscherf/GitLink/tags"
-				}
-			]
-		},
-		{
 			"name": "Gitignore",
 			"details": "https://github.com/kevinxucs/Sublime-Gitignore",
 			"releases": [
@@ -410,6 +400,16 @@
 				{
 					"sublime_text": "*",
 					"details": "https://github.com/SnoringFrog/GitlabIntegrate/tags"
+				}
+			]
+		},
+		{
+			"name": "GitLink",
+			"details": "https://github.com/rscherf/GitLink",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/rscherf/GitLink/tags"
 				}
 			]
 		},


### PR DESCRIPTION
Another developer contributed to GitHubLink and added support for Bitbucket. It no longer makes sense to call this plugin GitHubLink.
