### PR TITLE
Add "Run Apps" for inovoking external tools from ST

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1178,6 +1178,16 @@
 			]
 		},
 		{
+			"name": "Run Apps",
+			"details": "https://github.com/liuhewei/run-app-sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"details": "https://github.com/liuhewei/run-app-sublime/tags"
+				}
+			]
+		},
+		{
 			"details": "https://github.com/qfel/RunCommand",
 			"releases": [
 				{


### PR DESCRIPTION
It's a typical feature in IDEs such as Visual studio, Eclipse, ... Usually called "External Tools".

Very simple implementation: user can add customized applications, and then the commands will appear in command pallete which is very easy to invoke through "ctrl+shift+p".
