### PR TITLE
Changed Release Channel for Canvas Snippets

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -169,7 +169,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"details": "https://github.com/skadimoolam/Canvas-Snippets/tree/master"
+					"details": "https://github.com/skadimoolam/Canvas-Snippets/tags"
 				}
 			]
 		},


### PR DESCRIPTION
From 'tree/master' to 'tags'.
