### PR TITLE
Update URL of packages

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1105,7 +1105,7 @@
 		},
 		{
 			"name": "AutoCompleteJS",
-			"details": "https://github.com/SublimeText/AutoCompleteJS",
+			"details": "https://github.com/titoBouzout/AutoCompleteJS",
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/b.json
+++ b/repository/b.json
@@ -819,7 +819,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeText/BufferScroll",
+			"details": "https://github.com/titoBouzout/BufferScroll",
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/c.json
+++ b/repository/c.json
@@ -119,7 +119,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeText/Camaleon",
+			"details": "https://github.com/titoBouzout/Camaleon",
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -722,7 +722,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeText/ClipboardCommands",
+			"details": "https://github.com/titoBouzout/ClipboardCommands",
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/d.json
+++ b/repository/d.json
@@ -375,7 +375,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeText/Dictionaries",
+			"details": "https://github.com/titoBouzout/Dictionaries",
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/e.json
+++ b/repository/e.json
@@ -325,7 +325,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeText/EncodingHelper",
+			"details": "https://github.com/titoBouzout/EncodingHelper",
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -411,7 +411,7 @@
 		},
 		{
 			"name": "ePub",
-			"details": "https://github.com/SublimeText/ePub",
+			"details": "https://github.com/titoBouzout/ePub",
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/f.json
+++ b/repository/f.json
@@ -67,7 +67,7 @@
 		},
 		{
 			"name": "FakeDataGenerator",
-			"details": "https://github.com/SublimeText/FakeDataGenerator",
+			"details": "https://github.com/titoBouzout/FakeDataGenerator",
 			"author": "titoBouzout",
 			"labels": ["data"],
 			"releases": [
@@ -517,7 +517,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeText/FindResultsApplyChanges",
+			"details": "https://github.com/titoBouzout/FindResultsApplyChanges",
 			"releases": [
 				{
 					"sublime_text": ">3000",

--- a/repository/l.json
+++ b/repository/l.json
@@ -444,7 +444,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeText/LineEndings",
+			"details": "https://github.com/titoBouzout/LineEndings",
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/o.json
+++ b/repository/o.json
@@ -349,7 +349,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeText/Open-Include",
+			"details": "https://github.com/titoBouzout/Open-Include",
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/p.json
+++ b/repository/p.json
@@ -1191,7 +1191,7 @@
 		},
 		{
 			"name": "PreventFakeClones",
-			"details": "https://github.com/SublimeText/PreventFakeClones",
+			"details": "https://github.com/titoBouzout/PreventFakeClones",
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/s.json
+++ b/repository/s.json
@@ -620,7 +620,7 @@
 		},
 		{
 			"name": "SelectionsToFiles",
-			"details": "https://github.com/SublimeText/SelectionsToFiles",
+			"details": "https://github.com/titoBouzout/SelectionsToFiles",
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -964,7 +964,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeText/SideBarFolders",
+			"details": "https://github.com/titoBouzout/SideBarFolders",
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -973,7 +973,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeText/SideBarGit",
+			"details": "https://github.com/titoBouzout/SideBarGit",
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/t.json
+++ b/repository/t.json
@@ -98,7 +98,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeText/Tag",
+			"details": "https://github.com/titoBouzout/Tag",
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1354,7 +1354,7 @@
 		},
 		{
 			"name": "Toolbar",
-			"details": "https://github.com/SublimeText/Toolbar",
+			"details": "https://github.com/titoBouzout/Toolbar",
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/w.json
+++ b/repository/w.json
@@ -315,7 +315,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeText/WordCount",
+			"details": "https://github.com/titoBouzout/WordCount",
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
@wbond Will, I moved my packages to my own user account and left the SublimeText organization. Please update the URL to the new locations. I'll appreciate if you can take this pull request
The list of packages:

https://github.com/titoBouzout/AutoCompleteJS
https://github.com/titoBouzout/BufferScroll
https://github.com/titoBouzout/Camaleon
https://github.com/titoBouzout/ClipboardCommands
https://github.com/titoBouzout/Dictionaries
https://github.com/titoBouzout/EncodingHelper
https://github.com/titoBouzout/ePub
https://github.com/titoBouzout/FakeDataGenerator
https://github.com/titoBouzout/FindResultsApplyChanges
https://github.com/titoBouzout/LineEndings
https://github.com/titoBouzout/Open-Include
https://github.com/titoBouzout/PreventFakeClones
https://github.com/titoBouzout/SelectionsToFiles
https://github.com/titoBouzout/SideBarFolders
https://github.com/titoBouzout/SideBarGit
https://github.com/titoBouzout/Tag
https://github.com/titoBouzout/Toolbar
https://github.com/titoBouzout/WordCount

Thanks
