### PR TITLE
Updated Canvas Snippets to Schema 3

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -161,11 +161,12 @@
 		{
 			"name": "Canvas Snippets",
 			"details": "https://github.com/skadimoolam/Canvas-Snippets",
+			"author": "Adi",
 			"labels": ["snippets", "auto-complete", "canvas", "html5", "javascript"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Changed Canvas-Snippets release channel from "branch" to "tags".
