### PR TITLE
Replace MagentoIntel with PHPIntel

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -54,16 +54,6 @@
 			]
 		},
 		{
-			"name": "MagentoIntel",
-			"details": "https://github.com/jotson/SublimeMagentoIntel",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "MagerunCommander",
 			"details": "https://github.com/nhduy1985/sublime_mageruncommander",
 			"author": "Dustin Tran",

--- a/repository/p.json
+++ b/repository/p.json
@@ -744,6 +744,22 @@
 			]
 		},
 		{
+			"name": "PHPIntel",
+			"details": "https://github.com/jotson/SublimePHPIntel",
+			"labels": ["php", "auto-complete", "autocomplete", "intellisense", "completion"],
+			"previous_names": ["MagentoIntel"],
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"tags": "st2-"
+				},
+				{
+					"sublime_text": ">=3000",
+					"tags": "st3-"
+				}
+			]
+		},
+		{
 			"name": "PhpNamespace",
 			"details": "https://github.com/gl3n/sublime-php-namespace",
 			"releases": [


### PR DESCRIPTION
MagentoIntel is deprecated. The new version is PHPIntel which provides a superset of the same functionality.
