### PR TITLE
Adding `Clipboard Diff` plugin to c.json

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -703,6 +703,16 @@
 			]
 		},
 		{
+			"name": "Clipboard Diff",
+			"details": "https://github.com/sabhiram/sublime-clipboard-diff",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Clipboard History",
 			"details": "https://github.com/kemayo/sublime-text-2-clipboard-history",
 			"releases": [


### PR DESCRIPTION
First time submitting a sublime plugin :+1:

Very simple usage - compares the selection vs the clipboard and uses difflib to compute a diff and then outputs the diff to a new scratch view.

Typically when I  compare small chunks of data within a file I end up copying the `from` and `to` chunks to new files and then diff said files - this is sort of tedious and is remedied by this plugin.

Cheers!
