### PR TITLE
Adding new plugin: Travis YML Lint

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -1514,6 +1514,16 @@
 			]
 		},
 		{
+			"name": "Travis YML Lint",
+			"details": "https://github.com/sabhiram/sublime-travis-yml-lint",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "TreeTop",
 			"details": "https://github.com/royvandewater/Sublime2-TreeTop",
 			"releases": [


### PR DESCRIPTION
Sublime 2 / 3 plugin which given an active `.travis.yml` file will run it against the Travis CI Lint Service here: http://lint.travis-ci.org/.

Fairly simple plugin, comes in handy when I am not sure what keys are missing and things I might have mistyped. Also saves time since we do not need to copy paste the yml contents to the webpage.
