### PR TITLE
Adding support for Sublime Text 3 to QuickSimplenote using tags

### DIFF
--- a/repository/q.json
+++ b/repository/q.json
@@ -195,7 +195,11 @@
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"tags": true
+					"tags": "st2-"
+				},
+				{
+					"sublime_text": ">=3000",
+					"tags": "st3-"
 				}
 			]
 		},


### PR DESCRIPTION
Hi, I'm adding support for Sublime Text 3.
The idea is to use tags like st2-0.2.1 and st3-0.2.1 over different branches of the repository to distinguish between the python 2 and python 3 version of the plugin.
