### PR TITLE
Adding `Vertical Select` to v.json

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -190,6 +190,16 @@
 			]
 		},
 		{
+			"name": "Vertical Select",
+			"details": "https://github.com/sabhiram/sublime-vertical-select",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "VEX Syntax",
 			"details": "https://github.com/WhileRomeBurns/VEX_Syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Super simple plugin - all it does is multi-select the previous / next line (relative to the current selection).

It extends the previous / next line if they lack the num cols demanded by the source line.

I got really tired of selecting all the lines, hitting ctrl + shift + l, then navigating to the vertical line I wish to edit. Hopefully this is useful!

@FichteFoll,

I find this quicker to select things which are already aligned which need to be wrapped in a function, or prepended uniformly (etc).

consider addthing somehting like `object.` before all the variables being printed. You would just have to click on x, y or z and hit the key to select up and / or down - and type away. Slightly faster I feel, and allows for visual studio esq selection.

```
int foo(void) {
    std::cout << x << std::endl;
    std::cout << y << std::endl;
    std::cout << z << std::endl;
```

I was also thinking about extending it to select a column (first selected text point of the first row, and last selected text point of the last row would be the range we select - in all lines). Again, emulates visual studio behavior (which I find apt some-times :) )
