### PR TITLE
New Document Type

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -193,6 +193,20 @@
 			]
 		},
 		{
+			"name": "New Document Type",
+			"details": "https://github.com/nishanths/sublime_new_doc",
+			"homepage": "https://github.com/nishanths/sublime_new_doc",
+			"readme": "https://raw.githubusercontent.com/nishanths/sublime_new_doc/master/README.md",
+			"labels": ["file creation", "language syntax"],
+			"author": "nishanths",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "New from Selection",
 			"details": "https://github.com/idosela/sublime_new_from_selection",
 			"releases": [


### PR DESCRIPTION
New Document Type
====
New Document Type is a plugin for Sublime Text 3+ that lets you choose a document type that new files should open with. 

Repo: https://github.com/nishanths/sublime_new_doc

Usage
===
From `View > New Document Type` in the menu, or by manually editing `NewDocumentType.sublime-settings`.

What It Looks Like
===
![img](http://cl.ly/image/3g183a2b213g/screenshot-new-doc-menu-@.5x.png)