### PR TITLE
Add Git Mode package info.

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -271,6 +271,17 @@
 			]
 		},
 		{
+			"name": "Git Mode",
+			"details": "https://github.com/markbirbeck/sublime-text-gitmode",
+			"labels": ["git", "emacs"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Git Status Files",
 			"details": "https://github.com/mkraft/git-status-files",
 			"releases": [


### PR DESCRIPTION
Hi there.

This is YAGM (Yet Another Git Module)...but I feel it has value, because it is much easier to add new commands and features than many of the other implementations. This is because most functionality can be added by specifying the command to perform, and then setting some flags to indicate where any extra input should be gathered from (such as new branch or remote repo names), how the output should be directed (such as to a new buffer or just to a panel), and how it should be formatted (by automatically wiring in syntax files).

As I say in the ['Why' section of the README](https://github.com/markbirbeck/sublime-text-gitmode#why):

> The Git plugin is great, but:
>
> * it relies on a great deal of code for its functionality, yet a lot of this functionality is boiler-plate and could be easily factored out; GitMode uses Shell Command which is a factoring of this kind of boilerplate code, plus a few other features;
> * relying on code for functionality, rather than configuration, makes it difficult to contribute to and to customise. This is especially frustrating for small features;
> * the Git plugin uses slightly different terminology to Git itself, which seems unnecessary.
>
> The SublimeGit plugin is also nice, but it costs money and is not open source.

I hope you'll be able to add Git Mode to the channel.

Thanks!