### PR TITLE
Add Sublime Input

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2347,6 +2347,16 @@
 			]
 		},
 		{
+			"name": "Sublime Input",
+			"details": "https://github.com/mavidser/SublimeInput",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Sublime JS",
 			"details": "https://github.com/akira-cn/SublimeJS",
 			"releases": [


### PR DESCRIPTION
# SublimeInput
SublimeInput is a Sublime Text 3 plugin which gives STDIN input through comments to a program.

## Usage
Insert a multi-line comment at the top of program.

Examples, using the default format:

_Python:_
```python
'''input
2
foo
bar
'''
a=input()
for i in xrange(a):
    a=raw_input()
    print a
```
_C/C++_
```cpp
/*input
2
foo
bar
*/
#include <stdio.h>
int main() {
  int n,i;
  char s[10];
  scanf("%d",&n);
  for(i=0;i<n;i++) {
    scanf("%s",s);
    printf("%s\n",s);
} }
```

Both the programs will print the following output:
```
foo
bar
```