### PR TITLE
Remove space between words - SexySnippets

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -821,11 +821,12 @@
 			]
 		},
 		{
-			"name": "Sexy Snippets",
+			"name": "SexySnippets",
 			"details": "https://github.com/felquis/SexySnippets",
 			"homepage": "https://github.com/felquis/SexySnippets",
 			"author": "felquis",
 			"labels": ["HTML", "javascript", "snippet", "pattern", "CSS"],
+			"previous_names": ["Sexy Snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
I saw that space causing some issues in the URL
![screen shot 2015-01-04 at 18 26 40](https://cloud.githubusercontent.com/assets/736728/5607367/e8b34ec4-943f-11e4-9c7b-43ffed2111ae.png)

So I removed.