### PR TITLE
Add support for Merlin

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -572,6 +572,16 @@
 			]
 		},
 		{
+			"name": "Merlin",
+			"details": "https://github.com/cynddl/sublime-text-merlin",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Messages",
 			"details": "https://github.com/kristoformaynard/SublimeMessages",
 			"labels": ["linting", "tool execution"],


### PR DESCRIPTION
Add a sublime text plugin for [Merlin](https://github.com/the-lambda-church/merlin), a context sensitive completion tool for OCaml.
