### PR TITLE
Added HTML Extended package to the repository

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -612,7 +612,7 @@
 			"details": "https://github.com/orizens/html-extended",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]

--- a/repository/h.json
+++ b/repository/h.json
@@ -669,7 +669,6 @@
 				}
 			]
 		},
-		,
 		{
 			"name": "HTML Extended",
 			"details": "https://github.com/orizens/html-extended",

--- a/repository/h.json
+++ b/repository/h.json
@@ -608,6 +608,16 @@
 			]
 		},
 		{
+			"name": "HTML Extended",
+			"details": "https://github.com/orizens/html-extended",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "HTML Minifier",
 			"details": "https://github.com/geekpradd/sublime-html5-minifier",
 			"releases": [
@@ -665,16 +675,6 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "HTML Extended",
-			"details": "https://github.com/orizens/html-extended",
-			"releases": [
-				{
-					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]

--- a/repository/h.json
+++ b/repository/h.json
@@ -669,6 +669,17 @@
 				}
 			]
 		},
+		,
+		{
+			"name": "HTML Extended",
+			"details": "https://github.com/orizens/html-extended",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
 		{
 			"details": "https://bitbucket.org/atroxell/html-compress-and-replace",
 			"releases": [


### PR DESCRIPTION
The HTML Extended package added syntax highlight for html elements with "dash" separator as in:
```<youtube-player></youtube-player>```
So, In Sublime Text, the 'youtube-player' will be displayed in one color instead of 2 colors (for each word).