### PR TITLE
Adds Copy To SharePoint Root

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1844,7 +1844,7 @@
 			]
 		},
 		{
-			"name": "Copy To SharePoint Root",
+			"name": "CopyToSharePointRoot",
 			"details": "https://github.com/eakron/SublimeCopyToSharePointRoot",
 			"author": "eakron",
 			"labels": ["sharepoint"],

--- a/repository/c.json
+++ b/repository/c.json
@@ -1844,6 +1844,19 @@
 			]
 		},
 		{
+			"name": "Copy To SharePoint Root",
+			"details": "https://github.com/eakron/SublimeCopyToSharePointRoot",
+			"author": "eakron",
+			"labels": ["sharepoint"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["windows"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/adzenith/CopyEdit",
 			"releases": [
 				{

--- a/repository/c.json
+++ b/repository/c.json
@@ -1844,6 +1844,15 @@
 			]
 		},
 		{
+			"details": "https://github.com/adzenith/CopyEdit",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "CopyToSharePointRoot",
 			"details": "https://github.com/eakron/SublimeCopyToSharePointRoot",
 			"author": "eakron",
@@ -1853,15 +1862,6 @@
 					"sublime_text": "*",
 					"platforms": ["windows"],
 					"tags": true
-				}
-			]
-		},
-		{
-			"details": "https://github.com/adzenith/CopyEdit",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
 				}
 			]
 		},


### PR DESCRIPTION
Adds a simple helper for working with SharePoint development in Sublime Text which lets you quickly copy files to the "hive" using a Sublime build system and a Powershell script.