### PR TITLE
GotoMark

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -648,6 +648,16 @@
 			]
 		},
 		{
+			"name": "GoToMark",
+			"details": "https://github.com/lyzz0612/GotoMark",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Google Apps Scripts",
 			"details": "https://github.com/revolunet/sublimetext-google-apps-scripts",
 			"labels": ["google", "scripts", "drive", "javascript"],

--- a/repository/g.json
+++ b/repository/g.json
@@ -648,16 +648,6 @@
 			]
 		},
 		{
-			"name": "Pragma Mark",
-			"details": "https://github.com/lyzz0612/GotoMark",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "Google Apps Scripts",
 			"details": "https://github.com/revolunet/sublimetext-google-apps-scripts",
 			"labels": ["google", "scripts", "drive", "javascript"],

--- a/repository/g.json
+++ b/repository/g.json
@@ -648,7 +648,7 @@
 			]
 		},
 		{
-			"name": "GoToMark",
+			"name": "Pragma Mark",
 			"details": "https://github.com/lyzz0612/GotoMark",
 			"releases": [
 				{

--- a/repository/p.json
+++ b/repository/p.json
@@ -1142,6 +1142,16 @@
 			]
 		},
 		{
+			"name": "Pragma Mark",
+			"details": "https://github.com/lyzz0612/GotoMark",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Pre language syntax highlighting",
 			"details": "https://github.com/jonschlinkert/pre-sublime",
 			"labels": ["language syntax"],


### PR DESCRIPTION
To support phrase "pragma mark"
If you add phrase "pragma mark anyWords", and then you press ctrl+option+i or click goto/goto mark, you will see a listBox which list all phrase you added. choose one and you will goto that line.
The cache file saves in packages/User/GoMark.cache/*

支持"pragma mark“
在代码中敲下类似"pragma mark ..."的代码，按下快捷键ctrl+option+i或者选择goto/goto mark，会显示一个列表框，列表框中列出了你代码里所有符合这种格式标记，选中其中一个，你将会跳转到对应行
缓冲文件保存在packages/User/GoMark.cache/*