### PR TITLE
Sublime Text version indicator set to pre 3.0 only, redundant author removed

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -444,11 +444,10 @@
 			"name": "Vorhees",
 			"details": "https://github.com/frankjonen/vorhees/",
 			"labels": ["color scheme", "formatting", "language syntax"],
-			"author": "frankjonen",
 			"readme": "https://raw.githubusercontent.com/frankjonen/vorhees/master/README.md",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<3000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Thanks for the pointer. Fixed it.