### PR TITLE
Company changed org name on GitHub

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2960,7 +2960,7 @@
 		},
 		{
 			"name": "SummitEditor",
-			"details": "https://github.com/corvisacloud/SummitEditor",
+			"details": "https://github.com/corvisa/SummitEditor",
 			"releases": [
 				{
 					"sublime_text": ">3000",
@@ -2970,7 +2970,7 @@
 		},
 		{
 			"name": "SummitLinter",
-			"details": "https://github.com/corvisacloud/SummitLinter",
+			"details": "https://github.com/corvisa/SummitLinter",
 			"releases": [
 				{
 					"sublime_text": ">3000",


### PR DESCRIPTION
Our company went from corvisacloud to corvisa, the repo urls needed to be updated.