### PR TITLE
Add JXA Package to repository

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -330,7 +330,7 @@
 				{
 					"sublime_text": "*",
 					"tags": true
-				}	
+				}
 			]
 		},
 		{
@@ -839,6 +839,18 @@
 				{
 					"sublime_text": "<3000",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "JXA",
+			"details": "https://github.com/dharma-guardian/JXASublimeText",
+			"labels": ["build system", "editor emulation", "javascript", "open scripting architecture"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx"],
+					"tags": true
 				}
 			]
 		}

--- a/repository/j.json
+++ b/repository/j.json
@@ -843,7 +843,7 @@
 			]
 		},
 		{
-			"name": "JXA",
+			"name": "JXA Build System",
 			"details": "https://github.com/dharma-guardian/JXASublimeText",
 			"labels": ["build system", "editor emulation", "javascript", "open scripting architecture"],
 			"releases": [


### PR DESCRIPTION
In OSX Yosemite you can use Javascript now to program for the Open Scripting Architecture. Because the Script Editor by Apple is not ideal I want to add JXA integration in ST.