### PR TITLE
Add LDIF syntax highlighter

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -237,6 +237,16 @@
 			]
 		},
 		{
+			"name": "LDIF Syntax Highlighting",
+			"details": "https://github.com/FlashSystems/LDIF-Syntax",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Leanpub",
 			"details": "https://github.com/jbrooksuk/Leanpub",
 			"releases": [


### PR DESCRIPTION
Pull request for adding the LDIF (RFC 2849) syntax highlighter to the package control repository.