### PR TITLE
Replacing QuantifiedDev plugin with 1self

### DIFF
--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -16,6 +16,7 @@
 			"name": "1Self",
 			"details": "https://github.com/1self/sublime-text-plugin",
 			"labels": ["time tracking", "activity"],
+			"previous_names": ["QuantifiedDev"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -13,6 +13,17 @@
 			]
 		},
 		{
+			"name": "1Self",
+			"details": "https://github.com/1self/sublime-text-plugin",
+			"labels": ["time tracking", "activity"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "2pdf",
 			"details": "https://github.com/fraoustin/Sublime2pdf",
 			"releases": [

--- a/repository/q.json
+++ b/repository/q.json
@@ -44,17 +44,6 @@
 			]
 		},
 		{
-			"name": "QuantifiedDev",
-			"details": "https://github.com/QuantifiedDev/sublime-text-plugin",
-			"labels": ["time tracking", "activity"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "QuarkPHP",
 			"details": "https://github.com/sahibalejandro/quark-php-sublime",
 			"releases": [


### PR DESCRIPTION
QuantifiedDev is now 1self. Plugin changed to reflect the new name and use the latest platform APIs.