### PR TITLE
Add Python dependencies "ordereddict", "pytz", "pyyaml", "requests"

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -17,6 +17,62 @@
 			]
 		},
 		{
+			"name": "ordereddict",
+			"load_order": "50",
+			"description": "Python ordereddict module",
+			"author": "FichteFoll",
+			"issues": "https://github.com/packagecontrol/ordereddict/issues",
+			"releases": [
+				{
+					"base": "https://github.com/packagecontrol/ordereddict",
+					"tags": true,
+					"sublime_text": "<3000"
+				}
+			]
+		},
+		{
+			"name": "pytz",
+			"load_order": "50",
+			"description": "Python pytz module",
+			"author": "FichteFoll",
+			"issues": "https://github.com/packagecontrol/pytz/issues",
+			"releases": [
+				{
+					"base": "https://github.com/packagecontrol/pytz",
+					"tags": true,
+					"sublime_text": "*"
+				}
+			]
+		},
+		{
+			"name": "pyyaml",
+			"load_order": "50",
+			"description": "Python PyYAML module",
+			"author": "FichteFoll",
+			"issues": "https://github.com/packagecontrol/pyyaml/issues",
+			"releases": [
+				{
+					"base": "https://github.com/packagecontrol/pyyaml",
+					"tags": true,
+					"sublime_text": "*"
+				}
+			]
+		},
+		{
+			"name": "requests",
+			"load_order": "50",
+			"description": "Python requests module",
+			"author": "FichteFoll",
+			"issues": "https://github.com/packagecontrol/requests/issues",
+			"releases": [
+				{
+					"base": "https://github.com/packagecontrol/requests",
+					"tags": true,
+					"sublime_text": "*"
+				}
+			]
+		},
+		{
 			"name": "select-windows",
 			"load_order": "02",
 			"description": "Python select module for Sublime Text 2 on Windows",


### PR DESCRIPTION
It is encouraged to use the dependency modules instead of bundling your own for the reasons mentioned below, but your package won't be removed when you don't. I'll mention a few package authors who maintain a package that could use one or more of these dependencies, but I do not know all candidates. If you spot other packages bundling their own copy of these modules, please refer them to this issue.

@jabyrd3, @erdostom, @thomscode, @facelessuser, @alanhamlett, @guillermooo, @thijsdezoete (and myself)

If you need more dependencies, feel free to create repos and add them as well. See https://packagecontrol.io/docs/dependencies for more information.

---

Now that 3.0.1 is out, the following four Python dependencies will be added to the default package control channel:

- **ordereddict** (for ST2)
- **pytz** (all)
- **pyyaml** (all)
- **requests** (all)

*Advantages*
- No messing with `sys.path` or `try: import ... except ImportError: from . import` constructs for ST2 and ST3 compatability
- No need to bundle the dependency code in your own package (in a subdirectory)
- No duplicated modules in case a user installed two or more packages that use the same dependency
- In above case of duplicates you couldn't get
- Yes, it also works when manually installing the package (unpack) or git-cloning the repo, it just won't be as smooth and require two ST restarts. That is, as long as Package Control is installed.
- PC 2.0 won't be an issue since it will be deprecated soon-ish and won't find any packages besides its own upgrade anymore.

*Disadvantages*
- There is no version resolution, just the one latest version. However, the modules will likely not be updated frequently unless someone requires a feature from a later release (pytz is a candidate here).


Please see the respective repo on how to use a dependency, however the basic procedure will be to create a file named `dependencies.json` with in your repo the following content:
```js
{
   "*": {
      "*": [
         "requests"
      ]
   }
}
```
after which you can use `import requests` relentlessly in your plugin code.



---

@wbond, since this is the first time dependencies are added you might want to have a look at this. I also created a test for dependency order (pushed to `master` branch already).