### PR TITLE
Added a new plugin "Django Starter"

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -528,6 +528,16 @@
 			]
 		},
 		{
+			"name": "Django Starter",
+			"details": "https://github.com/geekpradd/Sublime-Django-Starter",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Django-DocsSearch",
 			"details": "https://github.com/saippuakauppias/sublime-text-2-Django-DocsSearch",
 			"releases": [

--- a/repository/d.json
+++ b/repository/d.json
@@ -532,7 +532,7 @@
 			"details": "https://github.com/geekpradd/Sublime-Django-Starter",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
It's similar to the Flask Starter Plugin except longer and more complicated (plus more useful).
It enables Django Developers to create Django Projects directly from Sublime Text rather than using django_admin.py from the Terminal. It auto creates all python files and Django Folders.

Link: https://github.com/geekpradd/Sublime-Django-Starter