### PR TITLE
Move ownership of sublime-protobuf-syntax to vihangm

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1423,7 +1423,7 @@
 		},
 		{
 			"name": "Protocol Buffer Syntax",
-			"details": "https://github.com/awalterschulze/sublime-protobuf-syntax",
+			"details": "https://github.com/vihangm/sublime-protobuf-syntax",
 			"labels": ["language syntax"],
 			"releases": [
 				{


### PR DESCRIPTION
@awalterschulze would like someone else to maintain this package so I'm taking over.
Discussion on https://github.com/awalterschulze/sublime-protobuf-syntax/pull/3