### PR TITLE
Rename 'Shell Command' to 'ShellCommand'.

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -890,9 +890,10 @@
 			]
 		},
 		{
-			"name": "Shell Command",
+			"name": "ShellCommand",
 			"details": "https://github.com/markbirbeck/sublime-text-shell-command",
 			"labels": ["shell", "emacs"],
+			"previous_names": ["Shell Command"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/s.json
+++ b/repository/s.json
@@ -890,18 +890,6 @@
 			]
 		},
 		{
-			"name": "ShellCommand",
-			"details": "https://github.com/markbirbeck/sublime-text-shell-command",
-			"labels": ["shell", "emacs"],
-			"previous_names": ["Shell Command"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Shell Turtlestein",
 			"details": "https://github.com/misfo/Shell-Turtlestein",
 			"releases": [
@@ -912,6 +900,18 @@
 				{
 					"sublime_text": ">=3000",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "ShellCommand",
+			"details": "https://github.com/markbirbeck/sublime-text-shell-command",
+			"labels": ["shell", "emacs"],
+			"previous_names": ["Shell Command"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
I'm loading the Shell Command package as a module in my Git Mode package and it has been pointed out by @randy3k (markbirbeck/sublime-text-gitmode#9) that this doesn't work with the space in the name. (I'd been testing with a symbolic link, which hid the problem...dumb of me!)

So this pull request is to rename the command package. I found information about the `previous_names` property in the `example-repository.json` file, so hopefully I've included everything that's necessary.

Thanks.