### PR TITLE
babel is the new 6to5

### DIFF
--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -65,17 +65,6 @@
 					"branch": "master"
 				}
 			]
-		},
-		{
-			"name": "6to5",
-			"details": "https://github.com/6to5/6to5-sublime",
-			"labels": ["language syntax", "snippets", "javascript"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
 		}
 	]
 }

--- a/repository/b.json
+++ b/repository/b.json
@@ -13,6 +13,18 @@
 			]
 		},
 		{
+			"name": "Babel",
+			"previous_names": ["6to5"],
+			"details": "https://github.com/babel/babel-sublime",
+			"labels": ["language syntax", "snippets", "javascript"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Back There",
 			"details": "https://github.com/iuliux/SublimeText2-BackThere",
 			"releases": [


### PR DESCRIPTION
We've rebranded 6to5 as bebel to better reflect our mission. We moved 6to5/6to5-sublime over to babel but things broke, so we moved 6to5-sublime back to 6to5. I guess once this is merged I'll go ahead and migrate the repo over. cc: @FichteFoll 

https://github.com/babel/