### PR TITLE
Append " - ES6 & JSX Syntax" to Babel

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -13,8 +13,8 @@
 			]
 		},
 		{
-			"name": "Babel",
-			"previous_names": ["6to5"],
+			"name": "Babel - ES6 & JSX Syntax",
+			"previous_names": ["6to5", "Babel"],
 			"details": "https://github.com/babel/babel-sublime",
 			"labels": ["language syntax", "snippets", "javascript"],
 			"releases": [


### PR DESCRIPTION
Otherwise people can't find the package when they search for ES6 or JSX :disappointed: 