### PR TITLE
Adding JSCS-Formatter to the repositories

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -645,6 +645,16 @@
 			]
 		},
 		{
+			"name": "JSCS-Formatter",
+			"details": "https://github.com/TheSavior/Sublime-JSCS-Formatter",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "jsfmt",
 			"details": "https://github.com/ionutvmi/sublime-jsfmt",
 			"releases": [


### PR DESCRIPTION
We are working on a new feature over in https://github.com/jscs-dev/node-jscs to enable auto formatting following the same rules that it uses for linting. This package should enable Sublime to utilize that.