### PR TITLE
add QuickRequire

### DIFF
--- a/repository/q.json
+++ b/repository/q.json
@@ -176,6 +176,17 @@
 			]
 		},
 		{
+			"name": "QuickRequire",
+			"details": "https://github.com/psalaets/QuickRequire",
+			"donate": null,
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "QuickSearchEnhanced",
 			"details": "https://github.com/shagabutdinov/sublime-quick-search-enhanced",
 			"donate": "https://github.com/shagabutdinov/sublime-enhanced/blob/master/readme-donations.md",


### PR DESCRIPTION
This is yet another node.js require() plugin. I made the mistake of writing it before looking at what already exists. If rejected, I understand and no worries since I can just manually install it. That said, this plugin is different from the others in a subtle way. Here's my case for it...

# What QuickRequire does

QuickRequire looks at what has been typed on the current line and uses javascript/node naming conventions to guess the module name. If you type

```js
fooBar
```

and trigger the plugin (ctrl/cmd + shift + o), you end up with

```js
fooBar = require("foo-bar")
```

The inserted require(...) is a sublime snippet.

# How it differs from popular existing plugins

## Require Node.js Modules Helper (RNMH)

RNMH gives you a quick-select dropdown to pick a module. I find this slower than having the plugin just pick the module name for you.

In ST2 I can't generate require calls for node built-in modules.

In ST3 3065 I get a stacktrace in the sublime console when installing. When I trigger its keyboard shortcut nothing happens.

## NodeRequirer

Same comment as above regarding the quick-select dropdown.

NodeRequirer assumes you want "var" and a semicolon as part of your require.

```
var ____ = require("____");
```

Also, the plugin requires that you have a package.json file in the project directory.