### PR TITLE
added DummyData plugin

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -916,6 +916,16 @@
 			]
 		},
 		{
+			"name": "DummyData",
+			"details": "https://github.com/blcook223/DummyData",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Duplicate Lines",
 			"details": "https://github.com/wjthomas9/duplicate-lines",
 			"releases": [


### PR DESCRIPTION
This plugin allows a user to easily create random dummy JSON data within ST. See https://github.com/blcook223/DummyData/blob/master/README.md for more details.