### PR TITLE
Add `GitSavvy` project

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -495,6 +495,25 @@
 			]
 		},
 		{
+			"name": "GitSavvy",
+			"details": "https://github.com/divmain/GitSavvy",
+			"labels": [
+				"git",
+				"dashboard",
+				"inline",
+				"stage",
+				"patch"
+			],
+			"readme": "https://raw.githubusercontent.com/divmain/GitSavvy/master/README.md",
+			"author": "divmain",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "GitStatus",
 			"details": "https://github.com/vlakarados/gitstatus",
 			"labels": ["vcs"],


### PR DESCRIPTION
Adds [GitSavvy](https://github.com/divmain/GitSavvy).  Features:

- status dashboard
- support for staging individual lines and hunks inline (similar to SourceTree)
- enhanced `git log`, filtering by author or open file
- open file on GitHub (with lines selected)
- GitHub issue/collaborator integration
- GitHub-style blame view
- offline wiki-style feature documentation in Sublime
- open source

This supports only Sublime Text 3.