### PR TITLE
Change the name of the package

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -659,6 +659,17 @@
 			]
 		},
 		{
+			"name": "Require CommonJS Modules Helper",
+			"details": "https://github.com/jfromaniello/sublime-node-require",
+			"previous_names": ["Require Node.js Modules Helper"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Require Helper",
 			"details": "https://github.com/spadgos/sublime-require-helper",
 			"releases": [
@@ -669,16 +680,6 @@
 				{
 					"sublime_text": ">=3000",
 					"tags": true
-				}
-			]
-		},
-		{
-			"name": "Require Node.js Modules Helper",
-			"details": "https://github.com/jfromaniello/sublime-node-require",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
 				}
 			]
 		},


### PR DESCRIPTION
I think there is a problem with Sublime 3 when the name of the package contains a dot.

And I've always wanted to change from Node.js to CommonJS because that what really is.