### PR TITLE
Rename OCaml package

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -365,6 +365,19 @@
 			]
 		},
 		{
+			"name": "Better OCaml",
+			"details": "https://github.com/whitequark/sublime-better-ocaml",
+			"description": "An improved version of default OCaml package",
+			"labels": ["language syntax"],
+			"previous_names": ["OCaml"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Better RSpec",
 			"details": "https://github.com/fnando/better-rspec-for-sublime-text",
 			"labels": ["language syntax", "snippets"],

--- a/repository/o.json
+++ b/repository/o.json
@@ -55,18 +55,6 @@
 			]
 		},
 		{
-			"name": "OCaml",
-			"details": "https://github.com/whitequark/sublime-better-ocaml",
-			"description": "An improved version of default OCaml package",
-			"labels": ["language syntax"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "OCaml Autocompletion",
 			"details": "https://github.com/whitequark/sublime-ocp-index",
 			"releases": [


### PR DESCRIPTION
It is currently the same as a default package and that causes issues.

See https://github.com/wbond/package_control/issues/890 and https://github.com/wbond/package_control_channel/pull/4145.

@whitequark, please acknowledge this change.
