### PR TITLE
Added Python Output Format

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1767,6 +1767,16 @@
 			]
 		},
 		{
+			"name": "Python Output Format",
+			"details": "https://github.com/Tenzer/PythonOutputFormat",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Python Path to Clipboard",
 			"details": "https://github.com/Mimino666/SublimeText2-python-package-to-clipboard",
 			"previous_names": ["Python Package to Clipboard"],


### PR DESCRIPTION
This plugin uses Python's [tokenize](https://docs.python.org/3/library/tokenize.html) module to format `print()`'ed code from Python programs into more readable text. There's an example in the [README file](https://github.com/Tenzer/PythonOutputFormat/blob/master/README.md), using the metadata this very pull request adds :)