### PR TITLE
added JavaScript Ultimate (and ascii version)

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -289,6 +289,28 @@
 			]
 		},
 		{
+			"name": "JavaScript Ultimate",
+			"details": "https://github.com/JoshuaWise/javascript-ultimate",
+			"labels": ["language syntax", "snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "JavaScript Ultimate (Ascii)",
+			"details": "https://github.com/JoshuaWise/javascript-ultimate-ascii",
+			"labels": ["language syntax", "snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "JavaScriptFunctionDefinition",
 			"details": "https://github.com/asdf23/JavaScriptFunctionDefinition",
 			"labels": ["JavaScript", "autocomplete"],

--- a/repository/j.json
+++ b/repository/j.json
@@ -291,18 +291,7 @@
 		{
 			"name": "JavaScript Ultimate",
 			"details": "https://github.com/JoshuaWise/javascript-ultimate",
-			"labels": ["language syntax", "snippets"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "JavaScript Ultimate (Ascii)",
-			"details": "https://github.com/JoshuaWise/javascript-ultimate-ascii",
-			"labels": ["language syntax", "snippets"],
+			"labels": ["language syntax", "snippets", "javascript"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
I created a package to replace the built-in JavaScript syntax language. There are two versions: a default version (for full Unicode support), and an Ascii-only version.