### PR TITLE
Monochrome Color Schemes

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1064,6 +1064,17 @@
 			]
 		},
 		{
+			"name": "Monochrome Color Schemes",
+			"details": "https://github.com/kristopherjohnson/MonochromeSublimeText",
+			"labels": ["color scheme", "monochrome", "amber", "green", "blueprint"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Monocyanide Colorscheme",
 			"details": "https://github.com/Centril/sublime-monocyanide-colorscheme",
 			"labels": ["monokai", "cyanide", "color scheme"],


### PR DESCRIPTION
Monochrome Color Schemes package from https://github.com/kristopherjohnson/MonochromeSublimeText.

See http://undefinedvalue.com/2015/02/01/monochrome-color-themes-xcode-and-sublime-text for more info about these color schemes.