### PR TITLE
Added Flask Plugin

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1347,6 +1347,17 @@
 			]
 		},
 		{
+			"name": "Color Scheme - Dusk",
+			"details": "https://github.com/geekpradd/Dusk-Color-Scheme",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Color Scheme - Eggplant Parm",
 			"details": "https://github.com/mimshwright/sublime-eggplant-parm",
 			"labels": ["color scheme"],

--- a/repository/d.json
+++ b/repository/d.json
@@ -947,6 +947,17 @@
 			]
 		},
 		{
+			"name": "Dusk",
+			"details": "https://github.com/geekpradd/Dusk-Color-Scheme",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "DustBuster",
 			"previous_names": ["Dust.js"],
 			"details": "https://github.com/zanuka/dust-buster",

--- a/repository/d.json
+++ b/repository/d.json
@@ -947,7 +947,7 @@
 			]
 		},
 		{
-			"name": "Dusk",
+			"name": "Color Scheme - Dusk",
 			"details": "https://github.com/geekpradd/Dusk-Color-Scheme",
 			"labels": ["color scheme"],
 			"releases": [

--- a/repository/d.json
+++ b/repository/d.json
@@ -947,17 +947,6 @@
 			]
 		},
 		{
-			"name": "Color Scheme - Dusk",
-			"details": "https://github.com/geekpradd/Dusk-Color-Scheme",
-			"labels": ["color scheme"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "DustBuster",
 			"previous_names": ["Dust.js"],
 			"details": "https://github.com/zanuka/dust-buster",

--- a/repository/f.json
+++ b/repository/f.json
@@ -684,6 +684,17 @@
 			]
 		},
 		{
+			"name": "Flask",
+			"details": "https://github.com/geekpradd/Flask-Sublime",
+			"labels": ["auto-complete", "snippets"],
+			"releases": [
+				{
+					"sublime_text": "*`",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Flask Starter",
 			"details": "https://github.com/geekpradd/Sublime-Flask-Starter",
 			"releases": [

--- a/repository/f.json
+++ b/repository/f.json
@@ -689,7 +689,7 @@
 			"labels": ["auto-complete", "snippets"],
 			"releases": [
 				{
-					"sublime_text": "*`",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]

--- a/repository/f.json
+++ b/repository/f.json
@@ -684,7 +684,7 @@
 			]
 		},
 		{
-			"name": "Flask",
+			"name": "Flask Completions",
 			"details": "https://github.com/geekpradd/Flask-Sublime",
 			"labels": ["auto-complete", "snippets"],
 			"releases": [


### PR DESCRIPTION
This plugin adds autocompletions and snippets for the Flask microframework. 

Everything is working however I need to add a certain feature to the plugin that I am unable to do so.
@FichteFoll, you've helped me before and so can you please tell me how do I add the name of the module in the autocompletions.

Like for example in the AngularJS plugin. 

![1](https://cloud.githubusercontent.com/assets/7867775/6613020/7ea67492-c8ac-11e4-8759-4893d82fad65.png)

Here to the right of the autocomplete AngularJS is written in Italics. I want to achieve the same effect but sublime-completions does not support it natively (snippets do). Currently, the autocompletion looks like this:

![2](https://cloud.githubusercontent.com/assets/7867775/6613045/ecde8b0c-c8ac-11e4-96e2-76abd2541249.png)

