### PR TITLE
change DjangoManageCommands from repository to channel.json

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -118,6 +118,7 @@
 		"https://raw.githubusercontent.com/tmanderson/VintageLines/master/packages.json",
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",
 		"https://raw.githubusercontent.com/vkocubinsky/sublime_packages/master/packages.json",
+		"https://raw.githubusercontent.com/vladimirnani/DjangoCommands/master/packages.json",
 		"https://raw.githubusercontent.com/wallysalami/QuickLook/master/packages.json",
 		"https://raw.githubusercontent.com/weslly/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/WhatWeDo/Sublime-Text-2-Compass-Build-System/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -118,7 +118,6 @@
 		"https://raw.githubusercontent.com/tmanderson/VintageLines/master/packages.json",
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",
 		"https://raw.githubusercontent.com/vkocubinsky/sublime_packages/master/packages.json",
-		"https://raw.githubusercontent.com/vladimirnani/DjangoCommands/master/packages.json",
 		"https://raw.githubusercontent.com/wallysalami/QuickLook/master/packages.json",
 		"https://raw.githubusercontent.com/weslly/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/WhatWeDo/Sublime-Text-2-Compass-Build-System/master/packages.json",

--- a/repository/d.json
+++ b/repository/d.json
@@ -528,16 +528,6 @@
 			]
 		},
 		{
-			"name": "Django Manage Commands",
-			"details": "https://github.com/vladimirnani/DjangoCommands",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Django Starter",
 			"details": "https://github.com/geekpradd/Sublime-Django-Starter",
 			"releases": [

--- a/repository/d.json
+++ b/repository/d.json
@@ -526,6 +526,21 @@
 					"tags": true
 				}
 			]
+		},	
+		{
+			"name": "Django Manage Commands",
+			"details": "https://github.com/vladimirnani/DjangoCommands",
+			"labels": ["Django", "python", "web", "management"],
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"tags": "st2-"
+				},
+				{
+					"sublime_text": ">=3000",
+					"tags": "st3-"
+				}
+			]	
 		},
 		{
 			"name": "Django Starter",


### PR DESCRIPTION
Is there any better way to give  a specific version of the plugin depending the sublime text version?