### PR TITLE
Add FBP DSL syntax highlighting

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -197,6 +197,16 @@
 			]
 		},
 		{
+			"name": "FBP DSL",
+			"details": "https://github.com/trustmaster/sublime-fbp",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Feature Presentation",
 			"details": "https://github.com/ctruett/FeaturePresentation",
 			"releases": [


### PR DESCRIPTION
This one is more simple than https://github.com/paulyoung/FBP.tmbundle and supports ST only, plus it uses different colors.