### PR TITLE
Added Logging Control plugin to repository.

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -772,6 +772,17 @@
 			]
 		},
 		{
+			"name": "Logging Control",
+			"details": "https://github.com/scholer/sublime_logging_control",
+			"labels": ["logging", "logger", "logs", "debugging", "debug", "console", "output"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Logstash Syntax Highlighting",
 			"details": "https://github.com/nir0s/sublime-logstash-syntax-highlighter",
 			"labels": ["language syntax", "syntax", "highlighting"],


### PR DESCRIPTION
I've created a plugin that enables the user to control the behavior of the standard python logging module, customizing the logging format, where to output, and which levels to output. 

Please pull this into the Package Control repository.
Default Channel test passes.

Thanks!