### PR TITLE
Added LC3-ASM

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -227,6 +227,16 @@
 			]
 		},
 		{
+			"name": "LC3-ASM",
+			"details": "https://github.com/aviaryan/lc3-sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LC4 Assembly Syntax",
 			"details": "https://github.com/meepzh/lc4-assembly-syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Added syntax highlighting for [LC3 Simulator](http://people.cs.georgetown.edu/~squier/Teaching/HardwareFundamentals/LC3-trunk/docs/README-LC3tools.html) *.asm files.

Please note that there is a similarly named package ([LC3 Assembly](https://github.com/wufufufu/Sublime-LC3)) on Package Control but in reality that is different. I have also opened [an issue](https://github.com/wufufufu/Sublime-LC3/issues/1) for that but the author hasn't replied yet.
