### PR TITLE
Adds BinaryPlist -- an automatic XML/Binary property list converter

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -419,6 +419,17 @@
 			]
 		},
 		{
+			"name": "BinaryPlist",
+			"details": "https://github.com/tyrone-sudeium/st3-binaryplist",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Bind Zone files",
 			"details": "https://github.com/sixty4k/st2-zonefile",
 			"releases": [


### PR DESCRIPTION
This is an extension to Sublime Text 3 which allows it to _automatically_ convert between the XML and binary variants of Apple's [Property List][1] file format.

I realise that it's superficially similar to an existing package [Plist Binary][2], which is already in Package Control. However, I believe this package should also be included in Package Control because it differs from the existing package in important and non-trivial ways:

1. It works in Windows and Linux, where the existing package is Mac only. This is because it's a solution entirely in Python and doesn't require any command line tools from the system like the existing package does.
2. It's completely hands-free. You simply install the package, and you'll start seeing all Binary Property Lists as XML files. When you save them, they'll get written back out as Binary Property Lists. This is in contrast to the existing package which requires a command invocation to convert between the formats.
3. The existing package supports any Sublime Text version, whereas this one requires Sublime Text 3. It's mainly for this reason that the two projects are incompatible.

Thank you for your consideration.

[1]: https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man5/plist.5.html
[2]: https://github.com/relikd/Plist-Binary_sublime