### PR TITLE
PyPapf now supports both ST2 and 3

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1916,7 +1916,7 @@
 			"labels": ["python", "formatting"],
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Sorry about the change so soon after adding the package but ST3 support is a pretty important change.