### PR TITLE
Added Sphere Online Judge Plugin

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1836,6 +1836,16 @@
 			]
 		},
 		{
+			"name": "Sphere Online Judge",
+			"details": "https://github.com/geekpradd/Sphere-Online-Judge-Sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags" : true
+				}
+			]
+		},
+		{
 			"name": "Spice",
 			"details": "https://github.com/leoheck/sublime-spice",
 			"releases": [


### PR DESCRIPTION
This plugin is used for displaying Sphere Online Judge (competitive programming) problem contents so that both programming and problem reading can be done together.

The plugin is ready for release but there is one feature I need assistance on. I'm using a textarea to display the problem which is fetched from a remote API. How do I display an Image in the textarea since some problems have images in them? Except that everything is built and ready for deployment.