### PR TITLE
Fork of ReactJS (sublime-react) that reverts the latest breaking changes

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -126,6 +126,7 @@
 		"https://raw.githubusercontent.com/yangsu/sublime-io/master/packages.json",
 		"https://raw.githubusercontent.com/yangsu/sublime-octopress/master/packages.json",
 		"https://raw.githubusercontent.com/zfkun/sublime-kissy-snippets/master/packages.json",
+		"https://raw.githubusercontent.com/n1ghtmare/sublime-react/master/package.json",
 		"https://release.sublimegit.net/packages.json",
 		"https://sublimerge-bfcloud.rhcloud.com/packages.json",
 		"https://wuub.net/packages.json"


### PR DESCRIPTION
The new version breaks the plugin and syntax highlighting for jsx and cjsx files stops working. The author "deprecated" it and doesn't plan to support it anymore.