### PR TITLE
Add productive snippets for Ruby and ERB

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1346,6 +1346,28 @@
 			]
 		},
 		{
+			"name": "ProductiveSnippetsERB",
+			"details": "https://github.com/janlelis/productive-sublime-snippets-erb",
+			"labels": ["snippets", "erb", "ruby"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "ProductiveSnippetsRuby",
+			"details": "https://github.com/janlelis/productive-sublime-snippets-ruby",
+			"labels": ["snippets", "ruby"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Project PHP ClassBrowser",
 			"details": "https://github.com/degami/ProjectPHPClassBrowser",
 			"releases": [


### PR DESCRIPTION
This commit adds new snippets for Ruby and Embedded Ruby.

It is intended as a replacement for the stock Ruby snippets and avoids gem specific code (e.g. code that is only meant for Ruby on Rails).