### PR TITLE
Add CJSX Syntax

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -708,6 +708,17 @@
 			]
 		},
 		{
+			"name": "CJSX Syntax",
+			"details": "https://github.com/Guidebook/sublime-cjsx",
+			"labels": ["CJSX", "syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Clafer Tools",
 			"details": "https://github.com/gsdlab/ClaferToolsST",
 			"labels": ["Clafer", "Compiler", "Instance Generator"],


### PR DESCRIPTION
JSX/Coffeescript/CJSX syntax highlighting was [removed from sublime-react](https://github.com/reactjs/sublime-react/commit/bd1d7b7c059721b9baf8acff9840ba8ab9d35143) in favor of babel-sublime, which [does not intend on supporting CJSX](https://github.com/babel/babel-sublime/issues/96).

This is a port of the existing CJSX syntax highlighting with a few improvements. I plan on adding some other CJSX features to this repo over time.