### PR TITLE
add shoulda-matchers Snippets

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -974,6 +974,16 @@
 			]
 		},
 		{
+			"name": "shoulda-matchers Snippets",
+			"details": "https://github.com/maxehmookau/shoulda-matchers-snippets",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Show Open Files",
 			"details": "https://github.com/grapegravity/ShowOpenFiles",
 			"labels": ["status", "file"],


### PR DESCRIPTION
Adds a set of snippets to make using thoughtbot/shoulda-matchers a bit less repetitive.