### PR TITLE
Added Sublime Portage package

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1083,6 +1083,17 @@
 			]
 		},
 		{
+			"name": "Portage",
+			"details": "https://github.com/krizalys/sublime-portage",
+			"labels": ["language syntax", "portage", "gentoo", "funtoo", "emerge", "ebuild"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Postgres PL pgSQL",
 			"details": "https://github.com/mulander/postgres.tmbundle",
 			"labels": ["language syntax"],


### PR DESCRIPTION
I propose to add this package to the Package Control channel. It adds syntax highlighting for most Portage files, the package manager used in Gentoo and derived OSes.