### PR TITLE
Add a GN package for the GN build system used by Chromium

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -632,6 +632,16 @@
 			]
 		},
 		{
+			"name": "GN",
+			"details": "https://github.com/eseidelGoogle/gn_sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Gnuplot",
 			"details": "https://github.com/hesstobi/sublime_gnuplot",
 			"labels": ["language syntax"],


### PR DESCRIPTION
The README at https://github.com/eseidelGoogle/gn_sublime
explains what GN is and how to learn more information.

GN is used by several hundred engineers working on Chromium
and associated projects, many of whom use Sublime.  Having this
package in Package Control should make it much easier for these
users to have proper highlighting and comment control for
.gn and .gni files.