### PR TITLE
FontCycler now supports all versions of ST

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -933,7 +933,7 @@
 			"details": "https://github.com/akshaykumar90/sublime-font-cycler",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Recently merged pull request https://github.com/akshaykumar90/sublime-font-cycler/commit/4b569923dca015953ec547f23d950f5839073251 makes this possible.

This fixes https://github.com/akshaykumar90/sublime-font-cycler/issues/1.

