### PR TITLE
ClangAutoComplete: Simple C/C++ completion plugin.

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -783,6 +783,18 @@
 			]
 		},
 		{
+			"name": "ClangAutoComplete",
+			"details": "https://github.com/pl-ca/ClangAutoComplete",
+			"labels": ["Clang", "Completion", "C", "C++"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["osx, linux, windows"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Clarion",
 			"details": "https://github.com/fushnisoft/SublimeClarion",
 			"labels": ["language syntax"],


### PR DESCRIPTION
This is a very simple plugin based on clang that offers structure/class members completion for C and C++.

It is compatible for ST3 on Windows, Linux, and OS X.