### PR TITLE
ClangAutoComplete: Typo in platforms support field.

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -789,7 +789,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["osx, linux, windows"],
+					"platforms": ["osx", "linux", "windows"],
 					"tags": true
 				}
 			]

--- a/repository/c.json
+++ b/repository/c.json
@@ -789,7 +789,6 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["osx", "linux", "windows"],
 					"tags": true
 				}
 			]


### PR DESCRIPTION
There was a small typo in the platforms array. It is expected that the platform names be separated by quotes.