### PR TITLE
Adding apigen

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -785,8 +785,8 @@
 			"details": "https://github.com/dans98/Sublime-ApiGen",
 			"releases": [
 				{
-					"sublime_text": "*",
-					"branch": "master"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},

--- a/repository/a.json
+++ b/repository/a.json
@@ -781,6 +781,16 @@
 			]
 		},
 		{
+			"name": "ApiGen",
+			"details": "https://github.com/dans98/Sublime-ApiGen",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "APL Highlighting",
 			"details": "https://github.com/StoneCypher/sublime-apl",
 			"releases": [


### PR DESCRIPTION
I've created a simple plugin that allows anyone to quickly generate php source code documentation, from within Sublime. It allows a user to run ApiGen from the context menu, & the side bar.

The plugin allows users to have multiple apigen.neon files thought-out their project. This allows them to generate small sections of documentation quickly during the development process.