### PR TITLE
Added Query Completions Silencer

### DIFF
--- a/repository/q.json
+++ b/repository/q.json
@@ -75,6 +75,17 @@
 			]
 		},
 		{
+			"name": "Query Completions Silencer",
+			"details": "https://github.com/twolfson/sublime-query-completions-silencer",
+			"labels": ["auto-complete"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Quick Docs Launcher",
 			"details": "https://github.com/linkarys/QuickDocsLauncher",
 			"labels": ["docs", "search", "command line"],


### PR DESCRIPTION
This PR adds Query Completions Silencer to `package_control_channel`. Query Completions Silencer was created to cope with no option to disable built-in callback hooks (e.g. HTML ones).

https://github.com/twolfson/sublime-query-completions-silencer

In this PR:

- Added Query Completions Silencer on a tag release basis
