### PR TITLE
Remove CV3 Developer Tools from package list

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2837,17 +2837,6 @@
 			]
 		},
 		{
-			"name": "CV3 Developer Tools",
-			"details": "https://github.com/thisishuey/CV3-Developer-Tools",
-			"previous_names": ["CV3 Build Template"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Cycle Setting",
 			"details": "https://github.com/jmm/Sublime-Text-Cycle-Setting/tree/package-control",
 			"releases": [


### PR DESCRIPTION
We have moved this package into a private repo and it is no longer available so we are cleaning up the entry in the package control list.