### PR TITLE
Enabled Sublime Text 3 support for Snippet Destroyer

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1558,7 +1558,7 @@
 			"labels": ["snippet", "delete", "destroy"],
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
While transitioning to ST3, I found a solution to supporting Snippet Destroyer. As a result, I would like to allow installation for Snippet Destroyer in ST3.

Repo: https://github.com/twolfson/sublime-snippet-destroyer

Documentation on ST3: https://github.com/twolfson/sublime-snippet-destroyer/tree/0.1.1#sublime-text-3-setup

In this PR:

- Enabled all Sublime Text versions for Snippet Destroyer