### PR TITLE
Add PHP-Codebeautifier

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -601,6 +601,16 @@
 			]
 		},
 		{
+			"name": "PHP Codebeautifier",
+			"details": "https://github.com/Ennosuke/PHP-Codebeautifier",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "PHP Companion",
 			"details": "https://github.com/erichard/SublimePHPCompanion",
 			"releases": [


### PR DESCRIPTION
Add the possibility to use phpcbf from within Sublime Text.

I know there is another beautifier for PHP but it's only for ST3 and the used beautifier has stalled development.