### PR TITLE
add LPC syntax package

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -919,6 +919,17 @@
 			]
 		},
 		{
+			"name": "LPC",
+			"details": "https://github.com/abathur/SublimeLPC",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LPrint",
 			"details": "https://github.com/mbr/LPrint",
 			"releases": [


### PR DESCRIPTION
Add syntax definition for LPC (Lars Pensjö C), a C variant used to develop within LDMud (and other LP-family MUD drivers).