### PR TITLE
Removing platform restriction for PackageSync

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -48,7 +48,6 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["osx", "windows"],
 					"tags": true
 				}
 			]


### PR DESCRIPTION
PackageSync can now be installed on linux as well, in addition to the originally supported platforms windows & osx.