### PR TITLE
Update spec finder repo url

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1891,11 +1891,11 @@
 		},
 		{
 			"name": "Spec Finder",
-			"details": "https://github.com/Resellers/sublime-spec-finder",
+			"details": "https://github.com/rogeriochaves/sublime-spec-finder",
 			"releases": [
 				{
 					"sublime_text": "*",
-					"tags": true
+					"branch": "master"
 				}
 			]
 		},

--- a/repository/s.json
+++ b/repository/s.json
@@ -1895,7 +1895,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
The sublime plugin is no longer available on the original repository and I used it a lot, so I forked and improved the plugin (to find the specs faster and with more precision).