### PR TITLE
added RailsBase16 color scheme to the package list

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -149,6 +149,17 @@
 			]
 		},
 		{
+			"name": "RailsBase16 Color Schemes",
+			"details": "https://github.com/tompave/rails_base_16",
+			"labels": ["color scheme", "ruby", "ruby on rails", "rails"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "RailsCasts Colour Scheme",
 			"details": "https://github.com/tdm00/sublime-theme-railscasts",
 			"labels": ["color scheme"],


### PR DESCRIPTION
RailsBase16 is a customization of the [Base16 color scheme](https://github.com/chriskempson/base16), which aims to provide better syntax support for Ruby and Ruby on Rails.  

[Readme and examples](https://github.com/tompave/rails_base_16/blob/master/README.md)

