### PR TITLE
Added new package: MatlabAutoComplete

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -461,8 +461,8 @@
 			]
 		},
 		{
-			"details": "https://github.com/joepmoritz/MatlabAutoComplete",
-			"labels": ["auto-complete"],
+			"details": "https://github.com/joepmoritz/MatlabFilenameAutoComplete",
+			"labels": ["auto-complete", "matlab"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/m.json
+++ b/repository/m.json
@@ -461,6 +461,16 @@
 			]
 		},
 		{
+			"details": "https://github.com/joepmoritz/MatlabAutoComplete",
+			"labels": ["auto-complete"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/jawb/Matrixify",
 			"releases": [
 				{


### PR DESCRIPTION
This new package adds Matlab filenames (without extension) in currently open folders to auto complete, when editing a Matlab file. This is useful as Matlab forces filenames to be the same as the function name, so this effectively adds all the user's custom functions to autocomplete.

This is slightly different from existing packages that autocompletes filenames and paths, as this is restricted to completing *.m files, does not add the extension, and triggers everywhere inside a Matlab file (but nowhere else).