### PR TITLE
Added package SublimeREPL Babel.

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2989,7 +2989,7 @@
 			]
 		},
 		{
-			"name": "SublimeREPL Babel",
+			"name": "SublimeREPL-babel",
 			"labels": ["repl", "javascript", "babel", "es6", "es7"],
 			"details": "https://github.com/ggrks/sublimerepl-babel",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -2530,6 +2530,17 @@
 			]
 		},
 		{
+			"name": "SublimeREPL Babel",
+			"labels": ["repl", "javascript", "babel", "es6", "es7"],
+			"details": "https://github.com/ggrks/sublimerepl-babel",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Sublime Bookmarks",
 			"details": "https://github.com/bollu/sublimeBookmark",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -2530,17 +2530,6 @@
 			]
 		},
 		{
-			"name": "SublimeREPL Babel",
-			"labels": ["repl", "javascript", "babel", "es6", "es7"],
-			"details": "https://github.com/ggrks/sublimerepl-babel",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Sublime Bookmarks",
 			"details": "https://github.com/bollu/sublimeBookmark",
 			"releases": [
@@ -2995,6 +2984,17 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "SublimeREPL Babel",
+			"labels": ["repl", "javascript", "babel", "es6", "es7"],
+			"details": "https://github.com/ggrks/sublimerepl-babel",
+			"releases": [
+				{
+					"sublime_text": "*",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
SublimeREPL-babel extends the SublimeREPL package with a javascript REPL provided by [babel](https://babeljs.io), which allows you to execute next generation javascript code in a command line prompt since most of the syntax are not wildly supported by major platforms.
The original [SublimeREPL](https://github.com/wuub/SublimeREPL) repository seems to be inactive for 4 months, so I think it's better to create a standalone package.