### PR TITLE
Add SimpleCov package for ST3

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1215,6 +1215,16 @@
 			]
 		},
 		{
+			"name": "SimpleCov",
+			"details": "https://github.com/sentience/SublimeSimpleCov",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SimpleMarker",
 			"details": "https://github.com/jugyo/SublimeSimpleMarker",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -1217,6 +1217,7 @@
 		{
 			"name": "SimpleCov",
 			"details": "https://github.com/sentience/SublimeSimpleCov",
+			"labels": ["testing", "ruby"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
This package is a fork of [Ruby Coverage](https://packagecontrol.io/packages/Ruby%20Coverage), which is already in Package Control; however, Ruby Coverage is ST2-only, whereas this package is ST3-only.

I [proposed releasing this fork under the original package name](https://github.com/integrum/SublimeRubyCoverage/pull/4); however, I’ve had no reply from the original package authors. I suspect it is no longer being maintained. Given that the old package is ST2-only and this one is ST3-only, there should be no confusion to Package Control users, who will only see one or the other when searching for a Ruby coverage package.