### PR TITLE
Fixed package URL after username change

### DIFF
--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -47,7 +47,7 @@
 		},
 		{
 			"name": "42 Headers",
-			"details": "https://github.com/Globicodeur/Sublime-Text-42-Headers",
+			"details": "https://github.com/Globidev/Sublime-Text-42-Headers",
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
I changed my Github username so the repository link was broken (Github set up a redirect for my repository but I guess the crawler does not follow redirects)