### PR TITLE
Add Better Stylus Snippets package to repository

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -398,16 +398,6 @@
 			]
 		},
 		{
-			"name": "Better Stylus Snippets",
-			"details": "https://github.com/lnikell/better-stylus-snippets",
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Better TypeScript",
 			"details": "https://github.com/lavrton/sublime-better-typescript",
 			"labels": ["language syntax", "snippets", "linting", "watch", "typescript"],

--- a/repository/b.json
+++ b/repository/b.json
@@ -397,6 +397,16 @@
 				}
 			]
 		},
+    {
+      "name": "Better Stylus Snippets",
+      "details": "https://github.com/lnikell/better-stylus-snippets",
+      "releases": [
+        {
+          "sublime_text": ">=3000",
+          "branch": "master"
+        }
+      ]
+    },
 		{
 			"name": "Better TypeScript",
 			"details": "https://github.com/lavrton/sublime-better-typescript",

--- a/repository/b.json
+++ b/repository/b.json
@@ -397,16 +397,16 @@
 				}
 			]
 		},
-    {
-      "name": "Better Stylus Snippets",
-      "details": "https://github.com/lnikell/better-stylus-snippets",
-      "releases": [
-        {
-          "sublime_text": ">=3000",
-          "branch": "master"
-        }
-      ]
-    },
+		{
+			"name": "Better Stylus Snippets",
+			"details": "https://github.com/lnikell/better-stylus-snippets",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"branch": "master"
+				}
+			]
+		},
 		{
 			"name": "Better TypeScript",
 			"details": "https://github.com/lavrton/sublime-better-typescript",

--- a/repository/b.json
+++ b/repository/b.json
@@ -403,7 +403,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},

--- a/repository/s.json
+++ b/repository/s.json
@@ -2437,6 +2437,16 @@
 			]
 		},
 		{
+			"name": "Stylus Clean Completions",
+			"details": "https://github.com/lnikell/stylus-clean-completions",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/billymoon/Stylus-Snippets",
 			"releases": [
 				{


### PR DESCRIPTION
Hello! 
I used your guides about creating packages and I know that your list of the packages have already contain Stylus Snippets, but that package did not have changes from 2013 and that package use old syntax with colon, which not supported in many companies.