### PR TITLE
Add Show Texdoc package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1035,6 +1035,16 @@
 			]
 		},
 		{
+			"name": "Show Texdoc",
+			"details": "https://github.com/CareF/Show-Texdoc",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/grapegravity/ShowEncoding",
 			"releases": [
 				{


### PR DESCRIPTION
Add Show Texdoc package, which allows users to call LaTeX package documents without leaving Sublime Text.
by CareF