### PR TITLE
Fix renamed repository of compass package

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -121,7 +121,7 @@
 		"https://raw.githubusercontent.com/vkocubinsky/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/wallysalami/QuickLook/master/packages.json",
 		"https://raw.githubusercontent.com/weslly/sublime_packages/master/packages.json",
-		"https://raw.githubusercontent.com/WhatWeDo/Sublime-Text-2-Compass-Build-System/master/packages.json",
+		"https://raw.githubusercontent.com/whatwedo/sublime-text-compass/master/packages.json",
 		"https://raw.githubusercontent.com/x3ns/x3-alpha-theme/master/packages.json",
 		"https://raw.githubusercontent.com/xgenvn/InputHelper/master/packages.json",
 		"https://raw.githubusercontent.com/yangsu/sublime-io/master/packages.json",


### PR DESCRIPTION
Seems no longer to be visible in the package control, even github should redirect all repository names correctly. So here is the fix.