### PR TITLE
Updated Ensime plugin support to new host

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -483,7 +483,7 @@
 		},
 		{
 			"name": "Ensime",
-			"details": "https://github.com/sublimescala/sublime-ensime",
+			"details": "https://github.com/ensime/ensime-sublime",
 			"releases": [
 				{
 					"sublime_text": "<3000",


### PR DESCRIPTION
The Ensime plugin has now moved under the Ensime organisation - update the plugin path to match to the recently fixed up plugin.