### PR TITLE
Changed GIT repo location for Entropy package

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -508,7 +508,7 @@
 		},
 		{
 			"name": "Entropy",
-			"details": "https://bitbucket.org/danechitoaie/entropy",
+			"details": "https://bitbucket.org/demandware/entropy",
 			"labels": ["demandware"],
 			"releases": [
 				{


### PR DESCRIPTION
See:
* PR #4578 
* PR #4580 

I've moved my GIT repo to their account (Demandware) and we merged the projects.