### PR TITLE
Added Jai Syntax Plus to repository lists.

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -78,6 +78,16 @@
 			]
 		},
 		{
+			"name": "Jai Syntax Plus",
+			"details": "https://bitbucket.org/jasonericson/jaisyntax",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Jamon",
 			"details": "https://github.com/drhayes/SublimeJamon",
 			"releases": [


### PR DESCRIPTION
I went back and forth on whether I should add this, as there's a Jai syntax highlighter already existing in Package Control. I eventually decided that my version is different enough that both mine and the existing one have merit for different reasons (mine is fairly "aggressive" in it's scoping resulting in a lot of coloring, which some people might not like).