### PR TITLE
Add Laravel 5 Snippets

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -108,17 +108,6 @@
 			]
 		},
 		{
-			"name": "Laravel Five Snippets",
-			"details": "https://github.com/brnlbs/laravel-five-snippets",
-			"labels": ["snippets"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Laravel Forms Bootstrap Snippets",
 			"details": "https://github.com/redgluten/laravel_forms_boostrap_snippets",
 			"labels": ["snippets"],

--- a/repository/l.json
+++ b/repository/l.json
@@ -75,6 +75,7 @@
 		},
 		{
 			"name": "Laravel 5 Snippets",
+			"previous_names": ["Laravel Five Snippets"],
 			"details": "https://github.com/Lykegenes/laravel-5-snippets",
 			"labels": ["snippets"],
 			"releases": [

--- a/repository/l.json
+++ b/repository/l.json
@@ -74,6 +74,17 @@
 			]
 		},
 		{
+			"name": "Laravel 5 Snippets",
+			"details": "https://github.com/Lykegenes/laravel-5-snippets",
+			"labels": ["snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Laravel Bootstrapper Snippets",
 			"details": "https://github.com/patricktalmadge/Bootstrapper_snippets",
 			"labels": ["snippets"],


### PR DESCRIPTION
Hi!

There is currently another similar package in the channel, but the author deleted his Github account so it's unavailable. The missing package name is "Laravel Five Snippets" if you want to remove it.

Thanks!