### PR TITLE
Updated repo url for Compare Side-By-Side

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1893,13 +1893,13 @@
 		},
 		{
 			"name": "Compare Side-By-Side",
-			"details": "https://bitbucket.org/dougty/sublime-compare-side-by-side",
+			"details": "https://github.com/DougTy/sublime-compare-side-by-side",
 			"author": "Doug Ty",
 			"labels": ["diff", "compare", "comparison"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "default"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Moved from BitBucket/Hg to GitHub

I saw that using branches is deprecated now, so I've changed it to tags.
Hopefully I've done that right.

Thanks!