### PR TITLE
Add package -- TypeShort

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2206,6 +2206,17 @@
 			]
 		},
 		{
+			"name": "TypeShort",
+			"details": "https://github.com/jfcherng/sublime-TypeShort",
+			"labels": ["snippets", "text manipulation"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "TypeSnippets",
 			"author": "Philipp Rudloff",
 			"details": "https://github.com/kleinfreund/TypeSnippets",


### PR DESCRIPTION
Repo: https://github.com/jfcherng/sublime-TypeShort

# TypeShort #

TypeShort is a snippet-like plugin for Sublime Text 3.

The original idea comes from [VvPhpDollar](https://github.com/ZhaonanLi/VvPhpDollar) by [ZhaonanLi](https://github.com/ZhaonanLi).

It will replace placeholders into corresponding replacements in real-time while typing.


## Usage ##

For example, typing a `$` or a `->` in PHP may be just not that comfortable.

You can set `fj_` (`_` means a space here, just for interpretation) as a placeholder for `$` in PHP.

This plugin will automatically replace `fj_` into `$` in PHP whenever you type it.

Although `fj_` has three characters, it could still be typed faster than a `$`.


## Screenshot(s) ##

![](https://raw.githubusercontent.com/jfcherng/sublime-TypeShort/gh-pages/images/screenshot.gif)