### PR TITLE
Add DoxyDoxygen to the official packages list

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -2,12 +2,12 @@
 	"schema_version": "3.0.0",
 	"repositories": [
 		"./repository.json",
-		"http://20tauri.free.fr/DoxyDoxygen/DoxyDoxygen.json",
 		"https://bitbucket.org/jjones028/p4sublime/raw/tip/packages.json",
 		"https://bitbucket.org/klorenz/sublime_packages/raw/tip/packages.json",
 		"https://csch1.triangulum.uberspace.de/release/packages.json",
 		"https://eberstarkgroup.com/releases/packages.json",
 		"https://packagecontrol.io/packages_2.json",
+		"https://raw.githubusercontent.com/20Tauri/DoxyDoxygen/master/DoxyDoxygen.json",
 		"https://raw.githubusercontent.com/accerqueira/sublime/master/packages.json",
 		"https://raw.githubusercontent.com/afterdesign/jshintify/master/packages.json",
 		"https://raw.githubusercontent.com/afterdesign/MacTerminal/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -2,6 +2,7 @@
 	"schema_version": "3.0.0",
 	"repositories": [
 		"./repository.json",
+		"http://20tauri.free.fr/DoxyDoxygen/DoxyDoxygen.json",
 		"https://bitbucket.org/jjones028/p4sublime/raw/tip/packages.json",
 		"https://bitbucket.org/klorenz/sublime_packages/raw/tip/packages.json",
 		"https://csch1.triangulum.uberspace.de/release/packages.json",


### PR DESCRIPTION
This package simplifies writing comments.

It have a good language comprehension.
May probably replace DoxyDoc package (except for the license), because even if DoxyDoxygen is not dedicated to C++ it provide a better support that it...

DoxyDoxygen have a different approch than the great DocBlockR. Due to his better knowledge of language, DoxyDoxygen may guess type without any configuration. It also provide a lot of long time requested functionaly that cannot be easily implentated to DocBlockR (like comments reparsing)

Here an example of generated documentation:
```JavaScript
/**
 * { description }
 *
 * @param      {number}  errorCode  { description }
 *
 * @return     {string}  { description_of_the_return_value }
 */
function error2msg(errorCode) {
    if (errorCode == 404) {
        return "page not found";
    }

    return "...";
}
```

Please visit the official [DoxyDoxygen page](http://20tauri.free.fr/DoxyDoxygen) for further informations

Thanks you for your time,
Thanks you for your review.