### PR TITLE
Added jinja2 and markupsafe to dependencies.json and to Glorified Copy 'n' Paste's dependency list

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -31,6 +31,34 @@
 			]
 		},
 		{
+			"name": "jinja2",
+			"load_order": "50",
+			"description": "Python Jinja2 module",
+			"author": "teddy_beer_maniac",
+			"issues": "https://bitbucket.org/teddy_beer_maniac/sublime-text-dependency-jinja2/issues",
+			"releases": [
+				{
+					"base": "https://bitbucket.org/teddy_beer_maniac/sublime-text-dependency-jinja2",
+					"tags": true,
+					"sublime_text": "*"
+				}
+			]
+		},
+		{
+			"name": "markupsafe",
+			"load_order": "50",
+			"description": "Python MarkupSafe module",
+			"author": "teddy_beer_maniac",
+			"issues": "https://bitbucket.org/teddy_beer_maniac/sublime-text-dependency-markupsafe/issues",
+			"releases": [
+				{
+					"base": "https://bitbucket.org/teddy_beer_maniac/sublime-text-dependency-markupsafe",
+					"tags": true,
+					"sublime_text": "*"
+				}
+			]
+		},
+		{
 			"name": "oauthlib",
 			"load_order": "50",
 			"description": "Python oauthlib module",

--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -32,7 +32,7 @@
 		},
 		{
 			"name": "jinja2",
-			"load_order": "50",
+			"load_order": "51",
 			"description": "Python Jinja2 module",
 			"author": "teddy_beer_maniac",
 			"issues": "https://bitbucket.org/teddy_beer_maniac/sublime-text-dependency-jinja2/issues",

--- a/repository/g.json
+++ b/repository/g.json
@@ -620,7 +620,11 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"tags": true
+					"tags": true,
+					"dependencies": [
+						"jinja2",
+						"markupsafe"
+					]
 				}
 			]
 		},

--- a/repository/g.json
+++ b/repository/g.json
@@ -620,11 +620,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"tags": true,
-					"dependencies": [
-						"jinja2",
-						"markupsafe"
-					]
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Is there by any chance possibility for dependencies to have dependencies themselves? I didn't feel like putting markupsafe along jinja2 was a good idea, but jinja2 will not work without it, so they both have to be added as dependencies in packages.