### PR TITLE
Add MDL Language package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -547,6 +547,17 @@
 			]
 		},
 		{
+			"name": "MDL Language",
+			"details": "https://github.com/ardenpm/sublime-mdl-language",
+			"labels" : ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MDN Search",
 			"details": "https://github.com/jackfranklin/ST2-MDN-Search",
 			"releases": [

--- a/repository/m.json
+++ b/repository/m.json
@@ -552,7 +552,7 @@
 			"labels" : ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Add new language definition for the NVIDIA MDL (Material Definition Language) Language. This language defines the appearance of materials for photorealistic renderers such as the NVIDIA Iray renderer. MDL is a free, published language for making materials.