### PR TITLE
Add Jasmine Promise Matchers package.

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -131,6 +131,17 @@
 			]
 		},
 		{
+			"name": "Jasmine Promise Matchers",
+			"details": "https://github.com/Hyzual/jasmine-promise-matchers-snippets",
+			"labels": ["snippets", "Jasmine", "angular", "javascript", "testing"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Jasmine Scaffold",
 			"details": "https://github.com/swirlycheetah/jasmine-scaffold-sublime-text",
 			"labels": ["Jasmine", "javascript", "testing", "unit test"],


### PR DESCRIPTION
Add [Jasmine Promise Matchers](https://github.com/bvaughn/jasmine-promise-matchers) snippets.
Since it is an optional extension to Jasmine, it should be a different package from the existing [Jasmine JS Package](https://packagecontrol.io/packages/Jasmine%20JS).