### PR TITLE
PokemonTeamSyntax added.

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1126,6 +1126,17 @@
 			]
 		},
 		{
+			"name": "PokemonTeamSyntax",
+			"details": "https://github.com/forsureitsme/PokemonTeamSyntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Polymer & Web Component Snippets",
 			"details": "https://github.com/robdodson/PolymerSnippets",
 			"labels": ["snippets"],


### PR DESCRIPTION
Syntax highlighting for Pokemon Team's importables.

Here's an example, running on Monokai Color Scheme:

![Pokemon Team Syntax](https://cloud.githubusercontent.com/assets/2235293/9205729/51c3f3d6-403a-11e5-8f46-3f99abe690e8.png)
