### PR TITLE
Added perl-Test-Class extension

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -472,6 +472,17 @@
 			]
 		},
 		{
+			"name": "perl-Test-Class",
+			"details": "https://github.com/jonasbn/SublimeText-Perl-Test-Class",
+			"labels": ["auto-complete", "formatting", "language syntax", "snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "perl-Test-More",
 			"details": "https://github.com/jonasbn/SublimeText-Perl-Test-More",
 			"labels": ["auto-complete", "formatting", "language syntax", "snippets"],

--- a/repository/p.json
+++ b/repository/p.json
@@ -478,7 +478,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},
@@ -489,7 +489,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Another Perl syntax package for Perl's Test::Class I created a long time ago, but I forgot to request its possible addition to the package control channel.

