### PR TITLE
Add GotoWindow package

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1181,6 +1181,16 @@
 			]
 		},
 		{
+			"name": "GotoWindow",
+			"details": "https://github.com/ccampbell/sublime-goto-window",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Gourmet",
 			"details": "https://github.com/gourmet/sublime",
 			"releases": [

--- a/repository/g.json
+++ b/repository/g.json
@@ -1186,7 +1186,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
This pull request adds a new sublime package I wrote to quickly jump around between open sublime windows using the keyboard.  It works like `super + t` except for open windows instead of files in the active window.