### PR TITLE
Add lxml dependency

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -45,6 +45,21 @@
 			]
 		},
 		{
+				"name": "lxml",
+				"load_order": "10",
+				"description": "lxml",
+				"author": "eerohele",
+				"issues": "https://github.com/eerohele/sublime-lxml/issues",
+				"releases": [
+						{
+								"base": "https://github.com/eerohele/sublime-lxml",
+								"tags": true,
+								"sublime_text": ">=3000",
+								"platforms": ["osx-x64", "linux-x64"]
+						}
+				]
+		},
+		{
 			"name": "markupsafe",
 			"load_order": "50",
 			"description": "Python MarkupSafe module",


### PR DESCRIPTION
I'm working on a plugin that uses [lxml](http://lxml.de/), so I thought I'd give this a go. I might be in way over my head here, but let's see.

My plugin will be ST3 only, so I've only added ST3 dependencies so far.

Also, 64-bit OS X and Linux only. I gave Windows my absolute best shot, but eventually had to give up, because I just wasn't able to statically compile lxml on a 64-bit Windows — the attempt nearly drove me mad. If someone out there wants to give it a go, I'd be happy to accept PRs on that.

I also tried using [Christoph Gohlke's precompiled lxml binaries](http://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml) (there's one compiled using Python 3.3, apparently, which is what ST3 uses), but ST3 wouldn't load it.

A 32-bit Linux shouldn't be impossible, I suppose, so if there's interest, I could try to give it a go.

The OS X dependency has been tested on two Macs and should work OK. I tested the Linux dependency on Elementary OS and it seemed to work OK, but there's someone out there who can help test these, that'd be great.

Wasn't sure about the load order value, so just let me know if I should change it to something else.