### PR TITLE
Updated repo link address Coffee2Js

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1399,7 +1399,7 @@
 		},
 		{
 			"name": "Coffee2Js",
-			"details": "https://github.com/mattseymour/sublime-coffee-to-js",
+			"details": "https://github.com/mattseymour/sublime-coffee2js",
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
I have / am renaming the repo so the repo name and plugin name are the same.

