### PR TITLE
add in SublimeLinter-cmakelint

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3052,6 +3052,17 @@
 			]
 		}, 
 		{
+			"name": "SublimeLinter-cmakelint",
+			"details": "https://github.com/jasjuang/SublimeLinter-cmakelint",
+			"labels": ["linting"],
+			"releases": [
+				{
+					"sublime_text": ">3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SublimeLinter_CatGutterTheme",
 			"details": "https://github.com/m10l/SublimeLinter-CatGutterTheme",
 			"labels": ["linting"],


### PR DESCRIPTION
This is a linter for cmake related files. SublimeLinter and cmakelint must be installed first. Modified based on https://github.com/SublimeLinter/SublimeLinter-cpplint.