### PR TITLE
fixed required sublime version for sublimious

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3272,7 +3272,7 @@
 			"details": "https://github.com/dvcrn/sublimious",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": ">=3000",
 					"tags": true,
 					"platforms": ["osx", "linux"]
 				}


### PR DESCRIPTION
Looks like I made a mistake in my last PR. Versioning for sublimious should be everything bigger than 3.0. Sorry for the messup!