### PR TITLE
Added 'kill' package to repository.json

### DIFF
--- a/repository/k.json
+++ b/repository/k.json
@@ -132,6 +132,17 @@
 			]
 		},
 		{
+			"name": "Kill",
+			"details": "https://github.com/goldsborough/kill",
+			"labels": ["build system", "process", "build"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Kimbie Color Scheme",
 			"details": "https://github.com/idleberg/Kimbie.tmTheme",
 			"labels": ["color scheme"],


### PR DESCRIPTION
This is a plugin to kill rogue processes. The point is that when you have an endless loop in Python or Ruby (and I can imagine anywhere else) you cannot stop that process and it will run in the background hogging resources. This plugin looks for the process corresponding to the current file and kills it.

It requires the [*psutil*](https://github.com/giampaolo/psutil) python package as a dependency.