### PR TITLE
[SystemVerilog] Switch to tag-based release

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3964,10 +3964,11 @@
 		{
 			"name": "SystemVerilog",
 			"details": "https://bitbucket.org/Clams/sublimesystemverilog",
+			"labels": ["language syntax", "snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "default"
+					"tags": true
 				}
 			]
 		}


### PR DESCRIPTION
Package SystemVerilog now uses tag-based release instead of branch, and
include labels language syntax and snippets.