### PR TITLE
add ConEmuOpen package for windows user

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1093,6 +1093,18 @@
 			]
 		},
 		{
+			"name": "Cmd",
+			"details": "https://github.com/kiliwalk/sublime_cmd",
+			"labels": ["conemu", "cmd", "windows"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["windows"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CMS Made Simple Snippets",
 			"details": "https://github.com/bbonora/SublimeCMSMadeSimple",
 			"labels": ["snippets"],

--- a/repository/c.json
+++ b/repository/c.json
@@ -1093,18 +1093,6 @@
 			]
 		},
 		{
-			"name": "Cmd",
-			"details": "https://github.com/kiliwalk/sublime_cmd",
-			"labels": ["conemu", "cmd", "windows"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"platforms": ["windows"],
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "CMS Made Simple Snippets",
 			"details": "https://github.com/bbonora/SublimeCMSMadeSimple",
 			"labels": ["snippets"],
@@ -2049,6 +2037,18 @@
 				{
 					"sublime_text": "*",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "ConEmuOpen",
+			"details": "https://github.com/kiliwalk/Sublime_ConEmuOpen",
+			"labels": ["conemu", "cmd", "windows", "cmd here"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["windows"],
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
launch [ConEmu](https://github.com/Maximus5/ConEmu) from the current dir or the project folder, only for sublime text 3 and windows!

**Features**
* support sublime text project, folder, and even files window!
* support sidebar's folder/file context menu
* with only one(single) ConEmu window and many tabs
* ConEmu tab with a contextual title, like `st:<project name>` and `st:<project name>: <relative path for inner folder>`, eg. `st:nbs`, `st:nbs: test\fiber`