### PR TITLE
Added React ES6 snippets

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -350,6 +350,16 @@
 			]
 		},
 		{
+			"name": "React ES6 Snippets",
+			"details": "https://github.com/mboperator/sublime-react-es6",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "React Templates",
 			"details": "https://github.com/talpor/sublime-rt",
 			"labels": ["language syntax", "RT"],

--- a/repository/r.json
+++ b/repository/r.json
@@ -356,7 +356,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},

--- a/repository/r.json
+++ b/repository/r.json
@@ -352,6 +352,7 @@
 		{
 			"name": "React ES6 Snippets",
 			"details": "https://github.com/mboperator/sublime-react-es6",
+			"labels": ["snippets", "jsx", "es6", "react"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
Same keybindings as Facebook's ReactJS Snippets, updated syntax.
I would submit a PR to them but they're sticking with ES5 syntax for maximum support.