### PR TITLE
Add MagicPython package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -99,6 +99,16 @@
 			]
 		},
 		{
+			"name": "MagicPython",
+			"details": "https://github.com/MagicStack/MagicPython.git",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Make File Executable",
 			"details": "https://github.com/glutanimate/sublime-make-file-executable",
 			"labels": ["chmod", "permissions"],


### PR DESCRIPTION
New Python highlighter that was built specifically to support all new Python 3 features.  Reimplemented from scratch and built with unit-tests that ensure that all features are supported.