### PR TITLE
Add MagicPython

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -99,6 +99,16 @@
 			]
 		},
 		{
+			"name": "MagicPython",
+			"details": "https://github.com/MagicStack/MagicPython",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Make File Executable",
 			"details": "https://github.com/glutanimate/sublime-make-file-executable",
 			"labels": ["chmod", "permissions"],

--- a/repository/m.json
+++ b/repository/m.json
@@ -101,10 +101,11 @@
 		{
 			"name": "MagicPython",
 			"details": "https://github.com/MagicStack/MagicPython",
+			"labels": ["language syntax", "python"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
New Python highlighter that was built specifically to support all new Python 3 features. Reimplemented from scratch and built with thorough unit-tests to ensure that all features are supported and it's safe to evolve the schema.

List of things that only MagicPython properly supports:
- new `async`/`await` syntax
- new `@` operator
- correct parsing of function parameter and result annotations (including line breaks etc)
- highlighting new `'{foo!r}'.format(..)` format specs (the format mini-language is validated!)
- highlighting full unicode escaping syntax inside string literals
- proper auto indentation in `async` statements
- many improvements of rendering of special `0b...`, `0x...`, `0o...` (including Python 2 `L` numbers) numeric literals
- correct highlighting of invalid keyword arguments/parameters -- `foo(class='spam', async='ham')`
- better rendering of built-in base classes *and* class keyword arguments `class Foo(Base, param=123)`
- constants are highlighted differently from regular variables
- all string prefixes are highlighted `br'spam'`
- properly highlight complex numbers `10 + 5j`
- much more stable than existing highlighters -- if something can't be parsed, the rest of the file will be highlighted properly
- characters after `/` (line continuation) are highlighted as invalid
- unittests to make sure that the highlighter works correctly and we can evolve it safely.
- and many other small usability and stability improvements

We've put tons of effort into this package, and will continue to maintain it long into the future.

https://github.com/MagicStack/MagicPython