### PR TITLE
Expand Selection to Quotes works with any version

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -875,7 +875,7 @@
 			"details": "https://github.com/kek/sublime-expand-selection-to-quotes",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"branch": "master"
 				}
 			]


### PR DESCRIPTION
This plugin has worked with Sublime Text 3 for a while, but I never got around to update the repository information.