### PR TITLE
SproutCore: removing the limit to ST2 only

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1731,7 +1731,7 @@
 		{
 			"name": "SnippetX",
 			"details": "https://github.com/ColinRyan/SnippetX",
-			"labels": ["text manipulation", "snippets"],			
+			"labels": ["text manipulation", "snippets"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2187,7 +2187,7 @@
 			"labels": ["snippets"],
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"branch": "master"
 				}
 			]


### PR DESCRIPTION
The SproutCore package can be run equally well in ST3, so the limit to ST2 is not needed.