### PR TITLE
add rubycritic

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1302,6 +1302,17 @@
 			]
 		},
 		{
+			"name": "Rubycritic",
+			"details": "https://github.com/pedrocarmona/SublimeRubycritic",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "RubyEval",
 			"details": "https://github.com/jugyo/SublimeRubyEval",
 			"releases": [


### PR DESCRIPTION
Rubycritic is a Sublime plugin to make a rubycritic assessment of current file, and automatically open it in the browser