### PR TITLE
Added "Bash from Context Menu"'s entry

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -161,6 +161,17 @@
 			]
 		},
 		{
+			"name": "Bash from Context Menu",
+			"details": "https://github.com/DoersGuild/Open-Bash-from-Context-Menu-on-Sublime-Text-3",
+			"labels": ["bash", "terminal"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Bats (Bash Automated Testing System)",
 			"details": "https://github.com/jverdeyen/sublime-bats",
 			"releases": [


### PR DESCRIPTION
This is a simple package to open a bash terminal in the current file's directory from the Sublime Text Context Menu.

Requires you to have `bash` in your system path.
Windows users can get it through MINGW