### PR TITLE
Add Jam Language package

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -80,6 +80,7 @@
 		{
 			"name": "Jam Language",
 			"details": "https://github.com/BenjaminSchaaf/jam-sublime-syntax",
+			"labels": ["jam", "language syntax", "build"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/j.json
+++ b/repository/j.json
@@ -78,6 +78,16 @@
 			]
 		},
 		{
+			"name": "Jam Language",
+			"details": "https://github.com/BenjaminSchaaf/jam-sublime-syntax",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Jamon",
 			"details": "https://github.com/drhayes/SublimeJamon",
 			"releases": [


### PR DESCRIPTION
(disclosure: I'm also the author of the language itself)

Just created a simple syntax highlighter and build system for [Jam](http://lets-jam.org)
Although the language is still in its infancy, it is nice to have syntax highlighting. So why not add it to the package manager while I'm at it?

Links (for convenience)
- The [repo](https://github.com/BenjaminSchaaf/jam-sublime-syntax)
- The current latest [tag](https://github.com/BenjaminSchaaf/jam-sublime-syntax/releases/tag/1.0.0-a)

Should I also add any labels as well? (like `language syntax`)