### PR TITLE
Added FSP Syntax package

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1177,6 +1177,17 @@
 			]
 		},
 		{
+			"name": "FSP Syntax",
+			"details": "https://github.com/toboid/sublime-fsp-syntax",
+			"labels": ["syntax", "fsp", "ltsa"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "FT Origami",
 			"details": "https://github.com/Financial-Times/FTOrigamiSublimeText",
 			"releases": [


### PR DESCRIPTION
Sublime text plugin for highlighting [FSP](http://www.doc.ic.ac.uk/~jnm/LTSdocumention/FSP-Syntax.html) syntax.
Looked for both FSP and LTSA packages on package control and can't find an existing implementation of this.