### PR TITLE
add package w/ strict tmLanguage for hosts files

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -664,6 +664,8 @@
 		{
 			"name": "Hosts",
 			"details": "https://github.com/tijn/hosts.tmLanguage",
+			"labels": ["language syntax"],
+			"previous_names": ["hosts"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/h.json
+++ b/repository/h.json
@@ -671,6 +671,16 @@
 			]
 		},
 		{
+			"name": "Hosts (scrupulous)",
+			"details": "https://github.com/tijn/hosts.tmLanguage",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "HostsEdit",
 			"details": "https://github.com/martinssipenko/SublimeHostsEdit",
 			"releases": [

--- a/repository/h.json
+++ b/repository/h.json
@@ -662,16 +662,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/rodrigoflores/hosts",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
-			"name": "Hosts (scrupulous)",
+			"name": "Hosts",
 			"details": "https://github.com/tijn/hosts.tmLanguage",
 			"releases": [
 				{


### PR DESCRIPTION
I generated some very long regular expressions with a Ruby script (included in the repository) to attain really precise syntax highlighting for hosts files.