### PR TITLE
Change "Oauth Mail" to "QuickMail"

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -13,16 +13,6 @@
 			]
 		},
 		{
-			"name": "Oauth Mail",
-			"details": "https://github.com/divinites/oauth-mail",
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "objc .strings syntax language",
 			"details": "https://github.com/PaNaVTEC/Objc-Strings-Syntax-Language",
 			"labels": ["language syntax"],

--- a/repository/q.json
+++ b/repository/q.json
@@ -168,7 +168,7 @@
 			]
 		},
 		{
-			"name": "Quick Mail",
+			"name": "QuickMail",
 			"previous_names": ["Oauth Mail"],
 			"details": "https://github.com/divinites/oauth-mail",
 			"releases": [

--- a/repository/q.json
+++ b/repository/q.json
@@ -168,6 +168,17 @@
 			]
 		},
 		{
+			"name": "Quick Mail",
+			"previous_names": ["Oauth Mail"],
+			"details": "https://github.com/divinites/oauth-mail",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "QuickOpen",
 			"details": "https://github.com/zsytssk/QuickOpen",
 			"releases": [


### PR DESCRIPTION
I made a major upgrade on the plug-in "Oauth Mail", users now can use username/password to send and receive emails. So "Oauth Mail" is no more a suitable name.