### PR TITLE
Add Syntax Highlighting for PostCSS

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3880,6 +3880,17 @@
 			]
 		},
 		{
+			"name": "Syntax Highlighting for PostCSS",
+			"details": "https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Syntax Highlighting for Sass",
 			"details": "https://github.com/P233/Syntax-highlighting-for-Sass",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Add Syntax Highlighting for [PostCSS](https://github.com/postcss/postcss).