### PR TITLE
Indentation Size Setting

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -351,6 +351,17 @@
 			]
 		},
 		{
+			"name": "Indentation Size Setting",
+			"details": "https://github.com/Kronuz/IndentSize",
+			"labels": ["indent", "tab", "size", "settings"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "IndentationNavigation",
 			"details": "https://github.com/shagabutdinov/sublime-indentation-navigation",
 			"donate": "https://github.com/shagabutdinov/sublime-enhanced/blob/master/readme-donations.md",


### PR DESCRIPTION
This plugins adds `indent_size` setting so mixed tabs/spaces (from many old codebases) can be easily used.