### PR TITLE
Added TwelfTools Package

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2222,6 +2222,16 @@
 			]
 		},
 		{
+			"name": "TwelfTools",
+			"details": "https://github.com/nfeltman/TwelfTools",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Twig",
 			"details": "https://github.com/purplefish32/sublime-text-2-twig",
 			"releases": [


### PR DESCRIPTION
Adding a new package called TwelfTools, which is intended to support the Twelf theorem prover.  

Some quick searches suggest that there is no other sublime package intended to support Twelf.