### PR TITLE
Added CodeCells

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1279,6 +1279,16 @@
 			]
 		},
 		{
+			"name": "CodeCells",
+			"details": "https://github.com/jesseengel/CodeCells",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Codechef",
 			"details": "https://github.com/prongs/SublimeCodechef",
 			"releases": [


### PR DESCRIPTION
CodeCells is a simple package I've been using for a while to facilitate copying and pasting chunks of code from a python script into a REPL like IPython. This allows you the easy of working with cells of code that you might get from an IPython Notebook, but with the workflow of having separate panels for your code and it's output. The use of cells is taken from the Spyder IDE `#%%`, which in turn took it from Matlab `%%`. It could be extended to other languages, but I thought it might be useful to others in it's current form.