### PR TITLE
Added TortoiseGit Context integration

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -1918,6 +1918,18 @@
 			]
 		},
 		{
+			"name": "TortoiseGit Context Integration",
+			"details": "https://github.com/ses4j/tgit-st3",
+			"labels": ["Git", "Tortoise", "TortoiseGit"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": "windows",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "TortoiseSVN",
 			"details": "https://github.com/dexbol/sublime-TortoiseSVN",
 			"labels": ["CVS", "SVN"],


### PR DESCRIPTION
There's a similar package (TortoiseGIT) but:

* it is 2 years stale
* It doesn't work well for me.
* It doesn't actually add context menu integration, where I feel it is most useful.
* It is a rough search-and-replace from TortoiseSVN and some odd warts persist where the SVN shows through.

This plugin works well for me, so I thought I'd publish it.