### PR TITLE
Removed RustCodeFormatter

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1484,16 +1484,6 @@
 			]
 		},
 		{
-			"name": "RustCodeFormatter",
-			"details": "https://github.com/kylepink/RustCodeFormatter",
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "RVM",
 			"details": "https://github.com/jinze/sublime-rvm",
 			"releases": [


### PR DESCRIPTION
Removing RustCodeFormatter as the project that this formatter makes use of has been deleted, therefore this plugin has become useless.