### PR TITLE
Added CloseTabsLeft

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1072,6 +1072,16 @@
 			]
 		},
 		{
+			"name": "CloseTabsLeft",
+			"details":"https://github.com/deXterbed/CloseTabsLeft",
+			"releases": [
+			{
+				"sublime_text": "<3000",
+				"tags": true
+			}
+			]
+		},
+		{
 			"name": "Cloudup",
 			"details": "https://github.com/justinshreve/SublimeCloudup",
 			"releases": [


### PR DESCRIPTION
There's no support for closing tabs on the left in ST2 as of now. TBH i never use the existing "close tabs on the right" command and I was a bit shocked to find out that there wasn't an option for the opposite, so there goes my first stab at python and sublime plugins. Would love some feedback from you guys. Thanks a lot for the docs and all the help!