### PR TITLE
LiveReload: remove plugin

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -728,16 +728,6 @@
 			]
 		},
 		{
-			"name": "LiveReload",
-			"details": "https://github.com/dz0ny/LiveReload-sublimetext2",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "LiveReloadMake",
 			"details": "https://github.com/alessandro-pezzato/LiveReloadMake-sublimetext3",
 			"releases": [


### PR DESCRIPTION
Plugin is no longer maintained nor does it work in SM3.