### PR TITLE
Fixed broken repository url for Base Encoder

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -120,7 +120,7 @@
 		},
 		{
 			"name": "Base Encoder",
-			"details": "https://github.com/euphwes/base-encoder",
+			"details": "https://github.com/socsieng/base-encoder",
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
Configuration is pointing to non existing repository