### PR TITLE
add Disk Inventory X package

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -535,6 +535,17 @@
 			]
 		},
 		{
+			"name": "Disk Inventory X",
+			"details": "https://github.com/RShergold/sublime-disk-inventory",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Display Functions (Java)",
 			"details": "https://github.com/BoundInCode/Display-Functions",
 			"releases": [


### PR DESCRIPTION
This package adds "Disk Inventory X" to the sublime side menu for directories. For the plugin to work the user must have Disk Inventory X installed at **/Applications/Disk Inventory X.app** (the default location)

If this is not installed the package throws an error on plugin_loaded()

https://github.com/RShergold/sublime-disk-inventory

[Disk Inventory X](http://www.derlien.com/)