### PR TITLE
Linking to Paradox syntax highlighting repository

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -193,6 +193,16 @@
 			]
 		},
 		{
+			"name": "Paradox",
+			"details": "https://github.com/taw/sublime-paradox",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Paraiso Black Color Scheme",
 			"details": "https://github.com/idleberg/ParaisoBlack.tmTheme",
 			"labels": ["color scheme"],


### PR DESCRIPTION
First time I'm creating a package, so not sure if I followed all steps correctly.

It's file format used by all Paradox Development Studio games (it doesn't have any official name as far as I know), for use by modders.

I've been using this simple highlight format [ https://github.com/taw/sublime-paradox/blob/master/Paradox.tmLanguage ] as User package locally for a while.

Awkwardly it doesn't have any distinguishing file extension.