### PR TITLE
add udev rules syntax highlighting package

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -31,6 +31,17 @@
 			]
 		},
 		{
+			"name": "udev rules",
+			"details": "https://github.com/tijn/udev.tmLanguage",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/dave-f/udp-trace",
 			"releases": [
 				{


### PR DESCRIPTION
Add syntax highlighting for udev rules. udev is (of course) a device manager for the Linux kernel, the successor of devfsd and hotplug.