### PR TITLE
Added DocBlockr_Python to channel.

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -693,6 +693,26 @@
 			]
 		},
 		{
+			"name": "DocBlockr_Python",
+			"details": "https://github.com/adambullmer/sublime_docblockr_python",
+			"releases": [
+				{
+					"platforms": "*",
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			],
+			"labels": [
+				"python",
+				"docstring",
+				"automatic",
+				"formatter",
+				"generator",
+				"auto-complete",
+				"snippets"
+			]
+		},
+		{
 			"name": "Docker Based Build Systems",
 			"details": "https://github.com/domeide/sublime-docker",
 			"labels": ["build system","build"],


### PR DESCRIPTION
Port of the DocBlockr project but for Python docstrings. Uses similar architecture and strategies for detecting docstrings and definitions. as the DocBlockr project, but the engine to get the definition of the class/function had to be rewritten entirely to allow for parsing python code and not C based code.