### PR TITLE
Add DiffView package

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -461,6 +461,17 @@
 			]
 		},
 		{
+			"name": "DiffView",
+			"details": "https://github.com/CJTozer/SublimeDiffView",
+			"labels": ["Git", "diff", "compare", "difference", "comparison"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Diffy",
 			"details": "https://github.com/zsong/diffy",
 			"labels": ["diff", "compare", "difference", "comparison"],


### PR DESCRIPTION
Side-by-side diff viewer for VCS comparisons.
* Currently supports Git only.
* Only tested on Sublime Text 3 (hence restricted to ST3 for now).