### PR TITLE
Added Highlight Dodgy Chars repo

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -432,6 +432,16 @@
 			]
 		},
 		{
+			"name": "Highlight Dodgy Chars",
+			"details": "https://github.com/TuureKaunisto/highlight-dodgy-chars",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Highlight Whitespaces",
 			"details": "https://github.com/disq/HighlightWhitespaces",
 			"labels": ["formatting", "language syntax", "linting"],


### PR DESCRIPTION
This is a plugin that highlights non-ascii chars making eg. spotting zero width spaces much easier.