### PR TITLE
Add PostCSS Sorting

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1353,6 +1353,16 @@
 			]
 		},
 		{
+			"name": "PostCSS Sorting",
+			"details": "https://github.com/hudochenkov/sublime-postcss-sorting",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Poster",
 			"details": "https://github.com/ssddanbrown/Poster",
 			"releases": [


### PR DESCRIPTION
[PostCSS Sorting](https://github.com/hudochenkov/sublime-postcss-sorting) plugin to sort CSS rules content with specified order.