### PR TITLE
add Typora Markdown App (OSX)

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2466,6 +2466,17 @@
 			]
 		},
 		{
+			"name": "Typora Markdown App (OSX)",
+			"details": "https://github.com/Asoul/typora-markdown-sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx"],
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "TypoScript",
 			"details": "https://bitbucket.org/danielsiepmann-team/sublime-text-typoscript",
 			"author": "Daniel Siepmann",

--- a/repository/t.json
+++ b/repository/t.json
@@ -2472,7 +2472,7 @@
 				{
 					"sublime_text": "*",
 					"platforms": ["osx"],
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
add Typora.app for markdown editor, forked from [Mou Markdown App (OSX)](https://github.com/rwoody/mou-markdown-sublime)