### PR TITLE
Send to Shell

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -832,6 +832,18 @@
 			]
 		},
 		{
+			"name": "Send to Shell",
+			"details": "https://github.com/Twizzledrizzle/Send-to-Shell",
+			"labels": ["external", "terminal", "shell", "repl"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["windows"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/wch/SendText",
 			"labels": ["terminal"],
 			"releases": [


### PR DESCRIPTION
Send to Shell is a Windows package to work nicely together with an external terminal running for example IPython.