### PR TITLE
Swift Foundation Framework Autocompletion Snippets

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3755,6 +3755,16 @@
 			]
 		},
 		{
+			"name": "Swift Foundation Autocomplete Snippets",
+			"details": "https://github.com/wbond/sublime_alignment",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Swig",
 			"details": "https://github.com/enagorny/sublime-swig",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -3755,7 +3755,7 @@
 			]
 		},
 		{
-			"name": "Swift Foundation Completion",
+			"name": "Swift Foundation Completions",
 			"details": "https://github.com/hatunike/Swift-Foundation-Sublime-Autocomplete-Package",
 			"labels": ["snippets"],
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -3755,7 +3755,7 @@
 			]
 		},
 		{
-			"name": "Swift Foundation Autocompletion",
+			"name": "Swift Foundation Completion",
 			"details": "https://github.com/hatunike/Swift-Foundation-Sublime-Autocomplete-Package",
 			"labels": ["snippets"],
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -3755,8 +3755,9 @@
 			]
 		},
 		{
-			"name": "Swift Foundation Autocomplete Snippets",
-			"details": "https://github.com/wbond/sublime_alignment",
+			"name": "Swift Foundation Autocompletion",
+			"details": "https://github.com/hatunike/Swift-Foundation-Sublime-Autocomplete-Package",
+			"labels": ["snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
A SublimeText autocomplete snippet package for the Swift Foundation framework. For use in .swift files that have access to Foundation.

Note : the snippets were generated from the open source version of Foundation. As long as the api's are synonymous with the closed Foundation api, these snippets can be used without issue.