### PR TITLE
Add ImportJS

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -248,6 +248,17 @@
 			]
 		},
 		{
+			"name": "ImportJS",
+			"details": "https://github.com/trotzig/import-js",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/jbrooksuk/ImprovedSQL",
 			"releases": [
 				{


### PR DESCRIPTION
ImportJS is a tool that helps you import javascript modules. See
https://github.com/trotzig/import-js for more details.