### PR TITLE
add google dictionary plugin

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -922,6 +922,17 @@
 			]
 		},
 		{
+			"name": "Google Dictionary",
+			"details": "https://github.com/houcheng/GoogleDictionary",
+			"labels": ["dictionary", "google", "translator"],
+			"releases": [
+				{
+					"sublime_text": ">=3080",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Google Reader",
 			"details": "https://github.com/speg/SublimeGReader",
 			"releases": [


### PR DESCRIPTION
Hi,
This is for google dictionary plugin; the new version disabled default hotkey and display the translated text via pop-up tips UI in sublime 3.
