### PR TITLE
remove space between the name of `Direct Edit`

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -508,6 +508,7 @@
 		{
 			"name": "DirectEdit",
 			"details": "https://github.com/UniFreak/SublimeDirectEdit",
+			"previous_names": ["Direct Edit"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/d.json
+++ b/repository/d.json
@@ -506,7 +506,7 @@
 			]
 		},
 		{
-			"name": "Direct Edit",
+			"name": "DirectEdit",
 			"details": "https://github.com/UniFreak/SublimeDirectEdit",
 			"releases": [
 				{


### PR DESCRIPTION
After the installation, the folder name in Data/Package will be `Direct Edit/`, and this cause my package from functional. so I removed the space between the name. hoping this will end the fold name be `DirectEdit`.