### PR TITLE
Add linux to ImportJS package platforms

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -253,7 +253,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["osx"],
+					"platforms": ["osx", "linux"],
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This plugin has been tested on a Linux Mint 64 Bit machine, and it's
working. So I'm adding yet another platform to the list. Windows might
come later down the line, but I haven't had the chance to test yet.