### PR TITLE
Add GLSL Compiler Package

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -645,7 +645,23 @@
 					"tags": true
 				}
 			]
-		},
+		}, 
+		{
+			"name": "GLSL Compiler", 
+			"details": "https://github.com/sindney/GLSLCompiler",
+			"releases": [
+				{
+					"platforms": "osx",
+					"sublime_text": "*",
+					"tags": "osx-"
+				},
+				{
+					"platforms": "windows",
+					"sublime_text": "*",
+					"tags": "win-"
+				}
+			]
+		}, 
 		{
 			"name": "GLSL Validator",
 			"details": "https://github.com/Mischa-Alff/ST-GLSL-Validator",


### PR DESCRIPTION
Adds a .glsl file build-system, build glsl code with shipped binary, and print errors if there's any.

It will search for keywords "vs", "vertex", "fs", "fragment", "ps", "pixel" to determine if it's vertex shader or not.

If no key words were found. It will pass #define VERTEX_SHADER / FRAGMENT_SHADER and compile the same shader twice.