### PR TITLE
plugin add Open URL Here

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -433,6 +433,16 @@
 			]
 		},
 		{
+			"name": "Open URL Here",
+			"details": "https://github.com/dkavraal/sublime_open_url_here",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/titoBouzout/Open-Include",
 			"releases": [
 				{


### PR DESCRIPTION
Sublime Text plugin to open URLs inside the editor. To mention, the URL is downloaded into a temporary file to be able to open. So saving the file after an edit inside Sublime Text practically does not affect the remote file.