### PR TITLE
add numpy dependency

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -200,7 +200,7 @@
 					"base": "https://github.com/komsit37/sublime-numpy",
 					"tags": true,
 					"sublime_text": ">=3000",
-					"platforms": ["windows", "osx"]
+					"platforms": ["windows-x64", "osx-x64"]
 				}
 			]
 		},

--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -190,6 +190,21 @@
 			]
 		},
 		{
+			"name": "numpy",
+			"load_order": "01",
+			"description": "Python numpy module",
+			"author": "komsit37",
+			"issues": "https://github.com/komsit37/sublime-numpy/issues",
+			"releases": [
+				{
+					"base": "https://github.com/komsit37/sublime-numpy",
+					"tags": true,
+					"sublime_text": ">=3000",
+					"platforms": ["windows", "osx"]
+				}
+			]
+		},
+		{
 			"name": "oauthlib",
 			"load_order": "50",
 			"description": "Python oauthlib module",


### PR DESCRIPTION
numpy 1.8.1 built for python 3.3 is required for my other plugin https://github.com/komsit37/sublime-q.
Original PR https://github.com/wbond/package_control_channel/pull/5156