### PR TITLE
Add ESpec syntax highlight package

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -705,6 +705,17 @@
 			]
 		},
 		{
+			"name": "ESpec syntax highlighting",
+			"details": "https://github.com/retgoat/ESpec",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Esuna Framework Snippets",
 			"details": "https://github.com/Idered/esuna-snippets",
 			"labels": ["snippets"],


### PR DESCRIPTION
ESpec is a BDD framework for Elixir.
ESpec based on awesome SublimeText/RSpec but has it's own snippets related espesially to ESpec.