### PR TITLE
Rename package ESpec syntax highlighting and add labels

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -705,8 +705,10 @@
 			]
 		},
 		{
-			"name": "ESpec syntax highlighting",
+			"name": "ESpec",
+			"previous_names": ["ESpec syntax highlighting"],
 			"details": "https://github.com/retgoat/ESpec",
+			"labels":["syntax", "snippets", "syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
Rename package, as I choose wrong name first time.
Also labels were added.