### PR TITLE
Rename ESpec syntax highlighting to just ESpec

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -705,8 +705,10 @@
 			]
 		},
 		{
-			"name": "ESpec syntax highlighting",
+			"name": "ESpec",
+			"previous_names": ["ESpec syntax highlighting"],
 			"details": "https://github.com/retgoat/ESpec",
+			"labels":["syntax", "snippets", "syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/e.json
+++ b/repository/e.json
@@ -708,7 +708,7 @@
 			"name": "ESpec",
 			"previous_names": ["ESpec syntax highlighting"],
 			"details": "https://github.com/retgoat/ESpec",
-			"labels":["syntax", "snippets", "syntax"],
+			"labels":["snippets", "build system", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
Rename ESpec syntax highlighting to just ESpec.
ESpec it's not just a syntax highlighter. 
It provides syntax highlight, contains many Espec snippets and a build system.