### PR TITLE
Add EnvironmentSettings plugin

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -604,6 +604,16 @@
 			]
 		},
 		{
+			"name": "Environment Settings",
+			"details": "https://bitbucket.org/daniele-niero/environmentsettings",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "EPL",
 			"details": "https://github.com/StefanE/sublime-epl",
 			"releases": [

--- a/repository/e.json
+++ b/repository/e.json
@@ -606,7 +606,6 @@
 		{
 			"name": "Environment Settings",
 			"details": "https://bitbucket.org/daniele-niero/environmentsettings",
-			"readme": "https://bitbucket.org/daniele-niero/environmentsettings/raw/66539d05c472fc312f9cfa77c6691aff82ef3153/README.md",
 			"labels": ["environment", "variables", "project"],
 			"releases": [
 				{


### PR DESCRIPTION
A plugin for SublimeText 3 that allows to set environment variables directly in the project  (sublime-project) file.
This variables can set as a dictionary named "env" and/or with an external batch/sh file with "evn_file".

For example:
```
{
	"folders":
	[
		{
			"path": "my/path"
		}
	],
	"settings":
	{
		"env":
		{
			"PATH": "%PATH%:~/Documents/MyTool"
		},
		"env_file": "~/Documents/myEnv.sh"
	}
}
```