### PR TITLE
Change ownership of RustAutoComplete

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1529,7 +1529,7 @@
 		},
 		{
 			"name": "RustAutoComplete",
-			"details": "https://github.com/glennw/RustAutoComplete",
+			"details": "https://github.com/defuz/RustAutoComplete",
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
Moves RustAutoComplete package to new repository.
