### PR TITLE
Change ownership of AriaTemplates Highlighter

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1099,7 +1099,7 @@
 		},
 		{
 			"name": "AriaTemplates Highlighter",
-			"details": "https://github.com/juliandescottes/sublime-ariatemplates-highlighter",
+			"details": "https://github.com/ariatemplates/sublime-ariatemplates-highlighter",
 			"labels": ["language syntax"],
 			"releases": [
 				{


### PR DESCRIPTION
AriaTemplates Highlighter was moved to https://github.com/ariatemplates/sublime-ariatemplates-highlighter