### PR TITLE
Add "AoikConsolePanelStartup"

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -774,6 +774,17 @@
 			]
 		},
 		{
+			"name": "AoikConsolePanelStartup",
+			"details": "https://github.com/AoiKuiyuyou/AoikConsolePanelStartup-SublimeText",
+			"labels": ["console"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Apache Hive",
 			"details": "https://github.com/glinmac/hive-sublime-text",
 			"labels": ["language syntax"],


### PR DESCRIPTION
# [AoikConsolePanelStartup](https://github.com/AoiKuiyuyou/AoikConsolePanelStartup-SublimeText)

A Sublime Text plugin to always show console panel at startup.

Tested working with:
- Sublime Text 2
- Sublime Text 3

![Image](https://raw.githubusercontent.com/AoiKuiyuyou/AoikConsolePanelStartup-SublimeText/9a3208128900af364f4e5c5f08b015ad050806fb/screencast.gif)