### PR TITLE
Add "Jasmine Matchers ES6 Snippets"

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -131,9 +131,9 @@
 			]
 		},
 		{
-			"name": "Jasmine Matchers Snippets",
-			"details": "https://github.com/JamieMason/Jasmine-Matchers-Snippets",
-			"labels": ["snippets", "javascript", "testing", "Jasmine"],
+			"name": "Jasmine Matchers ES6 Snippets",
+			"details": "https://github.com/JamieMason/Jasmine-Matchers-ES6-Snippets",
+			"labels": ["snippets", "javascript", "testing", "Jasmine", "es6", "es2015"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -142,9 +142,9 @@
 			]
 		},
 		{
-			"name": "Jasmine Matchers ES6 Snippets",
-			"details": "https://github.com/JamieMason/Jasmine-Matchers-ES6-Snippets",
-			"labels": ["snippets", "javascript", "testing", "Jasmine", "es6", "es2015"],
+			"name": "Jasmine Matchers Snippets",
+			"details": "https://github.com/JamieMason/Jasmine-Matchers-Snippets",
+			"labels": ["snippets", "javascript", "testing", "Jasmine"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/j.json
+++ b/repository/j.json
@@ -142,6 +142,17 @@
 			]
 		},
 		{
+			"name": "Jasmine Matchers ES6 Snippets",
+			"details": "https://github.com/JamieMason/Jasmine-Matchers-ES6-Snippets",
+			"labels": ["snippets", "javascript", "testing", "Jasmine", "es6", "es2015"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Jasmine Promise Matchers",
 			"details": "https://github.com/Hyzual/jasmine-promise-matchers-snippets",
 			"labels": ["snippets", "Jasmine", "angular", "javascript", "testing"],


### PR DESCRIPTION
This package is an ES6 variant of [Jasmine-Matchers-Snippets](https://packagecontrol.io/packages/Jasmine%20Matchers%20Snippets). 

(Background: I asked the question [Sublime Text: Different Snippet for JavaScript ES5 vs ES6?](http://stackoverflow.com/questions/35059744/sublime-text-different-snippet-for-javascript-es5-vs-es6) and, based on the answers there, have created this as an alternative package to install instead of the ES5 version).