### PR TITLE
Remove Sourcegraph plugin

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1991,17 +1991,6 @@
 			]
 		},
 		{
-			"name": "Sourcegraph",
-			"details": "https://github.com/sourcegraph/sourcegraph-sublime",
-			"donate": null,
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "SourcePawn Syntax Highlighting",
 			"details": "https://github.com/Dillonb/SublimeSourcePawn",
 			"labels": ["language syntax"],


### PR DESCRIPTION
We are removing this plugin as we significantly improve it. See 404 at https://github.com/sourcegraph/sourcegraph-sublime.