### PR TITLE
Add AVA snippets to repository

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1738,6 +1738,17 @@
 			]
 		},
 		{
+			"name": "AVA Snippets",
+			"details": "https://github.com/cameronhunter/ava-sublime-snippets",
+			"labels": ["snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "AVM2 Pcode Syntax Highlighting",
 			"details": "https://github.com/calculuswhiz/pcode-syntax-definition",
 			"releases":[


### PR DESCRIPTION
Adding a snippet package for [AVA](https://github.com/sindresorhus/ava), a futuristic JavaScript test runner. This snippet behaves in the same way as the [Visual Studio equivalent](https://twitter.com/SamVerschueren/status/700387708594753537).

![How to create a test](https://cameronhunter.github.io/ava-sublime-snippets/ava-test-snippet.gif)