### PR TITLE
Added new plugin ImsiEncoder to the Default Channel

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -268,6 +268,16 @@
 			]
 		},
 		{
+			"name": "ImsiEncoder",
+			"details": "https://bitbucket.org/luisillo/imsiencoder",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "IMSwitchForVintage",
 			"details": "https://github.com/zhongxingdou/IMSwitchForVintage-sublime",
 			"releases": [


### PR DESCRIPTION
Plugin that allows to convert IMSI (international mobile subscriber identity used in telco industry) to NAI format.