### PR TITLE
Add Confluence, Remove Markup Jira Confluence

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2226,6 +2226,18 @@
 			]
 		},
 		{
+			"name": "Confluence",
+			"details": "https://github.com/mlf4aiur/SublimeConfluence",
+			"homepage": "https://github.com/mlf4aiur/SublimeConfluence",
+			"author": "Kevin Li",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Conky.tmLanguage",
 			"details": "https://github.com/oliverseal/Conky.tmLanguage",
 			"releases": [

--- a/repository/m.json
+++ b/repository/m.json
@@ -484,16 +484,6 @@
 			]
 		},
 		{
-			"name": "Markup Jira Confluence",
-			"details": "https://github.com/mlf4aiur/sublimetext-markup-jira-confluence",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "Mask",
 			"details": "https://github.com/tenbits/sublime-mask",
 			"releases": [
@@ -1490,7 +1480,7 @@
 					"tags": true
 				}
 			]
-		},		
+		},
 		{
 			"name": "Monochrome Color Schemes",
 			"details": "https://github.com/kristopherjohnson/MonochromeSublimeText",


### PR DESCRIPTION
The plugin "Confluence" is rewrite based on Atlassian Confluence REST API, and "Markup Jira Confluence" is deprecated.