### PR TITLE
Update location of the Crystal package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2742,7 +2742,7 @@
 		},
 		{
 			"name": "Crystal",
-			"details": "https://github.com/manastech/sublime-crystal",
+			"details": "https://github.com/crystal-lang/sublime-crystal",
 			"labels": ["crystal"],
 			"releases": [
 				{


### PR DESCRIPTION
Many Crystal related repositories were moved to it's own organization in GitHub.