### PR TITLE
Change SublimeGit from custom repo to github

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -127,7 +127,6 @@
 		"https://raw.githubusercontent.com/yangsu/sublime-io/master/packages.json",
 		"https://raw.githubusercontent.com/yangsu/sublime-octopress/master/packages.json",
 		"https://raw.githubusercontent.com/zfkun/sublime-kissy-snippets/master/packages.json",
-		"https://release.sublimegit.net/packages.json",
 		"https://s3.amazonaws.com/wallaby-downloads/sublime/packages.json",
 		"https://sequoiastudios.io/sublime_packages/packages.json",
 		"https://sublimerge-bfcloud.rhcloud.com/packages.json",

--- a/repository/s.json
+++ b/repository/s.json
@@ -3159,6 +3159,16 @@
 			"labels": ["git", "gerrit", "code review"]
 		},
 		{
+			"name": "SublimeGit",
+			"details": "https://github.com/SublimeGit/SublimeGit",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/a1fred/SublimeGoogle",
 			"releases": [
 				{


### PR DESCRIPTION
SublimeGit is going open source. Going forward it will be developed on github, and released from there.

This pull request removes this SublimeGit repo, and adds it as a standard package instead.