### PR TITLE
add plugin: GoTools EX - GoTools with EXtension

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1247,6 +1247,17 @@
 			]
 		},
 		{
+			"name": "GoTools Ex",
+			"details": "https://github.com/liuhewei/gotools-sublime",
+			"labels": ["go", "golang", "gocode", "oracle", "golint", "gofmt", "goimports", "govet"],
+			"releases": [
+				{
+					"sublime_text": ">=3067",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "GoToPoint",
 			"details": "https://github.com/breck7/gotopoint",
 			"releases": [


### PR DESCRIPTION
Integrate Golang tools such as gofmt, goimports, golint, govet, oracle, gorename. Support auto-format, auto-lint, auto-completion, goto definition and other IDE-like features for Golang development.

BTW: It's a fork and extension version of [GoTools](https://github.com/ironcladlou/GoTools) which's no longer maintained.