### PR TITLE
Add TabSnippets package

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -91,6 +91,16 @@
 			]
 		},
 		{
+			"name": "TabSnippets",
+			"details": "https://github.com/oleksiyk/SublimeTabSnippets",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "TabsShortcuts",
 			"details": "https://github.com/ejoubaud/SublimeTabsShortcuts",
 			"releases": [


### PR DESCRIPTION
This simple SublimeText module will make sure TAB will insert the matching snippet (based on snippet's tab trigger) or TAB (\t) if no snippet matches. Other completions can be inserted with ENTER while autocomplete panel is visible.