### PR TITLE
Add Hungry Backspace plugin

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -1089,6 +1089,17 @@
 			]
 		},
 		{
+			"name": "Hungry Backspace",
+			"details": "https://github.com/xdrop/Hungry-Backspace",
+			"labels" : ["hungry","backspace","indentation","spacing","delete","line"],
+			"releases": [
+				{
+					"sublime_text": ">3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Hybris Impex Syntax",
 			"details": "https://github.com/Blumed/Impex_Highlighting",
 			"labels": ["syntax", "hybris", "impex"],


### PR DESCRIPTION
Adding the [Hungry Backspace](https://github.com/xdrop/Hungry-Backspace/blob/master/README.md) plugin, for maintaining indentation level on backspace presses.