### PR TITLE
Rename Test RSpec to TestRSpec package

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -419,17 +419,6 @@
 			]
 		},
 		{
-			"name": "Test RSpec",
-			"details": "https://github.com/astrauka/TestRSpec",
-			"labels": ["ruby", "testing", "rspec", "spec"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"details": "https://github.com/CraigWilliams/TestChooser",
 			"releases": [
 				{
@@ -452,6 +441,18 @@
 		{
 			"name": "testNameGenerator",
 			"details": "https://github.com/testNameGenerator/SublimeText-plugin",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "TestRSpec",
+			"details": "https://github.com/astrauka/TestRSpec",
+			"previous_names": ["Test RSpec"],
+			"labels": ["ruby", "testing", "rspec", "spec"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
Rename Test RSpec to TestRSpec package

Using `TestRSpec` package name to load theme files and want to have single worded package name