### PR TITLE
Add link to new package - BeyondCompare that allows two files to be opened in the program to compare differences

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -473,6 +473,18 @@
 			]
 		},
 		{
+			"name": "BeyondCompare",
+			"details": "https://github.com/npadley/BeyondCompare",
+			"labels": ["diff", "difference"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "BGScript",
 			"details": "https://github.com/kalanda/Sublime-BGScript-Syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION
I use BeyondCompare as my difference system of choice and wanted a quick package to allow me to feed two files into the [command line tools](http://www.scootersoftware.com/support.php?zz=kb_OSXInstallCLT)