### PR TITLE
change the name of plugin 'GoTools EX'

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -893,6 +893,18 @@
 			]
 		},
 		{
+			"name": "Golang Tools Integration",
+			"previous_names": ["GoTools Ex"],
+			"details": "https://github.com/liuhewei/gotools-sublime",
+			"labels": ["go", "golang", "gocode", "oracle", "golint", "gorename"],
+			"releases": [
+				{
+					"sublime_text": ">=3067",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Golden Dragon Color Scheme",
 			"details": "https://github.com/zaynali53/golden-dragon",
 			"labels": ["color scheme"],
@@ -1239,17 +1251,6 @@
 		{
 			"details": "https://github.com/ironcladlou/GoTools",
 			"labels": ["go", "golang", "gocode", "oracle", "godef", "gofmt"],
-			"releases": [
-				{
-					"sublime_text": ">=3067",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "GoTools Ex",
-			"details": "https://github.com/liuhewei/gotools-sublime",
-			"labels": ["go", "golang", "gocode", "oracle", "golint", "gofmt", "goimports", "govet"],
 			"releases": [
 				{
 					"sublime_text": ">=3067",


### PR DESCRIPTION
Refer to https://github.com/wbond/package_control_channel/pull/5387

Name changed to "Golang Tools Integration", and update the position.