### PR TITLE
Add Django Tags repository to d.json

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -690,6 +690,16 @@
 			]
 		},
 		{
+			"name": "Django Tags",
+			"details": "https://github.com/Jeewes/SublimeDjangoTags",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Django-DocsSearch",
 			"details": "https://github.com/saippuakauppias/sublime-text-2-Django-DocsSearch",
 			"releases": [


### PR DESCRIPTION
Django Tags provides an easy way to use few common Django template tags in files using Django or Jinja syntax.

It's a fork of great [SublimeERB](https://github.com/eddorre/SublimeERB)

**Quick preview**
![django_tags](https://cloud.githubusercontent.com/assets/1615210/14571887/62f23860-0354-11e6-94f4-83654c250cee.gif)
