### PR TITLE
added anaconda_rust to the default channel

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -529,6 +529,16 @@
 			]
 		},
 		{
+			"details": "https://github.com/DamnWidget/anaconda_rust",
+			"labels": ["linting", "language syntax", "auto-complete", "rust"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "AnB (Alice and Bob Notation)",
 			"details": "https://github.com/futek/sublime-anb",
 			"labels": ["build system", "language syntax"],


### PR DESCRIPTION
Just as the title said, I just added my new anaconda plugin for the rust language.