### PR TITLE
Add EJS 2 package

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -295,6 +295,17 @@
 			]
 		},
 		{
+			"name": "EJS 2",
+			"details": "https://github.com/nwoltman/sublime-ejs",
+			"labels": ["language syntax", "snippets", "color scheme"],
+			"releases": [
+				{
+					"sublime_text": ">=3098",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ElasticsearchClient",
 			"details": "https://github.com/KunihikoKido/sublime-elasticsearch-client",
 			"releases": [


### PR DESCRIPTION
[EJS](http://ejs.co/) is a popular templating language in the Node.js community. The author of the [current](https://github.com/samholmes/EJS.tmLanguage) EJS syntax definition for Sublime seems to have abandoned the project since it hasn't been updated in almost 2 years despite the fact that it has been [broken for at least a year and a half](https://github.com/samholmes/EJS.tmLanguage/issues/14).

This package aims to be the new de facto EJS syntax definition for Sublime.