### PR TITLE
Update repo for ImportJS package

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -272,7 +272,7 @@
 		},
 		{
 			"name": "ImportJS",
-			"details": "https://github.com/trotzig/import-js",
+			"details": "https://github.com/Galooshi/sublime-import-js",
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
We've split up the original import-js repo into separate repos for each
editor plugin. We've also moved the main import-js repo to a new
organization, "Galooshi". You'll notice the move by being automatically
redirected from https://github.com/trotzig/import-js to
https://github.com/Galooshi/import-js. The redirect should also prove
that I as the author of this commit isn't trying to hijack the plugin in
any way. :)