### PR TITLE
add EasyClangComplete

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -77,6 +77,18 @@
 			]
 		},
 		{
+			"name": "EasyClangComplete",
+			"details": "https://github.com/niosus/EasyClangComplete",
+			"labels": ["auto-complete", "linting", "language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx", "linux", "windows"],
+					"tags": "st3-"
+				}
+			]
+		},
+		{
 			"details": "https://github.com/facelessuser/EasyDiff",
 			"releases": [
 				{


### PR DESCRIPTION
adding package EasyClangComplete for clang enabled autocomplete. There is a number of packages that do approximately the same, but all of them are hard to configure or lack features. This one aims to be easy to start using and easy to hack.