### PR TITLE
Add GNU GAS listing file repository entry.

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -101,7 +101,7 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]

--- a/repository/g.json
+++ b/repository/g.json
@@ -96,6 +96,17 @@
 			]
 		},
 		{
+			"name": "GCC Assembly Listing",
+			"details": "https://github.com/abcminiuser/sublimetext-gnu-gas",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "GDL",
 			"details": "https://github.com/runxel/GDL-sublime",
 			"releases": [
@@ -1099,7 +1110,7 @@
 					"tags": true
 				}
 			]
-		},		
+		},
 		{
 			"name": "GoSnippets",
 			"details": "https://github.com/dericofilho/sublime-gosnippets",


### PR DESCRIPTION
Adds a new simple SublimeText 3 package that provides syntax highlighting for GCC GAS listing files, generated by many build systems (or manually by users).