### PR TITLE
Add gerardroche/sublime-phpunit

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1187,6 +1187,17 @@
 			]
 		},
 		{
+			"name": "phpunitkit",
+			"details": "https://github.com/gerardroche/sublime-phpunit",
+			"labels": ["php", "phpunit", "test", "testing", "unit", "unit test"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Pipe Dream",
 			"details": "https://github.com/billymoon/Sublime-Pipe-Dream",
 			"releases": [


### PR DESCRIPTION
This is similar to stuartherbert/sublime-phpunit which may at some point incorporate the features in this package, it has already added some features but it supports ST2 which means its codebase is much very complicated. It was easier to write a plugin from scratch only supporting ST3 with the features I wanted.

Originally the package name was phpunit but that conflicts with the other package so I renamed it to "php_phpunit" because honestly I didn't know what else to name it. 