### PR TITLE
Add "Theme - Alpenglow"

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -532,6 +532,17 @@
 			]
 		},
 		{
+			"name": "Theme - Alpenglow",
+			"details": "https://github.com/AlpenglowTheme/alpenglow-theme",
+			"labels": ["theme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Theme - amCoder",
 			"details": "https://github.com/auiWorks/amCoder",
 			"labels": ["theme"],


### PR DESCRIPTION
Alpenglow is the spiritual successor to the [Afterglow theme](https://github.com/YabataDesign/afterglow-theme), a minimal dark UI theme and syntax color scheme for Sublime Text 2 and 3. The theme is based on the [Spacegray](https://github.com/kkga/spacegray) theme. The syntax color scheme is mostly derived from [idlefingers](http://idlefingers.co.uk/).

We have forked it a while back (see YabataDesign/afterglow-theme#125), since there has not been any activity on the Afterglow repository for months, as evidenced by:
 - many [open PRs](https://github.com/YabataDesign/afterglow-theme/pulls) and issues
 - uncertainty about the future of the repo: e.g. YabataDesign/afterglow-theme#120
 - no public activity of @YabataDesign for about a year

Link back to our repository: https://github.com/AlpenglowTheme/alpenglow-theme/issues/3