### PR TITLE
Updated Dracula Color Scheme

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -1017,7 +1017,7 @@
 		},
 		{
 			"name": "Dracula Color Scheme",
-			"details": "https://github.com/zenorocha/dracula-theme",
+			"details": "https://github.com/dracula/sublime",
 			"labels": ["color scheme"],
 			"releases": [
 				{


### PR DESCRIPTION
`Dracula Color Scheme` has been moved to ["Dracula Theme"](https://github.com/dracula) organization, hence the update