### PR TITLE
Added React Snippets.

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -392,6 +392,17 @@
 			]
 		},
 		{
+			"name": "React Snippets",
+			"details": "https://github.com/jeantimex/react-sublime-snippet",
+			"labels": ["snippets", "jsx", "react"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "React Templates",
 			"details": "https://github.com/talpor/sublime-rt",
 			"labels": ["language syntax", "RT"],

--- a/repository/r.json
+++ b/repository/r.json
@@ -381,9 +381,9 @@
 			]
 		},
 		{
-			"name": "React ES6 Snippets",
-			"details": "https://github.com/mboperator/sublime-react-es6",
-			"labels": ["snippets", "jsx", "es6", "react"],
+			"name": "React Development Snippets",
+			"details": "https://github.com/jeantimex/react-sublime-snippet",
+			"labels": ["snippets", "jsx", "es6", "react", "test case", "redux", "action"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -392,9 +392,9 @@
 			]
 		},
 		{
-			"name": "React Development Snippets",
-			"details": "https://github.com/jeantimex/react-sublime-snippet",
-			"labels": ["snippets", "jsx", "es6", "react", "test case", "redux", "action"],
+			"name": "React ES6 Snippets",
+			"details": "https://github.com/mboperator/sublime-react-es6",
+			"labels": ["snippets", "jsx", "es6", "react"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/r.json
+++ b/repository/r.json
@@ -392,9 +392,9 @@
 			]
 		},
 		{
-			"name": "React Snippets",
+			"name": "React Development Snippets",
 			"details": "https://github.com/jeantimex/react-sublime-snippet",
-			"labels": ["snippets", "jsx", "react"],
+			"labels": ["snippets", "jsx", "es6", "react", "test case", "redux", "action"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
The package provides modern React code snippets for writing React components, lifecycle functions and test cases faster. A lot of developers are using enzyme and chai to write React test cases, the snippets provide include them by default. Also We try to keep the commands as short as possible. Tested on ST2 and ST3. Please let me know if you see any issue, thanks a lot!