### PR TITLE
Add iTimeTrack package

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -911,6 +911,17 @@
 			]
 		},
 		{
+			"name": "iTimeTrack",
+			"details": "https://github.com/itimetrack/itimetrack-sublime",
+			"labels": ["time tracking", "coding", "utilities"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "iTodo",
 			"details": "https://github.com/chagel/itodo",
 			"releases": [

--- a/repository/i.json
+++ b/repository/i.json
@@ -917,7 +917,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"tags": true
+					"tags": "itt"
 				}
 			]
 		},


### PR DESCRIPTION
Adding package iTimeTrack, which is a fork of wakatime but logs heartbeats to the itimetrack.com website and generates billable time entries.