### PR TITLE
Make ImportJS available on Windows

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -276,7 +276,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["osx", "linux"],
+					"platforms": ["osx", "linux", "windows"],
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Recent changes have made it possible to run import-js in Sublime on
windows.

https://github.com/Galooshi/import-js/pull/282
https://github.com/Galooshi/sublime-import-js/pull/9