### PR TITLE
Preparing switch to new main repository url

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -276,7 +276,7 @@
 		},
 		{
 			"name": "LaTeX Word Count",
-			"details": "https://github.com/lionandoil/SublimeLaTeXWordCount",
+			"details": "https://github.com/kevinstadler/SublimeLaTeXWordCount",
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
I'm in the process of switching several repositories over to my main account, this will be the new main url for the LaTeX word count plugin