### PR TITLE
add rx for python

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -434,6 +434,20 @@
 			]
 		},
 		{
+			"name": "rx",
+			"load_order": "01",
+			"description": "Reactive extensions for Python",
+			"author": "guillermooo",
+			"issues": "https://github.com/guillermooo/rxpyst/issues",
+			"releases": [
+				{
+					"base": "https://github.com/guillermooo/rxpyst",
+					"tags": true,
+					"sublime_text": ">=3000"
+				}
+			]
+		},
+		{
 			"name": "sassc",
 			"load_order": "50",
 			"description": "Sassc binaries",


### PR DESCRIPTION
This adds the rxpy module so that it can be depended on by plugins. All tests for the changed file passed.