### PR TITLE
Hero Plain Theme

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -306,6 +306,16 @@
 			]
 		},
 		{
+			"name": "Hero Plain",
+			"details": "https://github.com/dinosaurfiles/Hero-Plain",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Hex to HSL Color Converter",
 			"details": "https://github.com/atadams/Hex-to-HSL-Color",
 			"releases": [


### PR DESCRIPTION
Hero Plain is a simple theme forked from Hero for Sublime Text 3. It adds file type icons on the side and removes the grid borders.