### PR TITLE
Change "Neka Theme" repo url and add labels

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -127,7 +127,8 @@
 		},
 		{
 			"name": "Neka Theme",
-			"details": "https://github.com/dempfi/Neka-Theme",
+			"details": "https://github.com/dempfi/neka-sublime",
+			"labels": ["theme", "color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
Because of too common name of repo decided to rename and make clear that this one is for sublime, also wanted to add labels for to my theme so it can be easily found.