### PR TITLE
Adding TooltipLSL

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2078,6 +2078,17 @@
 			]
 		},		
 		{
+			"name": "TooltipLSL",
+			"details": "https://github.com/Makopo/sublime-text-tooltip-lsl",
+			"labels": ["tooltip", "help system"],
+			"releases": [
+				{
+					"sublime_text": ">=3070",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "TopCoder Helper",
 			"details": "https://github.com/gsingh93/sublime-topcoder-helper",
 			"releases": [


### PR DESCRIPTION
A Sublime Text tooltip reference system for LSL/OSSL, which uses Sublime 3070+ show_popup() function.
The project is [here](https://github.com/Makopo/sublime-text-tooltip-lsl). Thanks.