### PR TITLE
Add package for CNC BoschRexroth MTX language support

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1287,6 +1287,17 @@
 			]
 		},
 		{
+			"name": "CNC BoschRexroth MTX",
+			"details": "https://github.com/deathaxe/sublime-mtx",
+			"labels": ["language syntax", "snippets", "completion", "auto-complete"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CNC SINUMERIK 840D language support",
 			"details": "https://github.com/deathaxe/sublime-s840d",
 			"labels": ["language syntax", "snippets", "completion", "auto-complete"],


### PR DESCRIPTION
Please add my new package for syntax highlighting of NC programs written for the BoschRexroth MTX numerical control to the package repository right next to the package for SINUMERIK 840D.