### PR TITLE
Update EasyClangComplete

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -82,7 +82,7 @@
 			"labels": ["auto-complete", "linting", "language syntax"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3070",
 					"platforms": ["osx", "linux", "windows"],
 					"tags": "st3-"
 				}


### PR DESCRIPTION
I only account for sublime text 3, but this is not reflected in the setup. It will be from now on.

Question: can I drop the st3-prefix for tags now?