### PR TITLE
added linux-x64 support (ubuntu 16.04) for numpy and q KDB

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -244,7 +244,7 @@
 					"base": "https://github.com/komsit37/sublime-numpy",
 					"tags": true,
 					"sublime_text": ">=3000",
-					"platforms": ["windows-x64", "osx-x64"]
+					"platforms": ["windows-x64", "osx-x64", "linux-x64"]
 				}
 			]
 		},

--- a/repository/q.json
+++ b/repository/q.json
@@ -9,7 +9,7 @@
 				{
 					"sublime_text": ">=3000",
 					"tags": true,
-					"platforms": ["osx-x64", "windows-x64"]
+					"platforms": ["osx-x64", "windows-x64", "linux-x64"]
 				}
 			]
 		},


### PR DESCRIPTION
I've built `numpy` with `python3.3` on `ubuntu 16.04 LTS` so `q KDB` (`komsit37/sublime-q`) now supports Linux on x64 architectures.