### PR TITLE
Remove CanISwitchToSublimeText3 plugin

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -182,15 +182,6 @@
 			]
 		},
 		{
-			"details": "https://github.com/SublimeGit/CanISwitchToSublimeText3",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "caniuse_local",
 			"details": "https://github.com/leecade/caniuse_local",
 			"labels": ["caniuse", "offline"],


### PR DESCRIPTION
Neither the plugin, nor the server component, is being maintained. Besides, I believe the functionality isn't really relevant any longer.