### PR TITLE
add NormalizeLineLength to package control channel

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -540,6 +540,16 @@
 			]
 		},
 		{
+			"name": "NormalizeLineLength",
+			"details": "https://github.com/kylebebak/sublime_normalize_line_length",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Not that useless project report",
 			"details": "https://github.com/pererinha/NotThatUselessProjectReport",
 			"labels": ["report"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -1979,6 +1979,16 @@
 			]
 		},
 		{
+		  "name": "SortList",
+		  "details": "https://github.com/kylebebak/sublime_sort_list",
+		  "releases": [
+		    {
+		      "sublime_text": "*",
+		      "tags": true
+		    }
+		  ]
+		},
+		{
 			"details": "https://github.com/Kentzo/SortLinesByColumn",
 			"releases": [
 				{

--- a/repository/s.json
+++ b/repository/s.json
@@ -1979,21 +1979,21 @@
 			]
 		},
 		{
-		  "name": "SortList",
-		  "details": "https://github.com/kylebebak/sublime_sort_list",
-		  "releases": [
-		    {
-		      "sublime_text": "*",
-		      "tags": true
-		    }
-		  ]
-		},
-		{
 			"details": "https://github.com/Kentzo/SortLinesByColumn",
 			"releases": [
 				{
 					"sublime_text": "<3000",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "SortList",
+			"details": "https://github.com/kylebebak/sublime_sort_list",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
A plugin to normalize/limit line length for multiple lines of selected text, e.g. for comments, docstrings.

[Here's the repo](https://github.com/kylebebak/sublime_normalize_line_length). The gif gives a good idea of how it works, as do the tests!