### PR TITLE
added linux dependency xdotool

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -614,6 +614,21 @@
 			]
 		},
 		{
+			"name": "xdotool",
+			"load_order": "50",
+			"description": "Automation tool on Linux",
+			"author": "randy3k",
+			"issues": "https://github.com/randy3k/sublime-xdotool/issues",
+			"releases": [
+				{
+					"base": "https://github.com/randy3k/sublime-xdotool",
+					"platforms": ["linux"],
+					"tags": true,
+					"sublime_text": "*"
+				}
+			]
+		},
+		{
 			"name": "xmltodict",
 			"load_order": "50",
 			"description": "Makes working with XML feel like you are working with JSON - https://github.com/martinblech/xmltodict",


### PR DESCRIPTION
This provies the [xdotool](https://github.com/jordansissel/xdotool) binary to Sublime Text, so developers could use this to automate things on linux without asking users to install xdotool.