### PR TITLE
Update EasyClangComplete

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -84,7 +84,7 @@
 				{
 					"sublime_text": ">=3070",
 					"platforms": ["osx", "linux", "windows"],
-					"tags": "st3-"
+					"tags": "true"
 				}
 			]
 		},

--- a/repository/e.json
+++ b/repository/e.json
@@ -84,7 +84,7 @@
 				{
 					"sublime_text": ">=3070",
 					"platforms": ["osx", "linux", "windows"],
-					"tags": "true"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
As suggested by @wbond in #5660 allow for tags to drop `st3-` prefix.