### PR TITLE
Add the F5 iRules package

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -23,6 +23,17 @@
 			]
 		},
 		{
+			"name": "F5 iRules",
+			"details": "https://github.com/ArtiomL/sublime-f5-irules",
+			"labels": ["language syntax", "snippets", "color scheme", "auto-complete"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Fabric Engine - KL Language Support",
 			"details": "https://github.com/fabric-engine/Sublime-KL",
 			"previous_names": ["Creation Platform - KL Language Support"],


### PR DESCRIPTION
A package for [F5 iRules](https://devcentral.f5.com/articles/irules-101-01-introduction-to-irules) syntax highlighting and auto-completion.
I followed the [directions](https://packagecontrol.io/docs/submitting_a_package) and ran all the tests.
Version number 12.1.0 was chosen to correlate to the latest F5 [TMOS](https://packetpushers.net/what-the-heck-is-f5-networks-tmos/) version supported by the package.