### PR TITLE
Add Skins support package to Sublime Text

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1608,7 +1608,7 @@
 			"labels": ["themes", "utilities"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]

--- a/repository/s.json
+++ b/repository/s.json
@@ -1603,6 +1603,17 @@
 			]
 		},
 		{
+			"name": "Skins",
+			"details": "https://github.com/deathaxe/sublime-skins",
+			"labels": ["themes", "utilities"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Skript",
 			"details": "https://github.com/piratjsk/ST3_Skript",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Inspired by Theme-Switcher and QuickThemes I created a little script to change both 'color_scheme' and 'theme' with one command from command pallet.

The intention with this package is to enable theme developers to provide a *.sublime-skins file in their package, whose content is displayed in the "Select Skin" command pallet or let the user save its current settings as skin.

No need to manually edit settings files any more in order to quickly change the design of Sublime Text.