### PR TITLE
mark Statusbar Path package as compatible w/ST3

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2722,7 +2722,7 @@
 			"details": "https://github.com/unphased/SublimeStatusbarPath",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"branch": "master"
 				}
 			]


### PR DESCRIPTION
I tested this package with ST3 and found that it works correctly there, so this pull request updates its compatibility value to mark it as compatible with both ST2 and ST3.

Note: @unphased is the owner of the package. I'm just an eager user.
