### PR TITLE
add Mac Set Lang package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -23,6 +23,17 @@
 			]
 		},
 		{
+			"name": "Mac Set Lang",
+			"details": "https://github.com/oyyq99999/SublimeMacSetLang",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MacDown App Menu",
 			"details": "https://github.com/diimdeep/sublime-text-macdown-app-menu",
 			"labels": ["markdown", "preview", "editor", "macdown.app"],


### PR DESCRIPTION
set the LANG for ST running on OS X to prevent some encoding issues(e.g., unicode literals for python3).