### PR TITLE
Add More-HTML-Email-Snippets to package list

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1728,6 +1728,16 @@
 			]
 		},
 		{
+			"name": "More HTML Email Snippets",
+			"details": "https://github.com/crdelapazz/More-HTML-Email-Snippets",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "More Layouts",
 			"details": "https://github.com/unknownuser88/morelayouts",
 			"author": "David Bekoyan",


### PR DESCRIPTION
Following are this plugin's difference from `HTML Email Snippets`
- This plugin is specialized for a purpose — **coding non-responsive email with least quirks possible** — while the other one is more flexible on its use.
- Since the purpose is assumed, it has conventions (bits of codes) enforced on snippets, allowing the developers **of similar purpose** type less on their own.
- It also have more snippets like buttons and html template.

*It would be a huge help to our team and other developers of similar purpose (that's why I prefer the public channel). Thanks!*