### PR TITLE
Add Steadfast Color Scheme

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2740,6 +2740,17 @@
 			]
 		},
 		{
+			"name": "Steadfast Color Scheme",
+			"details": "https://github.com/serogers/steadfast_color_scheme",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Stencil",
 			"details": "https://github.com/kgston/stencil-syntax-sublime",
 			"labels": ["language", "syntax", "stencil"],


### PR DESCRIPTION
### Overview

This PR adds the [Steadfast Color Scheme](https://github.com/serogers/steadfast_color_scheme) to the repository list. Steadfast features pleasant colors with nice contrast without being over the top. Great for coding in dark and light environments.

Thanks!

### Example

![example2.png](https://github.com/serogers/steadfast_color_scheme/blob/master/examples/ruby/example2.png?raw=true)