### PR TITLE
Compass: Remove from channels, add to repository

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -120,7 +120,6 @@
 		"https://raw.githubusercontent.com/vkocubinsky/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/wallysalami/QuickLook/master/packages.json",
 		"https://raw.githubusercontent.com/weslly/sublime_packages/master/packages.json",
-		"https://raw.githubusercontent.com/whatwedo/sublime-text-compass/master/packages.json",
 		"https://raw.githubusercontent.com/x3ns/x3-alpha-theme/master/packages.json",
 		"https://raw.githubusercontent.com/xgenvn/InputHelper/master/packages.json",
 		"https://raw.githubusercontent.com/yangsu/sublime-io/master/packages.json",

--- a/repository/c.json
+++ b/repository/c.json
@@ -2355,6 +2355,18 @@
 			]
 		},
 		{
+			"name": "Compass",
+			"details": "https://github.com/whatwedo/sublime-text-compass",
+			"author": "whatwedo",
+			"labels": ["compass", "scss", "sass", "css", "precompiler", "build", "watch", "css3", "build system", "minification"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Competitive Programming",
 			"details": "https://github.com/egtoneyUK/CompetitiveProgramming/",
 			"author": "egtoneyUK",


### PR DESCRIPTION
Removes the Compass package from the channel.json and adds it to the repository since it is hosted on Github anyway. I guess that's how it should be.