### PR TITLE
Remove package JuliaCompletions

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -1014,16 +1014,6 @@
 			]
 		},
 		{
-			"name": "JuliaCompletions",
-			"details": "https://github.com/jakeconnor/JuliaCompletions",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Jump Along Indent",
 			"details": "https://github.com/mwean/sublime_jump_along_indent",
 			"labels": ["text navigation"],


### PR DESCRIPTION
The package JuliaCompletions is superseded by the package Julia, which now
contains unicode completions implemented in a superior way. Furthermore,
JuliaCompletions lists the package Julia as dependency, so this removal should
be completely safe for all users.