### PR TITLE
Move ASCII Replacer to tags

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1353,7 +1353,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Instead of the ASCII replacer plugin being branch based for updates, moved it to tags