### PR TITLE
add plugin for github code/issue search 

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -500,16 +500,6 @@
 			]
 		},
 		{
-			"name": "Github Code Search",
-			"details": "https://github.com/kanghj/sublime-text-github-search-plugin",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Github Color Theme",
 			"details": "https://github.com/AlexanderEkdahl/github-sublime-theme",
 			"releases": [
@@ -526,6 +516,16 @@
 				{
 					"sublime_text": "*",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "Github Issue Search",
+			"details": "https://github.com/kanghj/sublime-text-github-search-plugin",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},

--- a/repository/g.json
+++ b/repository/g.json
@@ -520,8 +520,8 @@
 			]
 		},
 		{
-			"name": "Github Issue Search",
-			"details": "https://github.com/kanghj/sublime-text-github-search-plugin",
+			"name": "GitHub Markdown Snippets",
+			"details": "https://github.com/praveenpuglia/github_markdown_snippets",
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -530,8 +530,8 @@
 			]
 		},
 		{
-			"name": "GitHub Markdown Snippets",
-			"details": "https://github.com/praveenpuglia/github_markdown_snippets",
+			"name": "Github Search",
+			"details": "https://github.com/kanghj/sublime-text-github-search-plugin",
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/g.json
+++ b/repository/g.json
@@ -500,6 +500,16 @@
 			]
 		},
 		{
+			"name": "Github Code Search",
+			"details": "https://github.com/kanghj/sublime-text-github-search-plugin",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Github Color Theme",
 			"details": "https://github.com/AlexanderEkdahl/github-sublime-theme",
 			"releases": [


### PR DESCRIPTION
A plugin so that users can perform a github code/issue search from highlighted code in Sublime Text.


For easy access https://github.com/kanghj/sublime-text-github-search-plugin