### PR TITLE
add python_PEP8_indent

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2462,6 +2462,16 @@
 			]
 		},
 		{
+			"name": "Python PEP8 Indent",
+			"details": "https://github.com/bperriot/python_PEP8_indent",
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Python Pep8 Lint",
 			"details": "https://github.com/dreadatour/Pep8Lint",
 			"labels": ["linting"],


### PR DESCRIPTION
This plugin add a as-you-type proper indentation for Python in ST2.