### PR TITLE
+ GitTodo.

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -693,6 +693,17 @@
 			]
 		},
 		{
+			"name": "GitTodo",
+			"details": "https://github.com/hipkiss91/GitTodo",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["windows"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "GitUp",
 			"details": "https://github.com/braver/SublimeGitUp",
 			"labels": ["git"],


### PR DESCRIPTION
Allows developers within SublimeText 3 to automatically publish issues to a public repo on github through the use of properly formatted TODO's.
