### PR TITLE
[vhdl] changed vhdl's versioning to be * rather than st3 only

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -248,7 +248,7 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "*",
 					"branch": "master"
 				}
 			]


### PR DESCRIPTION
The package should be compatible with st2. I just tested it again. Please let me know if otherwise.