### PR TITLE
Added "Format JSDoc @params"

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1198,6 +1198,16 @@
 			]
 		},
 		{
+			"name": "Format JSDoc @params",
+			"details": "https://bitbucket.org/finitewisdom/sublime-jsdocparam",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "FormatLua",
 			"details": "https://github.com/denglf/FormatLua",
 			"releases": [

--- a/repository/f.json
+++ b/repository/f.json
@@ -1200,6 +1200,7 @@
 		{
 			"name": "Format JSDoc @params",
 			"details": "https://bitbucket.org/finitewisdom/sublime-jsdocparam",
+			"labels": ["jsdoc", "javascript", "formatting"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
# What It Does

If the current selection represents a set of @param lines within a JSDoc block, with one @param per line, it will reformat the lines to align the parameter types, names and descriptions. For example, if the selection represents this:

```
 * @param {module:app/model/model~Model} model - The model definition
 * @param {string} mode - The mode being performed (e.g. "add", "edit")
 * @param {string} name - The name of the field (e.g. "type")
 * @param {function} callback - The Node-style callback to invoke with the result
 * @param {?module:javascript~Error} callback.err - The error object
 * @param {string} callback.s - The authorization level
```

it will reformat it into this:

```
 * @param {module:app/model/model~Model} model        - The model definition
 * @param {string}                       mode         - The mode being performed (e.g. "add", "edit")
 * @param {string}                       name         - The name of the field (e.g. "type")
 * @param {function}                     callback     - The Node-style callback to invoke with the result
 * @param {?module:javascript~Error}     callback.err - The error object
 * @param {string}                       callback.s   - The authorization level
```
