### PR TITLE
Add AGC Assembly syntax.

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -278,6 +278,17 @@
 			]
 		},
 		{
+			"name": "AGC Assembly",
+			"details": "https://github.com/jimlawton/AGC-Assembly",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Agila Theme",
 			"details": "https://github.com/arvi/Agila-Theme",
 			"labels": ["theme", "color scheme", "oceanic", "solarized"],


### PR DESCRIPTION
Syntax mode for [Apollo Guidance Computer (AGC)](http://www.ibiblio.org/apollo/) assembly-language [source](https://github.com/rburkey2005/virtualagc).

Code repository:
- https://github.com/jimlawton/AGC-Assembly

Tags page with at least one semver tag:
- https://github.com/jimlawton/AGC-Assembly/tags
