### PR TITLE
Fixed AVR-ASM-Sublime package info due to account changing

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1964,10 +1964,12 @@
 			]
 		},
 		{
-			"details": "https://github.com/voventus/AVR-ASM-Sublime",
+			"name": "AvrAssembler",
+			"details": "https://github.com/vyivanov/AVR-ASM-Sublime",
 			"labels": ["language syntax"],
 			"releases": [
 				{
+					"platforms": ["osx", "linux", "windows"],
 					"sublime_text": "*",
 					"branch": "master"
 				}


### PR DESCRIPTION
My account was changed from "voventus" to "vyivanov". I have fixed my "AVR-ASM-Sublime" package info accordingly.