### PR TITLE
DW Site Tools: Package to import/export Adobe Dreamweaver site files (.STE)

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -1260,6 +1260,16 @@
 			]
 		},
 		{
+			"name": "DW Site Tools",
+			"details": "https://github.com/Tardog/dw-site-tools",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "DXL",
 			"details": "https://github.com/Adarma/DXL",
 			"labels": ["build system", "color scheme", "language syntax", "linting"],


### PR DESCRIPTION
- Code repository: https://github.com/Tardog/dw-site-tools
- Tags page: https://github.com/Tardog/dw-site-tools/tags
