### PR TITLE
Add Angular2 HTML Syntax

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -705,6 +705,17 @@
 			]
 		},
 		{
+			"name": "Angular2 HTML Syntax",
+			"details": "https://github.com/princemaple/angular2-html-syntax",
+			"labels": ["language syntax", "angular"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "AngularInject",
 			"details": "https://github.com/ayamflow/AngularInject",
 			"releases": [


### PR DESCRIPTION
Repo: https://github.com/princemaple/angular2-html-syntax
Releases: https://github.com/princemaple/angular2-html-syntax/releases

This fixes html syntax to correctly highlight Angular2 `input`, `output`, `template`, `reference` and `interpolation` syntaxes in the html template
