### PR TITLE
Review mono file icons addons

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -983,20 +983,9 @@
 			]
 		},
 		{
-			"name": "Boxy Theme Addon - Mono File Icons - Dark UI",
-			"details": "https://github.com/oivva/st-boxy-addon-mono-file-icons-dark-ui",
-			"author": "oivva",
-			"labels": ["theme", "addon", "icons"],
-			"releases": [
-				{
-					"sublime_text": ">=3103",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "Boxy Theme Addon - Mono File Icons - Light UI",
-			"details": "https://github.com/oivva/st-boxy-addon-mono-file-icons-light-ui",
+			"name": "Boxy Theme Addon - Mono File Icons",
+			"previous_names": ["Boxy Theme Addon - Mono File Icons - Dark UI"],
+			"details": "https://github.com/oivva/st-boxy-addon-mono-file-icons",
 			"author": "oivva",
 			"labels": ["theme", "addon", "icons"],
 			"releases": [


### PR DESCRIPTION
* Rename `Boxy Theme Addon - Mono File Icons - Dark UI` to `Boxy Theme Addon - Mono File Icons`
* Remove `Boxy Theme Addon - Mono File Icons - Light UI`

Repo: https://github.com/oivva/st-boxy-addon-mono-file-icons
Tags: https://github.com/oivva/st-boxy-addon-mono-file-icons/releases

[x]  Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
[x] Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))

