### PR TITLE
Add the Compile Jasper Template package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2468,6 +2468,17 @@
 			]
 		},
 		{
+			"name": "Compile Jasper Template",
+			"details": "https://github.com/MettleUp/CompileJasperTemplate",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Compile Selected ES6",
 			"details": "https://github.com/xinchaobeta/compile-selected-es6",
 			"releases": [


### PR DESCRIPTION
This is a very simple package that runs the current JRXML file through the JasperStarter compiler.

Code repository: https://github.com/MettleUp/CompileJasperTemplate
Code tags / releases: https://github.com/MettleUp/CompileJasperTemplate/tags
