### PR TITLE
move RSL package to GitHub instead of BitBucket

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1287,11 +1287,11 @@
 		},
 		{
 			"name": "RSL",
-			"details": "https://bitbucket.org/vuhonglinh/sublimetext-rsl",
+			"details": "https://github.com/li-vu/st-rsl",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"branch": "master"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/li-vu/st-rsl
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/li-vu/st-rsl/tags

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))

