### PR TITLE
Change name and homepage of package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -96,8 +96,11 @@
 			]
 		},
 		{
-			"name": "SashaS",
+			"name": "SashaSublime",
+			"previous_names": ["SashaS"],
 			"description": "Theme and color scheme, where all elements are good visible",
+			"donate": "http://kristinita.ru/Sublime-Text/SashaSublime#donate",
+			"homepage": "http://kristinita.ru/Sublime-Text/SashaSublime",
 			"details": "https://github.com/Kristinita/SashaSublime",
 			"author": "Sasha Chernykh",
 			"labels": ["theme", "color scheme"],
@@ -1343,15 +1346,15 @@
 		},
 		{
 			"name": "SideBarEnhancements",
-			"details": "https://github.com/titoBouzout/SideBarEnhancements",		
-			"readme": "https://raw.githubusercontent.com/titoBouzout/SideBarEnhancements/st3/readme.md",		
-			"donate": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=DD4SL2AHYJGBW",		
-			"labels": ["sidebar", "folder", "directory", "file", "clipboard"],		
-			"releases": [		
-				{		
+			"details": "https://github.com/titoBouzout/SideBarEnhancements",
+			"readme": "https://raw.githubusercontent.com/titoBouzout/SideBarEnhancements/st3/readme.md",
+			"donate": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=DD4SL2AHYJGBW",
+			"labels": ["sidebar", "folder", "directory", "file", "clipboard"],
+			"releases": [
+				{
 					"sublime_text": ">=3000",
 					"tags":true
-				}		
+				}
 			]
 		},
 		{


### PR DESCRIPTION
### Changing package name

Yes, I understand, which is [not desirable to use the word `Sublime` in the name of the package](https://packagecontrol.io/docs/submitting_a_package#Step_2), but I decided to still use that word. Reasons:
1. I do not want confusion in names. Users of the package may get confused if the package is always called SashaSublime, but in Package Control Package will have a different name.
2. I wish for greater recognition to use the word `Sublime`. `Sublime` in my package is not a name package only for Sublime Text, `Sublime` — an integral part of package name. Even if my package ever be in other editors/IDE, it will be called `SashaSublime`.
### Changing homepage

I am change homepage, because GitHub it limits the possibility of design README.MD file. For example, [I can not use JavaScript on README.MD page](http://stackoverflow.com/questions/21340803/embed-javascript-in-github-readme-md).

Thanks.
