### PR TITLE
Add cert tools package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -402,6 +402,17 @@
 			]
 		},
 		{
+			"name": "Cert Tools",
+			"details": "https://github.com/Gui13/sublime-certtools",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "cexio-ticker",
 			"details": "https://github.com/iceydee/cexio-ticker",
 			"releases": [


### PR DESCRIPTION
Please provide the following information:
- Link to your code repository: https://github.com/Gui13/sublime-certtools
- Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/Gui13/sublime-certtools/tags

Also make sure you:
1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))

I did all that!

This package allows users to decrypt PEM and CRT files with a right click.
It is still very limited but will evolve with user feedback.
It requires the openssl command to be available on the system (will make the path configurable in future version) and only supports the first certificate when parsing a cert chain for the moment (this is a TODO).

But this has saved me countless minutes of opening the console to parse a PEM in many nginx configurations :)
