### PR TITLE
SwiftSyntax - syntax highlighting for Swift 3.0 in .sublime-syntax format

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -4226,6 +4226,17 @@
 			]
 		},
 		{
+			"name": "SwiftSyntax",
+			"details": "https://github.com/GregoryBL/SwiftSyntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Swig",
 			"details": "https://github.com/enagorny/sublime-swig",
 			"releases": [


### PR DESCRIPTION
Please provide the following information:
- Link to your code repository: [https://github.com/GregoryBL/SwiftSyntax](https://github.com/GregoryBL/SwiftSyntax)
- Link to the tags page with at least one [semver](http://semver.org) tag: [https://github.com/GregoryBL/SwiftSyntax/tags](https://github.com/GregoryBL/SwiftSyntax/tags)

Also make sure you:
1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
