### PR TITLE
Add Hermes extension to the sublime package manager

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -306,6 +306,16 @@
 			]
 		},
 		{
+			"name": "Hermes",
+			"details": "https://github.com/gitlinks/hermes-4-sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Hex to HSL Color Converter",
 			"details": "https://github.com/atadams/Hex-to-HSL-Color",
 			"releases": [

--- a/repository/h.json
+++ b/repository/h.json
@@ -311,7 +311,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
This is an extension to be able to use project-hermes from sublime.
http://project-hermes.io/

Code: https://github.com/gitlinks/hermes-4-sublime
tags: https://github.com/gitlinks/hermes-4-sublime/tags

Thank you !
