### PR TITLE
Vintage Solid Caret

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -321,7 +321,7 @@
 			"author": "muffinmad",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]

--- a/repository/v.json
+++ b/repository/v.json
@@ -316,6 +316,17 @@
 			]
 		},
 		{
+			"name": "Vintage Solid Caret",
+			"details": "https://github.com/muffinmad/VintageSolidCaret",
+			"author": "muffinmad",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Vintage Surround",
 			"details": "https://github.com/jcartledge/vintage-sublime-surround",
 			"releases": [


### PR DESCRIPTION
Plugin sets `caret_style` to solid in command mode and sets it back in insert mode.
- Link to code repository: https://github.com/muffinmad/VintageSolidCaret
- Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/muffinmad/VintageSolidCaret/tags
