### PR TITLE
add World of Warcraft Macro syntax to the repositories

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -637,6 +637,17 @@
 			]
 		},
 		{
+			"name": "World of Warcraft Macro Syntax",
+			"details": "https://github.com/kigiri/wow-macro-syntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "World of Warcraft TOC file Syntax",
 			"details": "https://github.com/Vandesdelca32/wowtoc-syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- code repository: https://github.com/kigiri/wow-macro-syntax/
- tags page: https://github.com/kigiri/wow-macro-syntax/tags

tests passed localy.
