### PR TITLE
Add ATG Syntax package to a.json

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1518,6 +1518,17 @@
 			]
 		},
 		{
+			"name": "ATG(CocoR C#) Syntax",
+			"details": "https://github.com/nolanar/ATG-Syntax-Sublime",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Atomic Color Scheme",
 			"details": "https://github.com/gerardbm/Sublime-Atomic-Scheme",
 			"labels": ["color scheme"],


### PR DESCRIPTION
- Link to your code repository:
  [https://github.com/nolanar/ATG-Syntax-Sublime](https://github.com/nolanar/ATG-Syntax-Sublime)
- Link to the tags page: 
  [https://github.com/nolanar/ATG-Syntax-Sublime/tags](https://github.com/nolanar/ATG-Syntax-Sublime/tags)

This package adds syntax highlighting for Coco/R #C style ATG files.
