### PR TITLE
Adds EmberToolBox to default channel

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -492,6 +492,17 @@
 			]
 		},
 		{
+			"name": "EmberToolBox",
+			"details": "https://github.com/jackson-dean/ember-tool-box",
+			"labels": ["snippets", "javascript", "emberjs", "embercli", "ember"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Emblem.js Syntax Highlighting",
 			"details": "https://github.com/johanobergman/sublime-emblem-syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Please provide the following information:
- Link to your code repository: 
      https://github.com/jackson-dean/ember-tool-box
- Link to the tags page with at least one [semver](http://semver.org) tag: 
      https://github.com/jackson-dean/ember-tool-box/tree/0.1.7

Also make sure you:
1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
