### PR TITLE
rename acabin/docphp to garveen/docphp

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -860,7 +860,7 @@
 		},
 		{
 			"name": "DocPHPManualer",
-			"details": "https://github.com/acabin/docphp",
+			"details": "https://github.com/garveen/docphp",
 			"labels":["document","php","manual"],
 			"releases": [
 				{


### PR DESCRIPTION
Just because I changed my github id from `acabin` to `garveen`

https://github.com/acabin/docphp