### PR TITLE
Add "IMESupport Korean" package

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -32,6 +32,7 @@
 		"https://raw.githubusercontent.com/damccull/sublimetext-SolarizedToggle/master/packages.json",
 		"https://raw.githubusercontent.com/danielmagnussons/orgmode/master/packages.json",
 		"https://raw.githubusercontent.com/danielobrien/sublime-DLX-syntax/master/packages.json",
+		"https://raw.githubusercontent.com/EcmaXp/IMESupport/master/packages.json",
 		"https://raw.githubusercontent.com/enriquein/JavaSetterGetter/master/packages.json",
 		"https://raw.githubusercontent.com/farcaller/DashDoc/master/packages.json",
 		"https://raw.githubusercontent.com/FichteFoll/sublime_packages/master/package_control.json",

--- a/channel.json
+++ b/channel.json
@@ -32,7 +32,7 @@
 		"https://raw.githubusercontent.com/damccull/sublimetext-SolarizedToggle/master/packages.json",
 		"https://raw.githubusercontent.com/danielmagnussons/orgmode/master/packages.json",
 		"https://raw.githubusercontent.com/danielobrien/sublime-DLX-syntax/master/packages.json",
-		"https://raw.githubusercontent.com/EcmaXp/IMESupport/master/packages.json",
+		"https://raw.githubusercontent.com/EcmaXp/IMESupport-Korean/master/packages.json",
 		"https://raw.githubusercontent.com/enriquein/JavaSetterGetter/master/packages.json",
 		"https://raw.githubusercontent.com/farcaller/DashDoc/master/packages.json",
 		"https://raw.githubusercontent.com/FichteFoll/sublime_packages/master/package_control.json",


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/EcmaXp/IMESupport-Korean
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/EcmaXp/IMESupport-Korean/tree/v0.1.1

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4)) (Done, use branch `v0.1.1`)
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7)) (Done)

IMESupport is good package but does not maintained, so i patch that package for korean.
- Add config for ignore full-screen fix
- Fix set inline position delay
- Fix wrong position where log10(lineno) == 2