### PR TITLE
Add Laroute syntax support, which is language for routing of laravel

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -215,6 +215,16 @@
 			]
 		},
 		{
+			"name": "Laroute",
+			"details": "https://github.com/Fenzland/Laroute.sublime",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Lasso",
 			"details": "https://github.com/bfad/Sublime-Lasso",
 			"releases": [


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository:
 - Link to the tags page with at least one [semver](http://semver.org) tag: 

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))

