### PR TITLE
LBNF (sublime-lbnf-syntax)

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -407,7 +407,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},

--- a/repository/l.json
+++ b/repository/l.json
@@ -401,6 +401,17 @@
 			]
 		},
 		{
+			"name": "LBNF",
+			"details": "https://github.com/Centril/sublime-lbnf-syntax",
+			"labels": ["lbnf", "bnf", "bnfc"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "LC3 Assembly",
 			"details": "https://github.com/wufufufu/Sublime-LC3",
 			"releases": [


### PR DESCRIPTION
This provides syntax highlighting for [`LBNF`](https://github.com/BNFC/bnfc/blob/master/docs/lbnf.rst).

- Link to your code repository: https://github.com/Centril/sublime-lbnf-syntax/
- Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/Centril/sublime-lbnf-syntax/releases/tag/1.0.0