### PR TITLE
Added Bootstrap 4 Autocomplete

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -874,6 +874,18 @@
 			]
 		},
 		{
+			"name": "Bootstrap 4 Autocomplete",
+			"details": "https://github.com/webchun/bootstrap-4-sublime-autocomplete",
+			"author": "Webchun",
+			"labels": ["auto-complete"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Bootstrap 4 Snippets",
 			"details": "https://github.com/mdegoo/sublime-bootstrap4",
 			"labels": ["snippets","Bootstrap","Bootstrap4"],

--- a/repository/t.json
+++ b/repository/t.json
@@ -155,6 +155,18 @@
 			]
 		},
 		{
+			"name": "Tachyons Autocomplete",
+			"details": "https://github.com/webchun/tachyons-sublime-autocomplete",
+			"author": "Webchun",
+			"labels": ["auto-complete"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "TADS3",
 			"details": "https://github.com/VoidPhantom/sublime-tads3",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Please provide the following information:

 - Link to code repository: https://github.com/webchun/bootstrap-4-sublime-autocomplete
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/webchun/bootstrap-4-sublime-autocomplete/tags

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4)) :white_check_mark: Done
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7)) :white_check_mark: Passed - Done

