### PR TITLE
fix wrong readme link

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3156,7 +3156,7 @@
 			"details": "https://github.com/cslint/sublime-cslint",
 			"labels": ["linting", "formatting", "code style"],
 			"author": "molee1905",
-			"readme": "https://github.com/cslint/sublime-cslint/blob/master/README.md",
+			"readme": "https://raw.githubusercontent.com/cslint/sublime-cslint/master/README.md",
 			"issues": "https://github.com/cslint/sublime-cslint/issues",
 			"releases": [
 				{


### PR DESCRIPTION
Please provide the following information:
- Link to your code repository: https://github.com/cslint/sublime-cslint
- Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/cslint/sublime-cslint/releases/tag/v0.1.1

Also make sure you:
1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
