### PR TITLE
add MarkdownLivePreview

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -445,6 +445,17 @@
 			]
 		},
 		{
+			"name": "MarkdownLivePreview",
+			"details": "https://github.com/math2001/MarkdownLivePreview",
+			"labels": ["markdown", "preview"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/naokazuterada/MarkdownTOC",
 			"labels": ["markdown", "toc", "table of contents"],
 			"releases": [


### PR DESCRIPTION
Hello!

Here's my repo: <https://github.com/math2001/MarkdownLivePreview>

My tags: <https://github.com/math2001/MarkdownLivePreview/tags>

This package shows the markdown you're typing in a phantom in a view (moved to a new group).

Matt

