### PR TITLE
Update Jimbly's Clipboard History for ST3

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -524,8 +524,8 @@
 			"details": "https://github.com/Jimbly/SublimeClipboardHistory",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"branch": "master"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Also switching to use tags.  I made a new tag v1.1.0, will that actually supersede the old version (v2016.12.02.02.27.26) people have installed, or is something else required to migrate from "branch" to "tags"?

code repository: https://github.com/Jimbly/SublimeClipboardHistory
tags page:  https://github.com/Jimbly/SublimeClipboardHistory/releases
