### PR TITLE
added Bitbucket plugin

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -611,6 +611,18 @@
 			]
 		},
 		{
+			"name": "Bitbucket",
+			"details": "https://github.com/dtao/SublimeBucket",
+			"labels": ["bitbucket", "git", "mercurial"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/pheuter/BitcoinTicker",
 			"releases": [
 				{


### PR DESCRIPTION
Repository for the plugin itself:

https://github.com/dtao/SublimeBucket

I searched around and the closest thing I could find was [GitLink](https://github.com/rscherf/GitLink). However, that plugin seems to have one specific purpose: linking to source files in a code hosting service (GitHub, Bitbucket, or Codebase).

The Bitbucket plugin aims to be more specific to Bitbucket and offer more features as a result. For example, the latest version allows you to run a command (`find_bitbucket_pull_request`) to go from a line of code to the Bitbucket pull request where that line was last modified. It also supports Mercurial repos, which GitLink doesn't (I mean, "Git" is right there in the name).