### PR TITLE
Add Git blame plugin

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -367,6 +367,17 @@
 			]
 		},
 		{
+			"name": "Git blame",
+			"details": "https://github.com/psykzz/st3-gitblame",
+			"labels": ["git", "blame"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Git Commit Message Syntax",
 			"details": "https://github.com/adambullmer/sublime_git_commit_syntax",
 			"labels": [

--- a/repository/g.json
+++ b/repository/g.json
@@ -372,7 +372,7 @@
 			"labels": ["git", "blame"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3124",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/psykzz/st3-gitblame
 - Link to the tags page with at least one [semver](http://semver.org) tag:  https://github.com/psykzz/st3-gitblame/tree/1.0.0

----
Example Screen
![image](https://cloud.githubusercontent.com/assets/1134201/21066704/e98f7494-be5e-11e6-856f-472032ad5aab.png)

