### PR TITLE
Adding VeeamLogsHelper to the V repository

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -176,7 +176,7 @@
 			"details": "https://github.com/yandexx/VeeamLogsHelper",
 			"releases": [
 				{
-					"sublime_text": ">=3126",
+					"sublime_text": ">=3124",
 					"tags": true
 				}
 			]

--- a/repository/v.json
+++ b/repository/v.json
@@ -172,6 +172,16 @@
 			]
 		},
 		{
+			"name": "Veeam Logs Helper",
+			"details": "https://github.com/yandexx/VeeamLogsHelper",
+			"releases": [
+				{
+					"sublime_text": ">=3126",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Ver",
 			"details": "https://github.com/nyx-platform/ver-tmbundle",
 			"releases": [


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/yandexx/VeeamLogsHelper
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/yandexx/VeeamLogsHelper/tags

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4)) -- using "tags"
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7)) -- all tests OK
