### PR TITLE
Add GraphQL Syntax

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1621,10 +1621,15 @@
 		},
 		{
 			"name": "GraphQL",
-			"details": "https://github.com/graphql-python/GraphQL-SublimeText",
+			"details": "https://github.com/dncrews/GraphQL-SublimeText3",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3092",
+					"tags": true
+				},
+				{
+					"sublime_text": "<3092",
+					"base": "https://github.com/dncrews/GraphQL-SublimeText2",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Adds GraphQL Language Syntax Highlighting

- https://github.com/dncrews/GraphQL-SublimeText
- https://github.com/dncrews/GraphQL-SublimeText/tags


## Overview

This adds GraphQL Language syntax highlighting. There was already an [existing package](https://github.com/graphql-python/GraphQL-SublimeText), but the maintainer does not seem to be responsive to the fact that it doesn't actually work.