### PR TITLE
Added ADOdb library in PHP snippets

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -216,6 +216,16 @@
 			]
 		},
 		{
+			"details": "https://github.com/madhs/ADOdb_snippets",
+			"labels": ["snippets", "php", "adodb", "database"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Advanced Aria Templates snippets pack",
 			"details": "https://github.com/dpreussner/advanced-at-snippets-pack",
 			"labels": ["snippets"],


### PR DESCRIPTION
Various snippets for the ADOdb database abstraction library

Please provide the following information:

 - Link to your code repository: https://github.com/madhs/ADOdb_snippets
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/madhs/ADOdb_snippets/tags

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
