### PR TITLE
JavaScript Ultimate now requires build >= 3103

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -371,7 +371,7 @@
 			"labels": ["language syntax", "snippets", "javascript"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3103",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
`JavaScript Ultimate` is dropping support for builds that don't support the `.sublime-syntax` format.