### PR TITLE
Add PanePane package to default channel

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -195,6 +195,16 @@
 			]
 		},
 		{
+			"name": "PanePane",
+			"details": "https://github.com/mjsmith1028/panepane",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Panezr",
 			"details": "https://github.com/jpellerin/Panezr",
 			"releases": [


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/mjsmith1028/panepane
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/mjsmith1028/panepane/tags

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
