### PR TITLE
Add Laravel 5 Docs light color scheme

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -116,6 +116,17 @@
 			]
 		},
 		{
+			"name": "Laravel 5 Docs Light Color Scheme",
+			"details": "https://github.com/yos-virtus/laravel_docs_light_color_scheme",
+			"labels": ["color scheme", "light color scheme", "laravel docs", "laravel 5"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Laravel 5 Snippets",
 			"previous_names": ["Laravel Five Snippets"],
 			"details": "https://github.com/Lykegenes/laravel-5-snippets",


### PR DESCRIPTION
Link to the code repository: https://github.com/yos-virtus/laravel_docs_light_color_scheme
Link to the tags page: https://github.com/yos-virtus/laravel_docs_light_color_scheme/releases
