### PR TITLE
moved the sublemacspro plugin repo at github and changed the name

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -441,6 +441,21 @@
 			]
 		},
 		{
+			"name": "Emacs Pro Essentials",
+			"previous_names": ["sublemacspro"],
+			"details": "https://github.com/sublime-emacs/sublemacspro",
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"branch": "st2"
+				},
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Emacs Tabstops",
 			"details": "https://github.com/KristoforMaynard/EmacsTabstops",
 			"labels": ["emacs", "formatting", "text manipulation"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -3226,19 +3226,6 @@
 			]
 		},
 		{
-			"details": "https://github.com/grundprinzip/sublemacspro",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"branch": "st2"
-				},
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"details": "https://github.com/yrammos/SubLilyPond",
 			"releases": [
 				{


### PR DESCRIPTION
Here's the information I hope!

 - Link to your code repository: https://github.com/sublime-emacs/sublemacspro
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/sublime-emacs/sublemacspro/tags

Explanation:

Sublemacspro has been around a while but we needed to allow others to have control because the original author moved on. So we created a sublime-emacs github organization for working on this emacs plugin for Sublime. The original author is a member of this organization, along with me and one other.

The original repo is gone. We asked github to transfer it to this new location. I didn't realize it would happen so fast!

I ran all the tests and fixed three errors!! ;-) so I hope everything is in order!
