### PR TITLE
Add Angular CLI for Sublime Text

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -739,8 +739,8 @@
 		},
 		{
 			"name": "Angular CLI",
-			"details": "https://github.com/4ern/angular-cli",
-			"issues": "https://github.com/4ern/angular-cli/issues",
+			"details": "https://github.com/4ern/angular-cli-for-sublime-text",
+			"issues": "https://github.com/4ern/angular-cli-for-sublime-text/issues",
 			"homepage": "http://4ern.de",
 			"author": "4ern",
 			"labels": ["angular", "cli", "angular2"],

--- a/repository/a.json
+++ b/repository/a.json
@@ -738,6 +738,20 @@
 			]
 		},
 		{
+			"name": "Angular CLI",
+			"details": "https://github.com/4ern/angular-cli",
+			"issues": "https://github.com/4ern/angular-cli/issues",
+			"homepage": "http://4ern.de",
+			"author": "4ern",
+			"labels": ["angular", "cli", "angular2"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Angular Material Snippets",
 			"details": "https://github.com/devotis/sublime-angular-material-snippets",
 			"labels": ["snippets"],


### PR DESCRIPTION

This plugin allows you to run the Angular CLI commands using the Sublime Text interface.

- Link to repositories: [Angular CLI](https://github.com/4ern/angular-cli)
- Used "tags": true: Done!
- Ran the tests: Done!
