### PR TITLE
Add FASTBuild plugin

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -191,7 +191,7 @@
 			"details": "https://github.com/Manuzor/FASTBuild-Sublime",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3103",
 					"tags": true
 				}
 			]

--- a/repository/f.json
+++ b/repository/f.json
@@ -187,6 +187,16 @@
 			]
 		},
 		{
+			"name": "FASTBuild",
+			"details": "https://github.com/Manuzor/FASTBuild-Sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/papaDoc/FastSwitch",
 			"releases": [
 				{


### PR DESCRIPTION
This is a plugin that adds basic syntax support for [FASTBuild](http://fastbuild.org) scripts to Sublime Text 3 (haven't tested it with ST2).

Code repo: https://github.com/Manuzor/FASTBuild-Sublime
Tags page: https://github.com/Manuzor/FASTBuild-Sublime/releases

