### PR TITLE
Add Slime package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1854,6 +1854,16 @@
 			]
 		},
 		{
+			"name": "Slime",
+			"details": "https://github.com/hedgesky/slime.tmbundle",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Slugify",
 			"details": "https://github.com/alimony/sublime-slugify",
 			"labels": ["text manipulation"],
@@ -2885,7 +2895,7 @@
 		{
 			"name": "Stata Improved Editor",
 			"details": "https://github.com/zizhongyan/StataImproved",
-			"labels": ["stata"], 
+			"labels": ["stata"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2893,7 +2903,7 @@
 					"tags": true
 				}
 			]
-		}, 
+		},
 		{
 			"name": "StataEditor",
 			"details": "https://github.com/mattiasnordin/StataEditor",


### PR DESCRIPTION
[Slime](https://github.com/slime-lang/slime) is a template language for Elixir. This package adds Sublime Text support for it.

Repository: https://github.com/hedgesky/slime.tmbundle
Tags page: https://github.com/hedgesky/slime.tmbundle/tags

I've used `"tags": true` and ran the tests. Also I've checked already existing packages and it looks like there is no already existing similar package.