### PR TITLE
add JSONComma

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -937,6 +937,17 @@
 			]
 		},
 		{
+			"name": "JSONComma",
+			"details": "https://github.com/math2001/JSONComma",
+			"labels": ["JSON", "comma", "text manipulation", "formatting", "formatter", "trailing"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://bitbucket.org/hmml/jsonlint",
 			"labels": ["linting", "JSON"],
 			"releases": [


### PR DESCRIPTION
Hello!

An other package (should be the last one in a while). 

- repo: https://github.com/math2001/JSONComma
- tags: https://github.com/math2001/JSONComma/tree/v0.1.2

It removes the trailing commas, and adds the needed ones. Can set a settings to do this `on_save`. It uses the scope to not remove this for example:

```json
{ "key": "tricky ,}" }
```

Support ST2 (quickly tested). Note that the `json_comma_test` command doesn't work on ST2 because of it cannot create output panel (it's just for devs, so, it's not important). Not planning on adding support.