### PR TITLE
Merge GitGutter-Edge and GitGutter

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -481,21 +481,11 @@
 		},
 		{
 			"details": "https://github.com/jisaacks/GitGutter",
-			"previous_names": ["Git Gutter"],
+			"previous_names": ["Git Gutter", "GitGutter-Edge"],
 			"releases": [
 				{
 					"sublime_text": "*",
 					"tags": true
-				}
-			]
-		},
-		{
-			"name": "GitGutter-Edge",
-			"details": "https://github.com/jisaacks/GitGutter",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
 				}
 			]
 		},


### PR DESCRIPTION
[GitGutter](https://github.com/jisaacks/GitGutter) and GitGutter-Edge are the same package with different release strategies. GitGutter-Edge is branch based, which is deprecated. We have discussed to merge them in https://github.com/jisaacks/GitGutter/pull/359.
If I understand the [Renaming a Package](https://packagecontrol.io/docs/renaming_a_package) section correctly we just need to remove the entry and add it to the `previous_names`. Please confirm that this is the case.

Ping @jisaacks
