### PR TITLE
add  hex to int plugin

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -337,10 +337,10 @@
 			]
 		},
 		{
-			"name": "Hex to Int",
+			"name": "Hex to Int Preview",
 			"details": "https://github.com/unknownuser88/hex2int",
 			"author": "David Bekoyan",
-			"labels": ["hexadecimal", "converter"],
+			"labels": ["hexadecimal"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/h.json
+++ b/repository/h.json
@@ -337,6 +337,18 @@
 			]
 		},
 		{
+			"name": "Hex to Int",
+			"details": "https://github.com/unknownuser88/hex2int",
+			"author": "David Bekoyan",
+			"labels": ["hexadecimal", "converter"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Hex to RGB Converter",
 			"details": "https://github.com/vitorleal/Hex-to-RGB",
 			"releases": [
@@ -396,18 +408,6 @@
 				{
 					"sublime_text": ">=3000",
 					"tags": "st3-"
-				}
-			]
-		},
-		{
-			"name": "Hex to Int",
-			"details": "https://github.com/unknownuser88/hex2int",
-			"author": "David Bekoyan",
-			"labels": ["hexadecimal", "converter"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
 				}
 			]
 		},

--- a/repository/h.json
+++ b/repository/h.json
@@ -400,6 +400,18 @@
 			]
 		},
 		{
+			"name": "Hex to Int",
+			"details": "https://github.com/unknownuser88/hex2int",
+			"author": "David Bekoyan",
+			"labels": ["hexadecimal", "converter"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://bitbucket.org/thejeshgn/hg4subl",
 			"releases": [
 				{


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/unknownuser88/hex2int
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/unknownuser88/hex2int/releases/tag/v1.0.0

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
