### PR TITLE
Add dependency: package_setting_context

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -364,7 +364,7 @@
 			]
 		},
 		{
-			"name": "PackageSettingContext",
+			"name": "package_setting_context",
 			"load_order": "01",
 			"description": "Allow final user to disable key bindings with very few changes needed from the dev",
 			"author": "math2001",

--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -364,6 +364,21 @@
 			]
 		},
 		{
+            "name": "PackageSettingContext",
+            "load_order": "01",
+            "description": "Allow final user to disable key bindings with very few changes needed from the dev",
+            "author": "math2001",
+            "issues": "https://github.com/math2001/PackageSettingContext/issues",
+            "releases": [
+                {
+                    "base": "https://github.com/math2001/PackageSettingContext",
+                    "sublime_text": "*",
+                    "platforms": ["*"],
+                    "tags": true
+                }
+            ]
+        },
+		{
 			"name": "paramiko",
 			"load_order": "51",
 			"description": "Python implementation of the SSHv2 protocol - http://paramiko-www.readthedocs.org/en/latest/index.html",

--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -364,20 +364,20 @@
 			]
 		},
 		{
-            "name": "PackageSettingContext",
-            "load_order": "01",
-            "description": "Allow final user to disable key bindings with very few changes needed from the dev",
-            "author": "math2001",
-            "issues": "https://github.com/math2001/PackageSettingContext/issues",
-            "releases": [
-                {
-                    "base": "https://github.com/math2001/PackageSettingContext",
-                    "sublime_text": "*",
-                    "platforms": ["*"],
-                    "tags": true
-                }
-            ]
-        },
+			"name": "PackageSettingContext",
+			"load_order": "01",
+			"description": "Allow final user to disable key bindings with very few changes needed from the dev",
+			"author": "math2001",
+			"issues": "https://github.com/math2001/PackageSettingContext/issues",
+			"releases": [
+				{
+					"base": "https://github.com/math2001/PackageSettingContext",
+					"sublime_text": "*",
+					"platforms": ["*"],
+					"tags": true
+				}
+			]
+		},
 		{
 			"name": "paramiko",
 			"load_order": "51",


### PR DESCRIPTION
This package is a *dependency*, but not a regular one: it adds a listener, instead of providing a library.

It allows you to do this:

```json
[
    {
        "keys": ["ctrl+l"],
        "command": "my_super_command",
        "context": [
            { "key": "plugin_setting.YourPackage.enabled_shortcut_my_super_command" }
        ]
    }
]
```

It looks in the *package* setting, and enable/disable the key binding depending on the value. It supports nested keys ([it can look into `dict` and `list`](https://github.com/math2001/PackageSettingContext#further-infos))

Repository: https://github.com/math2001/package_setting_context
Tags: https://github.com/math2001/package_setting_context/releases

The ChannelRepositoryTools' tests passed. 

I need this dependency in [FileManager](https://github.com/math2001/FileManager/issues/9), so if you think that's wrong, but you don't have time to look deeper, don't hesitate to let me know! 😄 