### PR TITLE
Specify that 'Unity3D Shader Highlighter and Snippets' requires build 3103 or greater

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -353,7 +353,7 @@
 			"labels": ["language syntax", "snippets"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3103",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Specify sublime version

 - Link to your code repository: https://github.com/petereichinger/Unity3D-Shader
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/petereichinger/Unity3D-Shader/releases
