### PR TITLE
Adding SmartPathCopy to build and copy commands depending on current file

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1967,7 +1967,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx"],
+					"platforms": ["osx", "linux", "windows"],
 					"tags": true
 				}
 			]

--- a/repository/s.json
+++ b/repository/s.json
@@ -1961,6 +1961,18 @@
 			]
 		},
 		{
+			"name": "Smart Path Copy",
+			"details": "https://github.com/santi-h/SmartPathCopy",
+			"labels": ["clipboard", "copy", "path"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Smart Region",
 			"details": "https://github.com/gbaptista/sublime-3-smart-region",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -1967,7 +1967,6 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx", "linux", "windows"],
 					"tags": true
 				}
 			]


### PR DESCRIPTION
 - Link to code repository: https://github.com/santi-h/SmartPathCopy
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/santi-h/SmartPathCopy/tags

From Readme:
# SmartPathCopy (Sublime Text 2/3 plugin)
When you head over to the console right after making some changes to a file, chances are that the command you will run is related to the file you were just looking at, and the type of the command will depend on the type of the file.

For example, if you're making changes to `path/to/test.rb`, chances are you're going to run a command to run the tests in `path/to/test.rb`.

Similarly, if you're writing a migration on rails like `db/migrate/20150406132142_add_authentication_token_to_users.rb`, chances are that when you head over to the console, you just want to run either `rake db:migrate` or `rake db:migrate:up VERSION=20170213214913`

### Installation
Recommended way is using [PackageControl](http://wbond.net/sublime_packages/package_control/installation) package.

### Usage
Hit `super`+`shift`+`c` to send the relevant command to the clipboard. By default it will build the following commands:
- For files ending in `_spec.rb`: `rspec <file>:<line_number>`
- For files in `db/migrate`: `rake db:migrate:up VERSION=<migration_version>`
- For files in `lib/tasks`: `rake <task_name>`


### Configuration
The default configuration is:
```python
{
  "smart_path_copy_default_rules": [
    ["_spec\\.rb$",                     "rspec $filepath:$line_number"  ],
    ["db/migrate/(\\d+)[^\\/]+\\.rb$",  "rake db:migrate:up VERSION=$1" ],
    ["lib/tasks/([^\\/]+)\\.rake$",     "rake $1"                       ]
  ]
}
```

Each element in the `"smart_path_copy_default_rules"` list consists of a regex expression and a command.
The regex expression serves as a condition: If the file you're currently on satifies the condition (regex), then the command next to it will be copied to the clipboard when you hit `super`+`shift`+`c`.

If no condition is satisfied, the whole path of the current file is copied to the clipboard.

The default configuration is useful if you're developing in rails, but you can add your own configuration in `Sublime Text` > `Preferences` > `Settings`.
If you want to override the default configuration, just add your own `"smart_path_copy_default_rules"`. If you want to keep the default configuration and add rules on top of it, use `"smart_path_copy_user_rules"`.

Notice that you can add groups in the regexes and use them (as `$<group_number>`) in the command.

You can also use in the command section:
- `$filepath`: absolute file path of the current file.
- `$line_number`: line number the cursor is on.

The default shortcut is `super`+`shift`+`c`, but you can modify it from `Sublime Text` > `Preferences` > `Key Bindings`.
For example, if you want the shortcut to be `super`+`shift`+`h`, you will add:
```python
[
  # ...
  { "keys": ["super+shift+h"], "command": "smart_path_copy"},
  # ...
]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wbond/package_control_channel/6162)
<!-- Reviewable:end -->
