### PR TITLE
LightScript Syntax Highlighting

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -745,6 +745,17 @@
 			]
 		},
 		{
+			"name": "LightScript",
+			"details": "https://github.com/lightscript/lightscript-sublime",
+			"labels": ["language syntax", "javascript", "lightscript"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Line Completion",
 			"details": "https://github.com/astropanic/Compline",
 			"releases": [


### PR DESCRIPTION
language: lightscript.org (website coming soon)

code: https://github.com/lightscript/lightscript-sublime
tags: https://github.com/lightscript/lightscript-sublime/tags

note that the package is a fork of babel-sublime