### PR TITLE
Remove platform specific releases for SCSS Compiler.

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -569,8 +569,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"tags": true,
-					"platforms": ["osx", "linux"]
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository:
https://github.com/mattarnster/scsscompiler
 - Link to the tags page with at least one [semver](http://semver.org) tag: 
https://github.com/mattarnster/scsscompiler/tags

This is an update to remove the platforms from my package - it's now supported cross-platform.
