### PR TITLE
Add WordCount package

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -557,6 +557,18 @@
 			]
 		},
 		{
+			"name": "WordCount",
+			"details": "https://github.com/philipbelesky/WordCount",
+			"homepage": "https://github.com/titoBouzout/WordCount",
+			"author": "titoBouzout",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/SublimeText/WordHighlight",
 			"releases": [
 				{


### PR DESCRIPTION
Link to code repository: https://github.com/philipbelesky/WordCount/

Links showing at least one version tag: https://github.com/philipbelesky/WordCount/tags

Tests were ran.

Note that I got in touch with the original author to see if they would add the tag necessary to be on  package control. I didn't hear back so have forked and added the tag needed. Homepage and author have been set to the original repo.