### PR TITLE
Add DOS-CGA Color Scheme

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -1029,7 +1029,7 @@
 			]
 		},
 		{
-			"name": "DOS-CGA Theme",
+			"name": "DOS-CGA Color Scheme",
 			"details": "https://github.com/fnkt/dos-cga-theme",
 			"labels": ["color scheme"],
 			"releases": [

--- a/repository/d.json
+++ b/repository/d.json
@@ -1029,6 +1029,17 @@
 			]
 		},
 		{
+			"name": "DOS-CGA Theme",
+			"details": "https://github.com/fnkt/dos-cga-theme",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Dota KV",
 			"details": "https://github.com/bhargavrpatel/dota_kv",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/fnky/dos-cga-theme
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/fnky/dos-cga-theme/releases/tag/0.1.0

Also make sure you:

 - [x] Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 - [x] Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
