### PR TITLE
updated Bitbucket package to work on all platforms

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -660,7 +660,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx", "linux"],
+					"platforms": ["*"],
 					"tags": true
 				}
 			]


### PR DESCRIPTION
It turns out that the [Bitbucket plugin](https://github.com/dtao/SublimeBucket) *almost* already supported Windows; the only changes necessary were [this](https://github.com/dtao/SublimeBucket/commit/7f27c7c998067cf061455d042a3041c5ea43c9b8) and [this](https://github.com/dtao/SublimeBucket/commit/235683b4c80415146de4beb2960ad7d0d049ddc1).