### PR TITLE
Add Simple JSX package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1550,6 +1550,17 @@
 			]
 		},
 		{
+			"name": "Simple JSX",
+			"details": "https://github.com/ccampbell/sublime-jsx",
+			"labels": ["JavaScript", "JSX", "React"],
+			"releases": [
+				{
+					"sublime_text": ">=3106",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Simple MVC Framework Snippets",
 			"details": "https://github.com/simple-mvc-framework/SMVC-Snippets",
 			"labels": ["snippets"],


### PR DESCRIPTION
This is a simple JSX package that adds JSX syntax highlighting on top of the Sublime Text built in JavaScript grammars. 

Relevant discussion in sublimehq/Packages#133

Repo: https://github.com/ccampbell/sublime-jsx
Tags: https://github.com/ccampbell/sublime-jsx/tags