### PR TITLE
Update CMakeBuilder for windows support

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1384,7 +1384,6 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["osx", "linux"],
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- Link to code repository: https://github.com/rwols/CMakeBuilder
- Link to the tags page: https://github.com/rwols/CMakeBuilder/releases

This commit updates CMakeBuilder for windows support (it removes the OSX and Linux restrictions).