### PR TITLE
Add NEURON syntax highlighting package to repository list

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -297,6 +297,16 @@
 			]
 		},
 		{
+			"name": "NEURON",
+			"details": "https://github.com/jordan-g/NEURON-for-Sublime-Text",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Neutron",
 			"details": "https://github.com/ale110/SublimeText-Neutron-Syntax",
 			"labels": ["color scheme"],


### PR DESCRIPTION
Hi,

I've written a syntax highlighting for [NEURON](https://www.neuron.yale.edu/neuron/) simulation environment files. I'd like to add it to the Package Control channel.

Repository: https://github.com/jordan-g/NEURON-for-Sublime-Text
Tags: https://github.com/jordan-g/NEURON-for-Sublime-Text/releases

Thanks!