### PR TITLE
SublimeHaskell: drop ST2 support

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3745,7 +3745,7 @@
 			"details": "https://github.com/SublimeHaskell/SublimeHaskell",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3000",
 					"branch": "master"
 				}
 			]

--- a/repository/s.json
+++ b/repository/s.json
@@ -3747,7 +3747,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},

--- a/repository/s.json
+++ b/repository/s.json
@@ -3743,6 +3743,7 @@
 		},
 		{
 			"details": "https://github.com/SublimeHaskell/SublimeHaskell",
+			"labels": ["haskell"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
Also switching to tags release strategy