### PR TITLE
Add Vale package

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -34,6 +34,17 @@
 			]
 		},
 		{
+			"name": "Vale",
+			"details": "https://github.com/ValeLint/SubVale",
+			"labels": ["linting", "prose"],
+			"releases": [
+				{
+					"sublime_text": ">=3080",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Valgrind",
 			"details": "https://github.com/oliverseal/sublime-text-valgrind",
 			"labels": ["language syntax", "valgrind", "c", "c++", "cpp"],


### PR DESCRIPTION
This is a package for linting prose according to user-defined style guides. I'm aware of SublimeLinter but, since Vale also includes features for managing styles, I thought it would be easier to release as a separate package. 

---

Repo: https://github.com/ValeLint/SubVale
Tags: https://github.com/ValeLint/SubVale/tags