### PR TITLE
Add "Show Image URL on Hover" to the channel

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1354,6 +1354,17 @@
 			]
 		},
 		{
+			"name": "Show Image URL on Hover",
+			"details": "https://github.com/rwols/ShowImageUrlOnHover",
+			"labels": ["utilities", "presentation"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Show Open Files",
 			"details": "https://github.com/grapegravity/ShowOpenFiles",
 			"labels": ["status", "file"],


### PR DESCRIPTION
 - Link to code repository: https://github.com/rwols/ShowImageUrlOnHover
 - Link to the tags page: https://github.com/rwols/ShowImageUrlOnHover/releases
