### PR TITLE
Moved repository to the new owner

### DIFF
--- a/repository/y.json
+++ b/repository/y.json
@@ -175,7 +175,7 @@
 		},
 		{
 			"name": "Yii2 Snippets",
-			"details": "https://github.com/filipyev/yii2-snippets",
+			"details": "https://github.com/psy-man/yii2-snippets",
 			"labels": ["snippets"],
 			"releases": [
 				{


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/psy-man/yii2-snippets
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/psy-man/yii2-snippets/releases/tag/v1.4.1

I have 2 github accounts, and wanna move this package from old one to my main acc.
