### PR TITLE
add another Vue.js component syntax highlight 

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2115,6 +2115,16 @@
 			]
 		},
 		{
+			"name": "Pue Syntax Highlight",
+			"details": "https://github.com/QingWei-Li/pue-syntax-highlight",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Pug",
 			"details": "https://github.com/davidrios/pug-tmbundle",
 			"labels": ["language syntax"],


### PR DESCRIPTION
This is another syntax highlight for Vue.js single-file components based on `pue-loader`:

Please provide the following information:

 - Link to your code repository: https://github.com/QingWei-Li/pue-syntax-highlight
 - Link to the tags page with at least one [semver](http://semver.org) tag:  https://github.com/QingWei-Li/pue-syntax-highlight/releases

Also make sure you:

 1. [x] Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. [x] Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
