### PR TITLE
Add package MagentoBacktraceMessageSyntaxAndOpenRestySyntax

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -77,6 +77,17 @@
 			]
 		},
 		{
+			"name": "MagentoErrorMessageSyntax",
+			"details": "https://github.com/Magebinary/MagentoErrorMessageSyntax",
+			"labels": ["Magento", "frontend", "language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "MagentoSnippets",
 			"details": "https://github.com/MageFront/MagentoSnippets",
 			"labels": ["Magento", "frontend", "snippets"],

--- a/repository/m.json
+++ b/repository/m.json
@@ -83,7 +83,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},

--- a/repository/m.json
+++ b/repository/m.json
@@ -77,8 +77,8 @@
 			]
 		},
 		{
-			"name": "MagentoErrorMessageSyntax",
-			"details": "https://github.com/Magebinary/MagentoErrorMessageSyntax",
+			"name": "MagentoBacktraceMessageSyntax",
+			"details": "https://git@github.com:Magebinary/MagentoBacktraceMessageSyntax",
 			"labels": ["Magento", "frontend", "language syntax"],
 			"releases": [
 				{

--- a/repository/m.json
+++ b/repository/m.json
@@ -78,7 +78,7 @@
 		},
 		{
 			"name": "MagentoBacktraceMessageSyntax",
-			"details": "https://git@github.com:Magebinary/MagentoBacktraceMessageSyntax",
+			"details": "https://github.com/Magebinary/MagentoBacktraceMessageSyntax",
 			"labels": ["Magento", "frontend", "language syntax"],
 			"releases": [
 				{

--- a/repository/o.json
+++ b/repository/o.json
@@ -644,17 +644,6 @@
 		},
 		{
 			"name": "OpenResty lua snippets",
-			"details": "https://github.com/Magebinary/OpenRestySyntax",
-			"labels": ["openresty lua", "nginx", "ngx"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "OpenResty Syntax",
 			"details": "https://github.com/membphis/openresty_lua_snippets",
 			"labels": ["openresty lua", "nginx", "ngx"],
 			"releases": [

--- a/repository/o.json
+++ b/repository/o.json
@@ -644,6 +644,17 @@
 		},
 		{
 			"name": "OpenResty lua snippets",
+			"details": "https://github.com/Magebinary/OpenRestySyntax",
+			"labels": ["openresty lua", "nginx", "ngx"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "OpenResty Syntax",
 			"details": "https://github.com/membphis/openresty_lua_snippets",
 			"labels": ["openresty lua", "nginx", "ngx"],
 			"releases": [


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/Magebinary/MagentoBacktraceMessageSyntax
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/Magebinary/MagentoBacktraceMessageSyntax/tags

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
