### PR TITLE
Added "Japanese Word Jump" package.

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -99,6 +99,16 @@
 			]
 		},
 		{
+			"name": "Japanese Word Jump",
+			"details": "https://github.com/ngr-t/SublimeJapaneseWordJump",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Jasmin JVM Assembler",
 			"details": "https://github.com/atmarksharp/jasmin-sublime",
 			"releases": [


### PR DESCRIPTION
Added "Japanese Word Jump" package.
This is a package which provides commands to jump words considering Japanese word segmentation.

[Link to my code repository](https://github.com/ngr-t/SublimeJapaneseWordJump)
[Link to the tags page](https://github.com/ngr-t/SublimeJapaneseWordJump/releases/tag/0.0.1)

I've made sure that:

 - [x] Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 - [x] Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))

Thanks