### PR TITLE
migrate BlitzMax plugin from bitbucket to github

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -788,7 +788,7 @@
 		},
 		{
 			"name": "BlitzMax",
-			"details": "https://bitbucket.org/muttley/sublimetext.blitzmax",
+			"details": "https://github.com/Muttley/sublimetext-blitzmax",
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository:
 - Link to the tags page with at least one [semver](http://semver.org) tag: 

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
