### PR TITLE
Remove PersistentPython

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -750,16 +750,6 @@
 			]
 		},
 		{
-			"name": "PersistentPython",
-			"details": "https://github.com/mottosso/PersistentPython",
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"details": "https://github.com/skuroda/PersistentRegexHighlight",
 			"releases": [
 				{


### PR DESCRIPTION
It doesn't work correctly and causes issues with users. Until I can have it fixed, it's better off gone.

- https://github.com/mottosso/PersistentPython
- https://github.com/mottosso/PersistentPython/tree/0.1.0