### PR TITLE
Adjust SuperSettings repository URL

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -4358,7 +4358,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/TechHawk/SuperSettings",
+			"details": "https://github.com/TobyGiacometti/SuperSettings",
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
The repository URL for SuperSettings changed and had to be adjusted. @FichteFoll, would be great if you could merge it.