### PR TITLE
Renaming "Chromium X-Refs" to "ChromiumXRefs" to make importing modules easier

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -966,7 +966,7 @@
 					"tags": true
 				}
 			]
-		},		
+		},
 		{
 			"name": "Chuby Ninja Color Scheme",
 			"details": "https://github.com/jturcotte/SublimeChubyNinja",

--- a/repository/c.json
+++ b/repository/c.json
@@ -943,7 +943,8 @@
 			]
 		},
 		{
-			"name": "Chromium X-Refs",
+			"name": "ChromiumXRefs",
+			"previous_names": ["Chromium X-Refs"],
 			"author": "Josh Karlin",
 			"description": "Shows Chromium code cross-references from cs.chromium.org",
 			"details": "https://github.com/karlinjf/ChromiumXRefs",

--- a/repository/c.json
+++ b/repository/c.json
@@ -943,6 +943,16 @@
 			]
 		},
 		{
+			"name": "ChromiumTodoView",
+			"details": "https://github.com/dougt/ChromiumTodoView-sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ChromiumXRefs",
 			"previous_names": ["Chromium X-Refs"],
 			"author": "Josh Karlin",
@@ -956,17 +966,7 @@
 					"tags": true
 				}
 			]
-		},
-		{
-			"name": "ChromiumTodoView",
-			"details": "https://github.com/dougt/ChromiumTodoView-sublime",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
+		},		
 		{
 			"name": "Chuby Ninja Color Scheme",
 			"details": "https://github.com/jturcotte/SublimeChubyNinja",


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/karlinjf/ChromiumXRefs/
 - Link to the tags page with at least one [semver](http://semver.org) tag:  https://github.com/karlinjf/ChromiumXRefs/releases

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
