### PR TITLE
Added Travis CI Statusbar plugin

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2584,6 +2584,16 @@
 			]
 		},
 		{
+			"name": "Travis CI Statusbar",
+			"details": "https://github.com/seripap/sublime-travis-ci-status",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Travis YML Lint",
 			"details": "https://github.com/sabhiram/sublime-travis-yml-lint",
 			"releases": [


### PR DESCRIPTION
Travis CI build information in status bar plugin-

 - Link to your code repository: https://github.com/seripap/sublime-travis-ci-status
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/seripap/sublime-travis-ci-status/releases
