### PR TITLE
markdown numbered headers

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -361,7 +361,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},

--- a/repository/m.json
+++ b/repository/m.json
@@ -355,6 +355,17 @@
 			]
 		},
 		{
+			"name": "Markdown Numbered Headers",
+			"details": "https://github.com/weituotian/md_numbered_headers",
+			"labels": ["markdown", "headers", "numbered headers"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Markdown Preview",
 			"details": "https://github.com/revolunet/sublimetext-markdown-preview",
 			"labels": ["markdown", "preview", "build"],


### PR DESCRIPTION

repository：[md_numbered_headers](https://github.com/weituotian/md_numbered_headers)
[tag 1.0.1](https://github.com/weituotian/md_numbered_headers/releases/tag/1.0.1)

