### PR TITLE
Added Requester plugin

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1034,6 +1034,23 @@
 			]
 		},
 		{
+			"name": "Requester",
+			"details": "https://github.com/kylebebak/Requester",
+			"labels": [
+				"http",
+				"api",
+				"rest",
+				"debug"
+			],
+			"author": "kylebebak",
+			"releases": [
+				{
+					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Require CommonJS Modules Helper",
 			"details": "https://github.com/jfromaniello/sublime-node-require",
 			"previous_names": ["Require Node.js Modules Helper"],


### PR DESCRIPTION
repo: <https://github.com/kylebebak/Requester>
tags: <https://github.com/kylebebak/Requester/tags>

Requester is an HTTP client for ST3 built on top of [Requests](http://docs.python-requests.org/en/master/). I would have named it __Requests__, but because the __requests__ package is a dependency this wasn't an option.

There are already 3 HTTP clients for ST, so why Requester?

- HTTP Requester
- RESTer
- Request

It was inspired by features in these plugins, and also by Postman. Basically, I think it's a lot more useful and easy to use. I wrote a summary of reasons why here: <https://github.com/kylebebak/Requester#recap>. Here are the main [features](https://github.com/kylebebak/Requester#features).

Note: the package overrides the <kbd>super+r</kbd> binding on OSX and the <kbd>ctrl+r</kbd> binding on Linux and Windows, __but only in response views, for replaying requests in these views__. This is done for convenience, and doesn't affect key bindings in any other contexts.

I'm aware [this raises a warning](https://github.com/packagecontrol/package_reviewer/wiki/Package-checks#resource-files) in the package_reviewer tool, I just wanted to clarify why it was done.
