### PR TITLE
Adding ThreatConnect python snippets

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -1823,6 +1823,17 @@
 			]
 		},
 		{
+			"name": "ThreatConnect Python Snippets",
+			"details": "https://github.com/fhightower/threatconnect-python-snippets",
+			"labels": ["snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ThreatConnect Share Comments",
 			"details": "https://github.com/fhightower/threatconnect-share-comment-snippets",
 			"labels": ["snippets"],


### PR DESCRIPTION
Please provide the following information:

 - Link to code repository: https://github.com/fhightower/threatconnect-python-snippets
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/fhightower/threatconnect-python-snippets/releases

