### PR TITLE
Changed LaTeXTools releases

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -341,8 +341,16 @@
 			"details": "https://github.com/SublimeText/LaTeXTools",
 			"releases": [
 				{
-					"sublime_text": "*",
-					"tags": true
+					"sublime_text": "<3000",
+					"tags": "st2-"
+				},
+				{
+					"sublime_text": "<3125",
+					"tags": "st3until3125-"
+				},
+				{
+					"sublime_text": ">=3125",
+					"tags": "st3-"
 				}
 			]
 		},

--- a/repository/l.json
+++ b/repository/l.json
@@ -345,7 +345,7 @@
 					"tags": "st2-"
 				},
 				{
-					"sublime_text": "<3125",
+					"sublime_text": "3000 - 3124",
 					"tags": "st3until3125-"
 				},
 				{


### PR DESCRIPTION
This changes the releases for LaTeXTools to use tags for different Sublime Text versions, because we want to add backward incompatible changes in future releases (Assume python 3 and use popups+phantoms w/o version checks), but people with other versions should still be able the current state w/o having problems. We have discussed this is https://github.com/SublimeText/LaTeXTools/issues/1086 .

I have created the corresponding tags for the latest minor release, so it should not be problematic to switch them.

ping @ig0774 @msiniscalchi 

Please provide the following information:

 - Link to your code repository:
https://github.com/SublimeText/LaTeXTools
 - Link to the tags page with at least one [semver](http://semver.org) tag: 
https://github.com/SublimeText/LaTeXTools/tags

Also make sure you:

 1. [x] Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. [x] Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
