### PR TITLE
Add Minecraft function file syntax definition

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -886,7 +886,7 @@
 			"labels": ["language syntax", "minecraft"],
 			"releases": [
 				{
-					"sublime_text": ">=3088",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]

--- a/repository/m.json
+++ b/repository/m.json
@@ -883,7 +883,7 @@
 		{
 			"name": "MCFunction",
 			"details": "https://github.com/AjaxGb/Sublime-MCFunction",
-			"labels": ["language syntax"],
+			"labels": ["language syntax", "minecraft"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/m.json
+++ b/repository/m.json
@@ -881,6 +881,17 @@
 			]
 		},
 		{
+			"name": "MCFunction",
+			"details": "https://github.com/AjaxGb/Sublime-MCFunction",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MDL Language",
 			"details": "https://github.com/ardenpm/sublime-mdl-language",
 			"labels" : ["language syntax"],

--- a/repository/m.json
+++ b/repository/m.json
@@ -886,7 +886,7 @@
 			"labels": ["language syntax", "minecraft"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3088",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
I'm submitting my language syntax definition for the new `.mcfunction` file format introduced in the 1.12 prereleases of Minecraft. Information on the format can be found [on the Minecraft wiki](http://minecraft.gamepedia.com/Function).

Repo: https://github.com/AjaxGb/Sublime-MCFunction
Tags: https://github.com/AjaxGb/Sublime-MCFunction/tags
