### PR TITLE
Update `CJSX Syntax` to drop support for ST2

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1083,7 +1083,7 @@
 			"labels": ["CJSX", "syntax"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3103",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
## What
Update the "CJSX Syntax" record in `c.json` to formally drop support for Sublime Text 2.

## Why
Recent changes to the project have forced us to drop support for ST2 in order to take advantage of more up to date tools + syntax introduced in ST3.

## References

* **Repo:** https://github.com/Guidebook/sublime-cjsx/
* **Related Release:** https://github.com/Guidebook/sublime-cjsx/releases/tag/v2.0.0
