### PR TITLE
Added the Notepad++ Color Scheme to repository/n.json

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -671,6 +671,17 @@
 			]
 		},
 		{
+			"name": "Notepad++ Theme",
+			"details": "https://github.com/evandrocoan/SublimeNotepadPlusPlusTheme",
+			"labels": ["theme", "notepad++"],
+			"releases": [
+				{
+					"sublime_text": ">=3114",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Nova Template Highlighter",
 			"details": "https://github.com/nova-framework/template-highlighter-sublime-text",
 			"labels": ["nova", "syntax highlighter"],

--- a/repository/n.json
+++ b/repository/n.json
@@ -638,6 +638,17 @@
 			]
 		},
 		{
+			"name": "Notepad++ Theme",
+			"details": "https://github.com/evandrocoan/SublimeNotepadPlusPlusTheme",
+			"labels": ["theme", "notepad++"],
+			"releases": [
+				{
+					"sublime_text": ">=3114",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Notes",
 			"details": "https://github.com/tbh1/sublime-notes",
 			"labels": ["language syntax", "documentation", "notes"],
@@ -666,17 +677,6 @@
 				{
 					"sublime_text": ">=3000",
 					"platforms": ["osx"],
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "Notepad++ Theme",
-			"details": "https://github.com/evandrocoan/SublimeNotepadPlusPlusTheme",
-			"labels": ["theme", "notepad++"],
-			"releases": [
-				{
-					"sublime_text": ">=3114",
 					"tags": true
 				}
 			]

--- a/repository/n.json
+++ b/repository/n.json
@@ -638,9 +638,9 @@
 			]
 		},
 		{
-			"name": "Notepad++ Theme",
+			"name": "Notepad++ Color Scheme",
 			"details": "https://github.com/evandrocoan/SublimeNotepadPlusPlusTheme",
-			"labels": ["theme", "notepad++"],
+			"labels": ["color scheme", "notepad++"],
 			"releases": [
 				{
 					"sublime_text": ">=3114",


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/evandrocoan/SublimeNotepadPlusPlusTheme
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/evandrocoan/SublimeNotepadPlusPlusTheme/releases

Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
```
Running Default Channel Tests

  ............................
  ----------------------------------------------------------------------
  Ran 7634 tests in 2.292s
  
  OK
```