### PR TITLE
Add pymdownx, remove Aprosopo theme, and modify mdpopups

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -259,7 +259,7 @@
 				{
 					"base": "https://github.com/facelessuser/sublime-markdown-popups",
 					"tags": true,
-					"sublime_text": ">=3080"
+					"sublime_text": ">=3214"
 				}
 			]
 		},
@@ -448,6 +448,20 @@
 					"base": "https://github.com/packagecontrol/pygments",
 					"tags": true,
 					"sublime_text": "*"
+				}
+			]
+		},
+		{
+			"name": "pymdownx",
+			"author": "facelessuser",
+			"load_order": "50",
+			"description": "PyMdown Extensions for Python Markdown",
+			"issues": "https://github.com/facelessuser/sublime-pymdownx/issues",
+			"releases": [
+				{
+					"base": "https://github.com/facelessuser/sublime-pymdownx",
+					"tags": true,
+					"sublime_text": ">=3000"
 				}
 			]
 		},

--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -259,7 +259,7 @@
 				{
 					"base": "https://github.com/facelessuser/sublime-markdown-popups",
 					"tags": true,
-					"sublime_text": ">=3214"
+					"sublime_text": ">=3124"
 				}
 			]
 		},

--- a/repository/t.json
+++ b/repository/t.json
@@ -649,21 +649,6 @@
 			]
 		},
 		{
-			"name": "Theme - Aprosopo",
-			"details": "https://github.com/facelessuser/Aprosopo",
-			"labels": ["theme"],
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"tags": "st2-"
-				},
-				{
-					"sublime_text": ">=3000",
-					"tags": "st3-"
-				}
-			]
-		},
-		{
 			"name": "Theme - Aqua",
 			"details": "https://github.com/cafarm/aqua-theme",
 			"labels": ["theme"],


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/facelessuser/sublime-pymdownx
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/facelessuser/sublime-pymdownx/tags

---

- Lock mdpopups to ST 3124+.
- Remove Theme - Aprosopo
- Add [pymdown-extensions](https://github.com/facelessuser/pymdown-extensions) dependency as pymdownx.

