### PR TITLE
Added jsonschema Python package to dependencies.json

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -221,6 +221,20 @@
 			]
 		},
 		{
+			"name": "jsonschema",
+			"load_order": "55",
+			"description": "An(other) implementation of JSON Schema for Python",
+			"author": "kylebebak",
+			"issues": "https://github.com/kylebebak/sublime-jsonschema/issues",
+			"releases": [
+				{
+					"base": "https://github.com/kylebebak/sublime-jsonschema",
+					"tags": true,
+					"sublime_text": ">=3000"
+				}
+			]
+		},
+		{
 			"name": "lxml",
 			"load_order": "10",
 			"description": "lxml",


### PR DESCRIPTION
From this package: <https://github.com/Julian/jsonschema>

Please provide the following information:

 - <https://github.com/kylebebak/sublime-jsonschema>
 - <https://github.com/kylebebak/sublime-jsonschema/releases>


This is the first time I've tried adding a dependency. I think everything is ready. I didn't know what to make of the `load_order` property dependencies, so I used 55, which at this time is equal to the largest value of `load_order`.