### PR TITLE
Adding language syntax label to HLSL Syntax project

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -657,6 +657,7 @@
 		{
 			"name": "HLSL Syntax",
 			"details": "https://github.com/MattSutherlin/HLSL_ST3",
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",


### PR DESCRIPTION
Forgot to do this in the initial commit/pull request.