### PR TITLE
Add MissingFindPanelKeys

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1421,6 +1421,17 @@
 			]
 		},
 		{
+			"name": "MissingFindPanelKeys",
+			"details": "https://github.com/mattst/SublimeMissingFindPanelKeys",
+			"labels": ["search"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MIST",
 			"details": "https://github.com/Vizzle/SublimePluginForMIST",
 			"releases": [


### PR DESCRIPTION
Please provide the following information:

- Link to your code repository: https://github.com/mattst/SublimeMissingFindPanelKeys
- Link to the tags page: https://github.com/mattst/SublimeMissingFindPanelKeys/tags

Also make sure you:

1. Used `"tags": true` ... DONE
2. Ran the tests ... DONE

Thanks.
