### PR TITLE
Add AoE2 RMS Syntax Highlighting

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1076,6 +1076,16 @@
 			]
 		},
 		{
+			"name": "AoE2 RMS Syntax Highlighting",
+			"details": "https://github.com/mangudai/syntax-highlighting",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "AoikConsolePanelStartup",
 			"details": "https://github.com/AoiKuiyuyou/AoikConsolePanelStartup-SublimeText",
 			"labels": ["console"],


### PR DESCRIPTION
- Repo: https://github.com/mangudai/syntax-highlighting
- Tags: https://github.com/mangudai/syntax-highlighting/tags

---

- [x] Checked that there're no similar packages
- [x] Used `"tags": true` and not `"branch": "master"`
- [x] Ran the tests: `Ran 7787 tests in 0.298s OK`

---

There's a bunch of other files in the repo (trying to publish for VS Code too), I hope that's fine.