### PR TITLE
Add GitHub Color Scheme

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -512,6 +512,17 @@
 			]
 		},
 		{
+			"name": "GitHub Color Scheme",
+			"details": "https://github.com/nicobeta/GitHub-Color-Scheme",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Github Color Theme",
 			"details": "https://github.com/AlexanderEkdahl/github-sublime-theme",
 			"releases": [


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/nicobeta/GitHub-Color-Scheme
 - Link to the tags page with at least one [semver](http://semver.org) tag:  https://github.com/nicobeta/GitHub-Color-Scheme/releases