### PR TITLE
repository: add UbuntuPaste for sublime-text-3

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -26,7 +26,7 @@
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"tags": "2."
+					"tags": "st2-"
 				},
 				{
 					"sublime_text": ">=3000",

--- a/repository/u.json
+++ b/repository/u.json
@@ -22,17 +22,12 @@
 			]
 		},
 		{
-			"details": "https://github.com/frankban/UbuntuPaste",
+			"details": "https://github.com/3v1n0/UbuntuPaste",
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"branch": "master"
-				}
-			]
-		},
-		{
-			"details": "https://github.com/3v1n0/UbuntuPaste",
-			"releases": [
+					"tags": "2."
+				},
 				{
 					"sublime_text": ">=3000",
 					"tags": true

--- a/repository/u.json
+++ b/repository/u.json
@@ -31,6 +31,15 @@
 			]
 		},
 		{
+			"details": "https://github.com/3v1n0/UbuntuPaste",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "udev rules",
 			"details": "https://github.com/tijn/udev.tmLanguage",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/3v1n0/UbuntuPaste
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/3v1n0/UbuntuPaste/tree/3.1.1

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4)): yes
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7)): done

```
Ran 7630 tests in 0.282s
  
  OK
```

This is a fork of a package that is already available for Sublime-2 (https://github.com/frankban/UbuntuPaste/), I've made a [PR against it](https://github.com/frankban/UbuntuPaste/pull/1) (long time ago) and asked the author to review it multiple times, but he has no time for it. So, I guess we can safely use this version for sublime-3 while keeping the other for sublime-2.