### PR TITLE
Hacknet Snippet Tools is a package that I made to help in the development of Hacknet Extensions (Mods for the game Hacknet). It helps by providing a set of snippets users can generate and then tab through to fill them out.

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -67,6 +67,17 @@
 			]
 		},
 		{
+			"name": "Hacknet Snippet Tools",
+			"details": "https://github.com/CNIAngel/Hacknet-Snippet-Tools",
+			"labels": ["language syntax", "xml", "auto-complete", "hacknet", "hacknet extensions"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "HACS Syntax",
 			"details": "https://github.com/tbpalsulich/hacs_sublime_text_theme",
 			"labels": ["language syntax", "linting", "auto-complete", "language", "hacs", "compiler"],

--- a/repository/h.json
+++ b/repository/h.json
@@ -69,7 +69,7 @@
 		{
 			"name": "Hacknet Snippet Tools",
 			"details": "https://github.com/CNIAngel/Hacknet-Snippet-Tools",
-			"labels": ["language syntax", "xml", "auto-complete", "hacknet", "hacknet extensions"],
+			"labels": ["auto-complete", "hacknet", "hacknet extensions"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
Summary says it all. I popped in the needed information and ran the
tests and it's all A-OK.

Link to Repo: https://github.com/CNIAngel/Hacknet-Snippet-Tools

Please provide the following information:

 - Link to your code repository:
 - Link to the tags page with at least one [semver](http://semver.org) tag: 

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
