### PR TITLE
Add "FoldFunctions" package

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1174,6 +1174,16 @@
 			]
 		},
 		{
+			"name": "Fold Functions",
+			"details": "https://github.com/math2001/FoldFunctions",
+			"releases": [
+				{
+					"sublime_text": ">=3126",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Fold Javascript Functions",
 			"details": "https://github.com/LuckyKat/sublime-fold-functions",
 			"releases": [


### PR DESCRIPTION
- Repo: https://github.com/math2001/FoldFunctions
- Tags: https://github.com/math2001/FoldFunctions/releases
- [x] used the tag
- [x] ran the tests

A simple package to fold functions in different languages. For now, only Python and JavaScript are supported.

Note: this package uses the `view.indentation_level` method, which is (still) not documented. Should I create a kind of polyfill for this, or it's likely to stay?

![](https://github.com/math2001/FoldFunctions/raw/master/fold-functions.gif)