### PR TITLE
Add package that lets you run Elixir's `mix test`  

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -460,6 +460,16 @@
 			]
 		},
 		{
+			"name": "ElixirTest",
+			"details": "https://github.com/tarzan/sublime-text-elixir-tests",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Elm Language Support",
 			"details": "https://github.com/elm-community/Elm.tmLanguage",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository:
    https://github.com/tarzan/sublime-text-elixir-tests

 - Link to the tags page with at least one [semver](http://semver.org) tag: 
    https://github.com/tarzan/sublime-text-elixir-tests/tags

Also make sure you:

 1. Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
👍 
 2. Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
👍 