### PR TITLE
Adding gislack package

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -358,6 +358,16 @@
 			]
 		},
 		{
+			"name": "gislacks",
+			"details": "https://github.com/tanaikech/gislacks",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/condemil/Gist",
 			"releases": [
 				{


### PR DESCRIPTION
This is a plugin of Sublime Text 3 for submitting files to both Gist and Slack.

Repository: https://github.com/tanaikech/gislacks
Tags: https://github.com/tanaikech/gislacks/tags

I used the tag
I ran the tests
