### PR TITLE
Remove the space in "Fold Functions"

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1174,16 +1174,6 @@
 			]
 		},
 		{
-			"name": "FoldFunctions",
-			"details": "https://github.com/math2001/FoldFunctions",
-			"releases": [
-				{
-					"sublime_text": ">=3126",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Fold Javascript Functions",
 			"details": "https://github.com/LuckyKat/sublime-fold-functions",
 			"releases": [
@@ -1262,6 +1252,16 @@
 				{
 					"sublime_text": "*",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "FoldFunctions",
+			"details": "https://github.com/math2001/FoldFunctions",
+			"releases": [
+				{
+					"sublime_text": ">=3126",
+					"tags": true
 				}
 			]
 		},

--- a/repository/f.json
+++ b/repository/f.json
@@ -1174,7 +1174,7 @@
 			]
 		},
 		{
-			"name": "Fold Functions",
+			"name": "FoldFunctions",
 			"details": "https://github.com/math2001/FoldFunctions",
 			"releases": [
 				{


### PR DESCRIPTION
I'm sorry, I just realized I put a space in the name, which I don't want because I want the package name to be the same of the GitHub repository one.

Sorry again...