### PR TITLE
Adding Alphanumeric Markdown Footnote

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -499,6 +499,16 @@
 			]
 		},
 		{
+			"name": "Alphanumeric Markdown Footnote",
+			"details": "https://github.com/TehShrike/Sublime-AlphanumericMarkdownFootnote",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Alphpetize",
 			"details": "https://github.com/foxxyz/sublime_alphpetize",
 			"releases": [


### PR DESCRIPTION
Please provide the following information:

 - Link to your code repository: https://github.com/TehShrike/Sublime-AlphanumericMarkdownFootnote
 - Link to the tags page with at least one [semver](http://semver.org) tag: https://github.com/TehShrike/Sublime-AlphanumericMarkdownFootnote/tags

Also make sure you:

 1. [x] Used `"tags": true` and not `"branch": "master"` ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. [x] Ran the tests ([tests docs](https://packagecontrol.io/docs/submitting_a_package#Step_7))
