### PR TITLE
renamed "Blade Spacer" to "Laravel Blade Spacer" for better visibility

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -768,16 +768,6 @@
 			]
 		},
 		{
-			"name": "Blade Spacer",
-			"details": "https://github.com/austenc/blade-spacer",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "BlameHighlighter",
 			"details": "https://github.com/skyronic/BlameHighlighter",
 			"releases": [

--- a/repository/l.json
+++ b/repository/l.json
@@ -139,6 +139,17 @@
 			]
 		},
 		{
+			"name": "Laravel Blade Spacer",
+			"previous_names": ["Blade Spacer"],
+			"details": "https://github.com/austenc/blade-spacer",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Laravel Bootstrapper Snippets",
 			"details": "https://github.com/patricktalmadge/Bootstrapper_snippets",
 			"labels": ["snippets"],


### PR DESCRIPTION
I think a lot of people might miss this as they search for "Laravel" and the package doesn't have that in its name. Thanks!

Please provide the following information:

 - Code repository: https://github.com/austenc/blade-spacer
 - Tags page: https://github.com/austenc/blade-spacer/tags
