### PR TITLE
Update r.json with React-CSS-Converter

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -492,6 +492,17 @@
 			]
 		},
 		{
+			"name": "React-CSS-Converter",
+			"details": "https://github.com/davidfufu/React-CSS-Notation-Converter",
+			"labels": ["css", "react", "conversion", "notation", "styling"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "react-native-snippets",
 			"details": "https://github.com/Shrugs/react-native-snippets",
 			"labels": ["snippets", "react", "native", "react-native", "jsx"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
This is a small plugin for Sublime Text 3 that converts CSS notation to and from its normal syntax to the DOM notation that is accessed by React. This special notation is also called Dom notation. I made this to speed up React development due to the fact that CSS style objects can be created and stored within React components, but rewriting the CSS into React friendly, DOM notation was a hassle. This is important because it would be very tedious to convert regular css to react ready CSS.There currently does not exist a plugin to do so.  MDN link about the differences in notation: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Properties_Reference