### PR TITLE
Rename “YAML Macros” to “YAMLMacros”

### DIFF
--- a/repository/y.json
+++ b/repository/y.json
@@ -12,7 +12,8 @@
 			]
 		},
 		{
-			"name": "YAML Macros",
+			"name": "YAMLMacros",
+			"previous_names": ["YAML Macros"],
 			"details": "https://github.com/Thom1729/YAML-Macros",
 			"releases": [
 				{

--- a/repository/y.json
+++ b/repository/y.json
@@ -12,9 +12,8 @@
 			]
 		},
 		{
-			"name": "YAMLMacros",
-			"previous_names": ["YAML Macros"],
-			"details": "https://github.com/Thom1729/YAML-Macros",
+			"name": "YAML Nav",
+			"details": "https://github.com/ddiachkov/sublime-yaml-nav",
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -23,8 +22,9 @@
 			]
 		},
 		{
-			"name": "YAML Nav",
-			"details": "https://github.com/ddiachkov/sublime-yaml-nav",
+			"name": "YAMLMacros",
+			"previous_names": ["YAML Macros"],
+			"details": "https://github.com/Thom1729/YAML-Macros",
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/y.json
+++ b/repository/y.json
@@ -12,6 +12,16 @@
 			]
 		},
 		{
+			"name": "YAML Macros",
+			"details": "https://github.com/Thom1729/YAML-Macros",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "YAML Nav",
 			"details": "https://github.com/ddiachkov/sublime-yaml-nav",
 			"releases": [


### PR DESCRIPTION
To make it easier for users to reference libraries inside the package.