### PR TITLE
Rename “ruamel” dependency to “ruamel-yaml”.

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -607,6 +607,20 @@
 			]
 		},
 		{
+			"name": "ruamel",
+			"load_order": "01",
+			"description": "Python ruamel.yaml module",
+			"author": "Thomas Smith",
+			"issues": "https://github.com/Thom1729/sublime-ruamel/issues",
+			"releases": [
+				{
+					"base": "https://github.com/Thom1729/sublime-ruamel",
+					"tags": true,
+					"sublime_text": ">=3000"
+				}
+			]
+		},
+		{
 			"name": "rx",
 			"load_order": "01",
 			"description": "Reactive extensions for Python",

--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -607,7 +607,7 @@
 			]
 		},
 		{
-			"name": "ruamel",
+			"name": "ruamel-yaml",
 			"load_order": "01",
 			"description": "Python ruamel.yaml module",
 			"author": "Thomas Smith",


### PR DESCRIPTION
Per discussion [here](https://github.com/wbond/package_control_channel/pull/6405#pullrequestreview-47538459). If “ruamel.yaml” would be a more appropriate dependency name, I will make it so.