### PR TITLE
add react native autocomplete

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -499,6 +499,7 @@
 				{
 					"version": 0.46,
 					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},

--- a/repository/r.json
+++ b/repository/r.json
@@ -492,7 +492,7 @@
 			]
 		},
 		{
-			"name": "React Native Completions",
+			"name": "React Native Autocomplete",
 			"details": "https://github.com/gebeto/react-native-autocomplete",
 			"labels": ["completion"],
 			"releases": [

--- a/repository/r.json
+++ b/repository/r.json
@@ -499,7 +499,6 @@
 				{
 					"version": 0.46,
 					"sublime_text": "*",
-					"tags": true
 				}
 			]
 		},

--- a/repository/r.json
+++ b/repository/r.json
@@ -492,6 +492,18 @@
 			]
 		},
 		{
+			"name": "React Native Autocomplete",
+			"details": "https://github.com/gebeto/react-native-autocomplete",
+			"labels": ["completion"],
+			"releases": [
+				{
+					"version": 0.46,
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "React-CSS-Converter",
 			"details": "https://github.com/davidfufu/React-CSS-Notation-Converter",
 			"labels": ["css", "react", "conversion", "notation", "styling"],

--- a/repository/r.json
+++ b/repository/r.json
@@ -498,7 +498,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"tags": true
+					"tags": true 
 				}
 			]
 		},

--- a/repository/r.json
+++ b/repository/r.json
@@ -492,7 +492,7 @@
 			]
 		},
 		{
-			"name": "React Native Autocomplete",
+			"name": "React Native Completions",
 			"details": "https://github.com/gebeto/react-native-autocomplete",
 			"labels": ["completion"],
 			"releases": [

--- a/repository/r.json
+++ b/repository/r.json
@@ -498,7 +498,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"tags": true 
+					"tags": true
 				}
 			]
 		},

--- a/repository/r.json
+++ b/repository/r.json
@@ -497,7 +497,6 @@
 			"labels": ["completion"],
 			"releases": [
 				{
-					"version": 0.46,
 					"sublime_text": "*",
 					"tags": true
 				}

--- a/repository/r.json
+++ b/repository/r.json
@@ -481,17 +481,6 @@
 			]
 		},
 		{
-			"name": "React Templates",
-			"details": "https://github.com/talpor/sublime-rt",
-			"labels": ["language syntax", "RT"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "React Native Autocomplete",
 			"details": "https://github.com/gebeto/react-native-autocomplete",
 			"labels": ["completion"],
@@ -499,6 +488,17 @@
 				{
 					"sublime_text": "*",
 					"tags": true 
+				}
+			]
+		},
+		{
+			"name": "React Templates",
+			"details": "https://github.com/talpor/sublime-rt",
+			"labels": ["language syntax", "RT"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
This plugin add react native autocompletes, I wrote parsers that parse react native official documentation and create .sublime-completion files from that data, now it have small amount of completions, and have some defect in parser of StyleSheet but it small, now styles autocomletes parse very good and autocomplete looks great:)

<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
