### PR TITLE
Add python 2to3 converter

### DIFF
--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -35,6 +35,17 @@
 			]
 		},
 		{
+			"name": "2to3",
+			"details": "https://github.com/jsn5/2to3_sublime_plugin",
+			"labels": ["python", "2to3"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "3024 Color Scheme",
 			"details": "https://github.com/idleberg/3024.tmTheme",
 			"labels": ["color scheme"],

--- a/repository/c.json
+++ b/repository/c.json
@@ -2980,6 +2980,16 @@
 			]
 		},
 		{
+			"name": "ConvertPython2to3",
+			"details": "https://github.com/jsn5/2to3_sublime_plugin",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Convoy",
 			"details": "https://github.com/joshbeitler/convoy",
 			"releases": [
@@ -4150,6 +4160,6 @@
 					"branch": "cython"
 				}
 			]
-		}
+		}		
 	]
 }

--- a/repository/c.json
+++ b/repository/c.json
@@ -2980,16 +2980,6 @@
 			]
 		},
 		{
-			"name": "ConvertPython2to3",
-			"details": "https://github.com/jsn5/2to3_sublime_plugin",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Convoy",
 			"details": "https://github.com/joshbeitler/convoy",
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -3945,16 +3945,6 @@
 			]
 		},
 		{
-			"name": "Cucumber Snippets e Highlight em Inglês",
-			"details": "https://github.com/RobertoPegoraro/cucumber-snippets-highlight-english",
-			"releases": [
-				{
-					"sublime_text": ">=3092",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Cucumber Snippets e Highlight em Português",
 			"details": "https://github.com/RobertoPegoraro/cucumber-snippets-highlight-portugues",
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -3945,6 +3945,16 @@
 			]
 		},
 		{
+			"name": "Cucumber Snippets e Highlight em Inglês",
+			"details": "https://github.com/RobertoPegoraro/cucumber-snippets-highlight-english",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Cucumber Snippets e Highlight em Português",
 			"details": "https://github.com/RobertoPegoraro/cucumber-snippets-highlight-portugues",
 			"releases": [
@@ -4150,6 +4160,6 @@
 					"branch": "cython"
 				}
 			]
-		}		
+		}
 	]
 }


### PR DESCRIPTION
Made a plugin to convert python code from version 2 to 3 on the go.

<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
