### PR TITLE
Add Goto With Common Suffix

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1371,6 +1371,17 @@
 			]
 		},
 		{
+			"name": "Goto With Common Suffix",
+			"details": "https://github.com/ivantsepp/goto-with-common-suffix",
+			"labels": ["file navigation"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Goto-CSS-Declaration",
 			"details": "https://github.com/rmaksim/Sublime-Text-2-Goto-CSS-Declaration",
 			"author": "Razumenko Maksim",


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
This plugin allows you to do file searches with common suffixes. For example, If I opened up my project, I want to be able to paste `https://github.com/ivantsepp/goto-with-common-suffix/blob/master/goto_with_common_suffix.py` and it will open up that file.