### PR TITLE
Add P3 Assembly sublime syntax package

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2,6 +2,17 @@
 	"schema_version": "3.0.0",
 	"packages": [
 		{
+			"name": "P3 Assembly",
+			"details": "https://github.com/rgcv/p3assembly-sublime-syntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "P4 Syntax Highlighter",
 			"details": "https://github.com/c3m3gyanesh/p4-syntax-highlighter",
 			"releases": [

--- a/repository/p.json
+++ b/repository/p.json
@@ -7,7 +7,7 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

I'd like to submit this package to Package Control as I'd like to share this small little useful syntax I managed to write up in order to share it in a more eloquent and automated fashion. I am still learning the nooks and crannies of both `.yaml` and `.sublime-syntax`'s, well, syntax, but I think this could be a good start.

In short, this package adds a syntax theme (no actual color theme, just the syntax itself) for the P3 Assembly language, being P3 a processor used in academia in one of Portugal's University of Lisbon's faculties. More information can be found in the repository's README file.