### PR TITLE
Add Toggle Slashes plugin

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -395,6 +395,17 @@
 			]
 		},
 		{
+			"name": "Open Files In List",
+			"details": "https://github.com/Wargazm/open_files_in_list",
+			"labels": ["file open", "file navigation"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Open Folder",
 			"details": "https://github.com/mikepfirrmann/openfolder",
 			"labels": ["file navigation"],

--- a/repository/t.json
+++ b/repository/t.json
@@ -2202,6 +2202,16 @@
 			]
 		},
 		{
+			"name": "Toggle Slashes",
+			"details": "https://github.com/Wargazm/toggle_slashes",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Toggle Symbol to String",
 			"details": "https://github.com/zoomix/SublimeToggleSymbol",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

This simple plugin creates a command that toggles backslashes to forward slashes and vice-versa.  