### PR TITLE
Remove CSS3_Syntax package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3733,16 +3733,6 @@
 			]
 		},
 		{
-			"name": "CSS3_Syntax",
-			"details": "https://github.com/y0ssar1an/CSS3_Syntax",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "CSScomb",
 			"details": "https://github.com/csscomb/sublime-csscomb",
 			"previous_names": ["CSScomb.js", "CSScomb JS"],


### PR DESCRIPTION
This is an ancient ST2 package of mine that has been deprecated since 2014. It has been replaced by [the CSS3 package](https://github.com/y0ssar1an/CSS3). I'm deleting [the CSS3_Syntax repo](https://github.com/y0ssar1an/CSS3_Syntax).