### PR TITLE
add webhare package

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -207,6 +207,17 @@
 			]
 		},
 		{
+			"name": "WebHare",
+			"details": "https://github.com/WebHare/sublime-package",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"platforms": ["osx", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Webloader",
 			"details": "https://github.com/rozsahegyi/sublime-webloader",
 			"releases": [


### PR DESCRIPTION
This package adds a lot of utility for WebHare developers - whether they have a local installation or only have network/webdav access to such a system.

We understand this market/target group is currently small, but having this package in PackageControl instead of having to manually distribute configurations would make it a lot easier for the sublime/webhare fans to use this integration