### PR TITLE
Added Oracle package.

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -735,7 +735,7 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]

--- a/repository/o.json
+++ b/repository/o.json
@@ -736,7 +736,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},

--- a/repository/o.json
+++ b/repository/o.json
@@ -730,6 +730,17 @@
 			]
 		},
 		{
+			"name": "Oracle",
+			"details": "https://github.com/Thom1729/sublime-oracle",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Oracle PL SQL",
 			"details": "https://github.com/mulander/oracle.tmbundle",
 			"labels": ["language syntax"],


### PR DESCRIPTION
There does not currently exist a satisfactory syntax for Oracle SQL and PL/SQL. The core SQL syntax does not support many Oracle features, and given the variance between popular SQL implementations it is unlikely that the generic core syntax could ever take the place of an Oracle-specific package.

There is an [existing "Oracle PL SQL" syntax](https://github.com/mulander/oracle.tmbundle). It omits basic features that I use on a regular basis. In principle, it could be improved, but because it uses the `.tmLanguage` format, this would mean a total rewrite anyway. There have been no commits for two years, and the author [no longer works in PL/SQL](https://github.com/mulander/oracle.tmbundle/issues/15).

There is also [a SQLPlus package](https://packagecontrol.io/packages/SQLPlus). Its primary focus is interfacing with an Oracle client, but it does provide some syntax highlighting. However, it is also a `.tmLanguage`, and it is very minimal. The syntax itself has not been updated in two years.

This Oracle package provides syntax highlighting for Oracle SQL queries and for PL/SQL. It is a modern `.sublime-syntax` based (I hope) on modern conventions and principles. It uses [YAML Macros](https://github.com/Thom1729/YAML-Macros) extensively; I think that implementing some common Oracle constructs without macros would be simply impractical.

The syntax is not feature-complete by a long shot, but it should cover most Oracle SQL queries and a large chunk of PL/SQL. I have been using it exclusively for about a year.