### PR TITLE
Add ABAP language support plugin

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -24,6 +24,17 @@
 			]
 		},
 		{
+			"name": "ABAP",
+			"details": "https://github.com/flaiker/abap-st3",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Abaqus",
 			"details": "https://github.com/SenhorLucas/AbaqusSublimePackage",
 			"labels": ["abaqus", "language syntax", "snippets", "text manipulation"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
This is just a simple plugin to provide ABAP language support / syntax highlighting. ABAP is the main language in use by [SAP](https://www.sap.com).
The .tmLanguage file for this is taken from the repository that GitHub's linguist also uses for highlighting. You can find some more details in the README.
