### PR TITLE
Add JSSM highlighting

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -1115,7 +1115,6 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master",
 					"tags": true
 				}
 			]

--- a/repository/j.json
+++ b/repository/j.json
@@ -1115,7 +1115,8 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"branch": "master",
+					"tags": true
 				}
 			]
 		},

--- a/repository/j.json
+++ b/repository/j.json
@@ -1109,6 +1109,17 @@
 			]
 		},
 		{
+			"name": "JSSM",
+			"details": "https://github.com/StoneCypher/sublime-jssm",
+			"labels": ["javascript", "state machine", "fsm", "language syntax", "jssm"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "JSTL autocomplete",
 			"details": "https://github.com/eparisio/st3-jstl-snippet-autocomplete",
 			"labels": ["snippets", "auto-complete"],


### PR DESCRIPTION
This is a novel highlighter for an otherwise uncovered state machine notation `JSSM`

It looks like this.  I think it's purty

![](https://raw.githubusercontent.com/StoneCypher/sublime-jssm/master/screenshot.png)