### PR TITLE
Add Ember Single-File Component Syntax

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -553,6 +553,17 @@
 			]
 		},
 		{
+			"name": "Ember Single-File Component Syntax",
+			"details": "https://github.com/urbany/ember-sfc-syntax-highlight",
+			"labels": ["ember", "sfc", "single-file", "syntax", "highlighting", "handlebars", "glimmer"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Ember Syntax",
 			"details": "https://github.com/healthsparq/sublime-ember-syntax",
 			"labels": ["ember", "syntax", "highlighting", "handlebars", "glimmer"],


### PR DESCRIPTION
This is a package to add syntax highlighting for single-file Ember.js components which allow the user to put in a single file, the component's script, template and styles. This differ from other Ember.js syntax which only allow either Template or Script syntax highlight.

