### PR TITLE
Add Guna (Theme)

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -2039,6 +2039,17 @@
 			]
 		},
 		{
+			"name": "Guna",
+			"details": "https://github.com/poucotm/Guna",
+			"labels": ["theme", "color-scheme", "clock"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Gutter Color",
 			"details": "https://github.com/ggordan/GutterColor",
 			"releases": [


### PR DESCRIPTION
Guna is a theme plug-in.
It has `.no-sublime-package` file to use `.pyc` sub-modules. In my test, packaging (.sublime-package) makes some unexpected result when installing, upgrading.
