### PR TITLE
master: Added NetSuite SDF package to repo

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -288,7 +288,7 @@
 			]
 		},
 		{
-			"name": "NetSuite SDF",
+			"name": "NetSuite SDF Test",
 			"details": "https://github.com/limebox/sublime-sdf",
 			"releases": [
 				{

--- a/repository/n.json
+++ b/repository/n.json
@@ -288,7 +288,7 @@
 			]
 		},
 		{
-			"name": "NetSuite SDF Test",
+			"name": "NetSuite SDF",
 			"details": "https://github.com/limebox/sublime-sdf",
 			"releases": [
 				{

--- a/repository/n.json
+++ b/repository/n.json
@@ -288,6 +288,16 @@
 			]
 		},
 		{
+			"name": "NetSuite SDF",
+			"details": "https://github.com/limebox/sublime-sdf",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Nette",
 			"details": "https://github.com/Michal-Mikolas/Nette-package-for-Sublime-Text-2",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

Hello, this package is for the NetSuite SDF CLI tool which requires a NetSuite account (you can see the Chocolatey package here: https://chocolatey.org/packages/sdfcli, I am presently working on a Brew as well). This is a pre-release but I wanted to make it available for people to start playing with. It is limited to people who use NetSuite, so the documentation I can give you is locked behind an account.

This is needed because the only software that has a NetSuite plugin is Eclipse, and that's nasty. This provides all of the same functionality as the Eclipse plugin while resting inside the beauty and simplicity of Sublime. This is my first Sublime plugin and even my first entry into Python, so please forgive the code.

In order to use this software, you need to have the NetSuite SDF CLI tool installed. This is done either manually or using Chocolatey on Windows and soon Brew on a Mac. For a video representation of this Plugin, please see this video:
https://www.dropbox.com/s/3tkudqdnctt2s1v/Sublime%20Text%203%20Plugin.mp4?dl=0

Let me know if there is anything else I need to do.

Thank you,

TJ