### PR TITLE
Add Scalafmt package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -272,18 +272,6 @@
 			]
 		},
 		{
-			"name": "ScalaFormatter",
-			"details": "https://github.com/fedragon/scalaformatter",
-			"labels": ["scala", "formatting"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"platforms": "osx",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Scala Snippets",
 			"details": "https://github.com/iDev0urer/sublime-scala-snippets",
 			"labels": ["snippets", "scala"],
@@ -301,6 +289,18 @@
 			"releases": [
 				{
 					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "ScalaFormatter",
+			"details": "https://github.com/fedragon/scalaformatter",
+			"labels": ["scala", "formatting"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": "osx",
 					"tags": true
 				}
 			]

--- a/repository/s.json
+++ b/repository/s.json
@@ -294,13 +294,12 @@
 			]
 		},
 		{
-			"name": "ScalaFormatter",
-			"details": "https://github.com/fedragon/scalaformatter",
-			"labels": ["scala", "formatting"],
+			"name": "Scalafmt",
+			"details": "https://github.com/fedragon/sublime-scalafmt",
+			"labels": ["scala", "format", "formatting", "formatter", "scalafmt"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": "osx",
 					"tags": true
 				}
 			]

--- a/repository/s.json
+++ b/repository/s.json
@@ -272,6 +272,18 @@
 			]
 		},
 		{
+			"name": "ScaFor",
+			"details": "https://github.com/fedragon/scafor",
+			"labels": ["scala", "formatting"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": "osx",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Scala Snippets",
 			"details": "https://github.com/iDev0urer/sublime-scala-snippets",
 			"labels": ["snippets", "scala"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -272,8 +272,8 @@
 			]
 		},
 		{
-			"name": "ScaFor",
-			"details": "https://github.com/fedragon/scafor",
+			"name": "ScalaFormatter",
+			"details": "https://github.com/fedragon/scalaformatter",
 			"labels": ["scala", "formatting"],
 			"releases": [
 				{


### PR DESCRIPTION
Hi, 
I know about other such plugins (`ScalaFormat`, `Scalariform`) and have tried them out before developing this plugin: the difference is in the formatting engine used (`scalafmt` in this, `scalariform` in the others). Seeing that those plugins are slim wrappers on top of `scalariform`, it didn't seem to me a viable option to generalize them to support `scalafmt` as well. 
I hope this can save you some time :)