### PR TITLE
add comic sans toggle to repo list

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2639,6 +2639,16 @@
 			]
 		},
 		{
+			"name": "ComicSansToggle",
+			"details": "https://github.com/seangoedecke/sublime-comic-sans-toggle/",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Commandbox",
 			"details": "https://github.com/Ortus-Solutions/sublime-commandbox",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

This is a little fun package to toggle your font to and from Comic Sans, mainly as a joke to mess with your coworkers. It sets the font_face in your view-specific settings, then reverts it when you enter the command again.

Packages already exist to toggle between a list of fonts, but they're all intended for serious work, unlike this one. I wrote this package because I don't want anyone to have to mess with their actual work setup in order to pull a silly joke.

Here's the repo: https://github.com/seangoedecke/sublime-comic-sans-toggle/

Thanks!

