### PR TITLE
add laravel docs (light) colour scheme based on docs theme

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -184,6 +184,20 @@
 			]
 		},
 		{
+			"name": "Laravel Colour Scheme",
+			"details": "https://github.com/michaeldyrynda/Laravel.tmTheme",
+			"issues": "https://github.com/michaeldyrynda/Laravel.tmTheme/issues",
+			"homepage": "https://dyrynda.com.au",
+			"author": "michaeldyrynda",
+			"labels": ["color scheme", "light color scheme", "laravel", "laravel docs", "laravel color scheme"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Laravel Forms Bootstrap Snippets",
 			"details": "https://github.com/redgluten/laravel_forms_boostrap_snippets",
 			"labels": ["snippets"],


### PR DESCRIPTION
This colour scheme provides an interpretation of the colour scheme used in the official [Laravel documentation](https://laravel.com/docs) and has been built with all languages that are commonly used with the Laravel framework in mind.