### PR TITLE
Add JBuilder support for sublime

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -443,6 +443,19 @@
 			]
 		},
 		{
+			"name": "JBuilder",
+			"details": "https://github.com/zwade/sublime_jbuilder",
+			"author": "Zachary Wade",
+			"labels": ["ocaml", "build-system", "jbuilder", "jbuild"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["osx", "linux"],
+					"tags": true
+				}
+			] 
+		},
+		{
 			"name": "JCommander",
 			"details": "https://github.com/zanuka/jcommander",
 			"labels": ["snippets","auto-complete","utilities"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

Adds a JBuilder-based build system for sublime. This is still relatively new, and only supports target selection and building. However, it makes it significantly easier to use `merlin` and `OCaml` in general by making it easy to build projects from within sublime.

As mentioned, its still very basic, but there are several people whom I know will use this functionality.

Thanks,
Zach (@zwade)