### PR TITLE
Add a simple Web Search package for Sublime 3

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -257,6 +257,17 @@
 				}
 			]
 		},
+        {
+            "name": "Web Search",
+            "details": "https://github.com/asalahli/sublime-web-search",
+            "labels": ["browser integration", "search", "web"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "tags": true
+                }
+            ]
+        },
 		{
 			"name": "WebSuite",
 			"details": "https://github.com/bthorben/WebSuite",

--- a/repository/w.json
+++ b/repository/w.json
@@ -134,6 +134,17 @@
 			]
 		},
 		{
+			"name": "Web Search",
+			"details": "https://github.com/asalahli/sublime-web-search",
+			"labels": ["browser integration", "search", "web"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "WebBuilder ST",
 			"details": "https://github.com/Houfeng/WebBuilder-ST",
 			"releases": [
@@ -257,17 +268,6 @@
 				}
 			]
 		},
-        {
-            "name": "Web Search",
-            "details": "https://github.com/asalahli/sublime-web-search",
-            "labels": ["browser integration", "search", "web"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "tags": true
-                }
-            ]
-        },
 		{
 			"name": "WebSuite",
 			"details": "https://github.com/bthorben/WebSuite",


### PR DESCRIPTION
Hi,

This is a package to perform a web search (currently only supports DuckDuckGo) from Sublime Text 3.

It includes two commands:
1. **Web Search** prompts the user for a query and performs a search with that query
2. **Web Search Selected** performs a search with the selected text. If there are multiple regions selected, it will display a list of first 10 selection and ask user to pick one.

When I added my repo to the channel, I realized that an identical (and more feature rich) package exists for Sublime Text 2. In the future, I might try to merge these to packages together, but that involves contacting the author, doing some refactoring etc, which is more work, so I think merging this as is would still be valuable until then.

Let me know if there's any additional work I need to do for this PR to get merged.

Thanks,
Azad