### PR TITLE
Add tmux_open (later 'tmux') package, rename Tmux to 'Tmux Syntax Highlight'

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -4209,18 +4209,6 @@
 			]
 		},
 		{
-			"name": "SublimeTmux",
-			"details": "https://github.com/huntie/sublime-tmux",
-			"labels": ["tmux", "terminal"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"platforms": ["linux", "osx"],
-					"tags": true
-				}
-			]
-		},
-		{
 			"details": "https://github.com/R3AL/SublimeTransporter",
 			"releases": [
 				{

--- a/repository/s.json
+++ b/repository/s.json
@@ -4209,6 +4209,18 @@
 			]
 		},
 		{
+			"name": "SublimeTmux",
+			"details": "https://github.com/huntie/sublime-tmux",
+			"labels": ["tmux", "terminal"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["linux", "osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/R3AL/SublimeTransporter",
 			"releases": [
 				{

--- a/repository/t.json
+++ b/repository/t.json
@@ -2125,7 +2125,8 @@
 			]
 		},
 		{
-			"name": "Tmux",
+			"name": "Tmux Syntax Highlight",
+			"previous_names": ["Tmux"],
 			"details": "https://github.com/keqh/sublime-tmux-syntax-highlight",
 			"labels": ["language syntax"],
 			"releases": [

--- a/repository/t.json
+++ b/repository/t.json
@@ -2137,6 +2137,18 @@
 			]
 		},
 		{
+			"name": "tmux_open",
+			"details": "https://github.com/huntie/sublime-tmux",
+			"labels": ["tmux", "terminal"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["linux", "osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "To Hastebin",
 			"details": "https://github.com/nicetrysean/SublimeToHastebin",
 			"releases": [


### PR DESCRIPTION
New package providing commands to open [tmux](https://github.com/tmux/tmux#readme) windows at the current file or project folder. Looking to provide more functionality in future, hence the wide-reaching name (another package `Tmux` already exists and provides syntax highlighting). Lower case `tmux` would be the ideal package name, if it's allowed to be that similar – the description may be adequately differentiating.

Many thanks,
Alex

