### PR TITLE
Add ComposerPackageInfo

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2775,6 +2775,18 @@
 			]
 		},
 		{
+			"name": "ComposerPackageInfo",
+			"details": "https://github.com/gh640/SublimeComposerPackageInfo",
+			"author": "Goto Hayato",
+			"labels": ["php", "composer"],
+			"releases": [
+				{
+					"sublime_text": ">=3124",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Compressor",
 			"details": "https://github.com/joernhees/sublime-compressor",
 			"labels": ["compression", "decompress", "gzip"],

--- a/repository/u.json
+++ b/repository/u.json
@@ -454,6 +454,16 @@
 			]
 		},
 		{
+			"name": "UrlConverter",
+			"details": "https://github.com/gh640/SublimeUrlConverter",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/mastahyeti/URLEncode",
 			"releases": [
 				{


### PR DESCRIPTION
This package provides a popup function which fetches and shows a Composer package's information.

I searched for similar packages before making this pull request. I found a package named "Composer" https://packagecontrol.io/packages/Composer but it's for deferent use and this function is better in another package, I believe. 

Please let me know if I did anything incorrectly. Thank you in advance.