### PR TITLE
Add ComposerPackageInfo.

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2851,6 +2851,18 @@
 			]
 		},
 		{
+			"name": "ComposerPackageInfo",
+			"details": "https://github.com/gh640/SublimeComposerPackageInfo",
+			"author": "Goto Hayato",
+			"labels": ["php", "composer"],
+			"releases": [
+				{
+					"sublime_text": ">=3124",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Compressor",
 			"details": "https://github.com/joernhees/sublime-compressor",
 			"labels": ["compression", "decompress", "gzip"],


### PR DESCRIPTION
(This is a retry of the PR https://github.com/wbond/package_control_channel/pull/6613 )

This package provides a popup function which fetches and shows a Composer package's information.

I searched for similar packages before making this pull request. I found a package named "Composer" https://packagecontrol.io/packages/Composer but it's for deferent use and this function is better in another package, I believe.

Please let me know if I did anything incorrectly. Thank you in advance.