### PR TITLE
Add SetWindowTitle plugin

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1177,6 +1177,7 @@
 			"author": "gwenzek",
 			"releases": [
 				{
+					"platforms": "linux",
 					"sublime_text": ">=3000",
 					"tags": true
 				}

--- a/repository/s.json
+++ b/repository/s.json
@@ -1171,6 +1171,18 @@
 			]
 		},
 		{
+			"name": "SetWindowTitle",
+			"details": "https://github.com/gwenzek/SublimeSetWindowTitle",
+			"homepage": "https://github.com/gwenzek/SublimeSetWindowTitle",
+			"author": "gwenzek",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SexySnippets",
 			"details": "https://github.com/felquis/SexySnippets",
 			"homepage": "https://github.com/felquis/SexySnippets",


### PR DESCRIPTION
This plugin allows you to configure the title of your Sublime Text windows. Every time you switch view, save a view, start editing a view, it will update the window title.

Only works for Linux for now.

https://github.com/gwenzek/SublimeSetWindowTitle