### PR TITLE
Add DXR plugin

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -1460,6 +1460,16 @@
 			]
 		},
 		{
+			"name": "DXR",
+			"details": "https://github.com/snorp/sublime-text-dxr",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Dylan",
 			"details": "https://github.com/dylan-lang/dylan.tmbundle",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

This is a simple plugin that allows opening the current file in Mozilla DXR (https://dxr.mozilla.org). This will primarily be useful for people working on Firefox or Gecko.