### PR TITLE
Aded new package PHPUnit Linux Lite

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1311,6 +1311,17 @@
 			]
 		},
 		{
+			"name": "PHPUnit Linux Lite",
+			"details": "https://github.com/ainme/sublime-phpunit-ubuntu",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "PHPUnit Snippets",
 			"details": "https://github.com/florianeckerstorfer/fe-sublime-phpunit",
 			"labels": ["snippets"],
@@ -2580,7 +2591,7 @@
 					"tags": true
 				}
 			]
-		},		
+		},
 		{
 			"name": "Python Fix Imports",
 			"details": "https://github.com/Stibbons/python-fiximports",


### PR DESCRIPTION
Hi,

I have seen a lot of phpunit packages here and that works pretty well. But additionally, this package will allow users to be able to run tests at the method level, uses the default terminal and shortcuts are ordered in a way that can be found in one place. I have been using this package for some time and also has shared with some of my colleagues to install it manually. The [original package](https://github.com/adamwathan/sublime-phpunit) which is being used by multiple users supports Mac only, so I thought of making a fork of it available for Linux platforms.
I hope it would be a great help for the Linux laravel community, which is a lot.
from original package by adam: "Convenient Sublime Text commands for running your PHPUnit tests. Scans up the directory tree to find the closest phpunit.xml file and runs phpunit from there. If it can't find one, it just runs phpunit from /."

<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
