### PR TITLE
A basic syntax highlighting package for MathML 3.0 (beta)

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -762,6 +762,17 @@
 			]
 		},
 		{
+			"name": "MathML",
+			"details": "https://github.com/Sensibility/MathML-Sublime-Plugin",
+			"labels": ["language syntax", "syntax", "MathML-syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Matlab Completions",
 			"details": "https://github.com/tushortz/Matlab-Completions",
 			"labels": ["matlab", "completion", "auto-complete"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
This package currently does rudimentary syntax highlighting for MathML (3.0). As of version 0.1.0, it only supports highlighting within files that have the `.mathml`, `.mathm` or `.math`. It doesn't yet (but soon will) support snippets and invalid scoping that ensure/make easier the use of MathML's required number of children for some tags, required units on length attributes, and specific allowed values. I also plan to add highlighting within html scopes in a later release. The most MathML-specific feature I can boast at this point is string scoping for the content of `<ms>` (math string) tags.