### PR TITLE
Combine Purescript and Purescript IDE

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2266,19 +2266,9 @@
 		},
 		{
 			"name": "PureScript",
-			"details": "https://github.com/joneshf/sublime-purescript",
-			"labels": ["language syntax"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
-			"name": "PureScript IDE",
 			"details": "https://github.com/b123400/purescript-ide-sublime",
-			"labels": ["ide"],
+			"labels": ["language syntax", "ide"],
+			"previous_names": ["PureScript IDE"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2580,7 +2570,7 @@
 					"tags": true
 				}
 			]
-		},		
+		},
 		{
 			"name": "Python Fix Imports",
 			"details": "https://github.com/Stibbons/python-fiximports",


### PR DESCRIPTION
Hello. It has come to a conclusion that the author of `Purescript` would like me to takeover the package, combining my `Purescript IDE` package.

This PR combines them.

There is one thing I am not sure though, the original `Purescript` package is not using tag for versioning, it has a version of `2015.06.16.21.00.00` on package control's page. The new combined package (if following semvar) should be `2.0.0`. Will that work?

If not then I have to make it something like `2017.10.09.21.00.00`?