### PR TITLE
Monokai Dark added

### DIFF
--- a/repository/packages.json
+++ b/repository/packages.json
@@ -1,0 +1,12 @@
+{
+	"schema_version": "3.0.0",
+	"name": "Monokai Dark",
+	"details": "https://github.com/thatal/Monokai-Dark",
+	"labels": ["Monokai", "color schema", "seti_Ui"],
+	"releases": [
+		{
+			"sublime_text": "*",
+			"tags": true
+		}
+	]
+}


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

This is Monokai Dark color schema, and it is suitable with seti_ui user and I search for a color which provide me a dark background with Monokai original syntax higlights. then i came up with my own Monokai color schema.
