### PR TITLE
HighlightDuplicates repo ownership change

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -554,7 +554,7 @@
 			"previous_names": ["HighlightDuplicates"],
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]

--- a/repository/h.json
+++ b/repository/h.json
@@ -570,7 +570,8 @@
 			]
 		},
 		{
-			"details": "https://github.com/qur2/HighlightDuplicates",
+			"name": "Highlight Duplicates",
+			"details": "https://github.com/LordBrom/HighlightDuplicates",
 			"releases": [
 				{
 					"sublime_text": "<3000",

--- a/repository/h.json
+++ b/repository/h.json
@@ -549,6 +549,16 @@
 			]
 		},
 		{
+			"name": "Highlight Duplicates",
+			"details": "https://github.com/LordBrom/HighlightDuplicates",
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Highlight Trailing Whitespace",
 			"details": "https://github.com/p3lim/sublime-highlight-trailing-whitespace",
 			"releases": [
@@ -566,16 +576,6 @@
 				{
 					"sublime_text": "*",
 					"tags": true
-				}
-			]
-		},
-		{
-			"name": "Highlight Duplicates",
-			"details": "https://github.com/LordBrom/HighlightDuplicates",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"branch": "master"
 				}
 			]
 		},

--- a/repository/h.json
+++ b/repository/h.json
@@ -555,7 +555,6 @@
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"branch": "master",
 					"tags": true
 				}
 			]

--- a/repository/h.json
+++ b/repository/h.json
@@ -551,10 +551,12 @@
 		{
 			"name": "Highlight Duplicates",
 			"details": "https://github.com/LordBrom/HighlightDuplicates",
+			"previous_names": ["HighlightDuplicates"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"branch": "master"
+					"branch": "master",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
The plugin is the same, but it has been transferred to a new owner.
Here is the pull request which discusses the ownership change: https://github.com/LordBrom/HighlightDuplicates/pull/4

Also, adding name attribute.

<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
