### PR TITLE
SublimeCodeIntel moved to repository/s.json

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -101,7 +101,6 @@
 		"https://raw.githubusercontent.com/sokolovstas/SublimeWebInspector/master/packages.json",
 		"https://raw.githubusercontent.com/soncy/AutoComments-for-Sublime-Text-2/master/packages.json",
 		"https://raw.githubusercontent.com/spectacles/CodeComplice/master/packages.json",
-		"https://raw.githubusercontent.com/SublimeCodeIntel/SublimeCodeIntel/master/packages.json",
 		"https://raw.githubusercontent.com/SublimeLinter/package_control_channel/master/packages.json",
 		"https://raw.githubusercontent.com/superbob/SublimeTextLanguageFrench/master/packages.json",
 		"https://raw.githubusercontent.com/tbfisher/sublimetext-Pandoc/master/packages.json",

--- a/repository/s.json
+++ b/repository/s.json
@@ -3933,6 +3933,25 @@
 			]
 		},
 		{
+			"name": "SublimeCodeIntel",
+			"author": "Kronuz",
+			"description": "Full-featured code intelligence and smart autocomplete engine",
+			"details": "https://github.com/SublimeCodeIntel/SublimeCodeIntel",
+			"homepage": "http://sublimecodeintel.github.io/SublimeCodeIntel/",
+			"donate": "http://sublimecodeintel.github.io/SublimeCodeIntel/donate.html",
+			"labels": ["auto-complete", "code navigation", "snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				},
+				{
+					"sublime_text": "<3000",
+					"tags": "st2-v"
+				}
+			]
+		},
+		{
 			"details": "https://github.com/Ky6uk/SublimeDancer",
 			"releases": [
 				{

--- a/repository/s.json
+++ b/repository/s.json
@@ -3937,8 +3937,8 @@
 			"author": "Kronuz",
 			"description": "Full-featured code intelligence and smart autocomplete engine",
 			"details": "https://github.com/SublimeCodeIntel/SublimeCodeIntel",
-			"homepage": "http://sublimecodeintel.github.io/SublimeCodeIntel/",
-			"donate": "http://sublimecodeintel.github.io/SublimeCodeIntel/donate.html",
+			"homepage": "https://sublimecodeintel.github.io/",
+			"donate": "https://sublimecodeintel.github.io/donate.html",
 			"labels": ["auto-complete", "code navigation", "snippets"],
 			"releases": [
 				{


### PR DESCRIPTION
Moved SublimeCodeIntel to `repository/s.json` to simply make use of tags for releases.