### PR TITLE
Add SublimeLinter-contrib-psalm to repository

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -4117,6 +4117,20 @@
 			]
 		},
 		{
+			"name": "SublimeLinter-contrib-psalm",
+			"description": "This linter plugin for SublimeLinter provides an interface to vimeo/psalm.",
+			"details": "https://github.com/amad/SublimeLinter-contrib-psalm",
+			"homepage": "https://github.com/amad/SublimeLinter-contrib-psalm",
+			"issues": "https://github.com/amad/SublimeLinter-contrib-psalm/issues",
+			"labels": ["psalm", "php"],
+			"releases": [
+				{
+					"sublime_text": ">3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SublimeLinter_CatGutterTheme",
 			"details": "https://github.com/m10l/SublimeLinter-CatGutterTheme",
 			"labels": ["linting"],


### PR DESCRIPTION
User can use [vimeo/psalm](https://github.com/vimeo/psalm) as a linter to SublimeLinter.

Notes:
Currently there is no plugin to use **vimeo/psalm**.