### PR TITLE
Add NegateSentence plugin

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -148,6 +148,17 @@
 			]
 		},
 		{
+			"name": "NegateSentence",
+			"details": "https://github.com/Bajena/SublimeNegateSentence",
+			"labels": ["testing", "natural language tools", "text manipulation"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Neka Theme",
 			"details": "https://github.com/dempfi/neka-sublime",
 			"labels": ["theme", "color scheme"],


### PR DESCRIPTION
This plugin negates and unnegates english 3rd person present simple sentences. It is useful when writing unit test cases - when we have a positive case we can quickly add an opposite test case description.

Plugin is not aware of the context - it simply does a grammatic negation, so for example it'll turn "is empty -> is not empty" instead of converting it to "is full". Still, it can be useful in pretty many cases.

Example use case here:
![negate](https://user-images.githubusercontent.com/5732023/31863830-784cef52-b753-11e7-855f-260ebdf3414b.gif)
