### PR TITLE
Add NaNoWriMo Word Count Updater

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -34,6 +34,16 @@
 			]
 		},
 		{
+			"name": "NaNoWriMo Word Count Updater",
+			"details": "https://github.com/Nanofus/nanowrimo_word_count_updater",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Naomi",
 			"details": "https://github.com/borela/naomi",
 			"labels": ["enhanced", "syntax", "highlight"],
@@ -822,7 +832,7 @@
 					"tags": true
 				}
 			]
-		},		
+		},
 		{
 			"name": "NPMInfo",
 			"details": "https://github.com/dsteinbach/npm-info",

--- a/repository/n.json
+++ b/repository/n.json
@@ -39,7 +39,7 @@
 			"labels": ["workflow", "sync"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]

--- a/repository/n.json
+++ b/repository/n.json
@@ -36,6 +36,7 @@
 		{
 			"name": "NaNoWriMo Word Count Updater",
 			"details": "https://github.com/Nanofus/nanowrimo_word_count_updater",
+			"labels": ["workflow", "sync"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

This package adds a way to update the user's word count for National Novel Writing Month (https://nanowrimo.org/) from inside Sublime Text.