### PR TITLE
Add RevealCommand

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1257,6 +1257,16 @@
 			]
 		},
 		{
+			"name": "RevealCommand",
+			"details": "https://github.com/marinintim/RevealCommand",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ReverseCharacters",
 			"details": "https://github.com/alfredbez/ReverseCharacters",
 			"releases": [


### PR DESCRIPTION
This is a simple plugin that adds two commands to Command Palette.

One minor point is that `Reveal: in Finder` despite it's name should
work everywhere, because it uses `open_dir` under the hood.

Package: https://github.com/marinintim/RevealCommand