### PR TITLE
Add old release version of JSX for Sublime Text 2

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -1149,7 +1149,7 @@
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"tags": "v2.0.2"
+					"tags": "st2-v"
 				},
 				{
 					"sublime_text": ">3000",

--- a/repository/j.json
+++ b/repository/j.json
@@ -1148,7 +1148,11 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<3000",
+					"tags": "v2.0.2"
+				},
+				{
+					"sublime_text": ">3000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
I'm screwed up and broke this package for Sublime Text 2 users:
https://github.com/allanhortle/JSX/issues/21

Will this add a fixed older release for users who are still using ST2, while still giving new versions for ST3?

I couldn't find anything in the docs that talked about specific tags.

