### PR TITLE
Add GitIgnorer

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -662,6 +662,17 @@
 			]
 		},
 		{
+			"name": "Gitignorer",
+			"details": "https://github.com/ThinkChaos/sublime-gitignorer",
+			"labels": ["project", "utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "GitlabIntegrate",
 			"details": "https://github.com/SnoringFrog/GitlabIntegrate",
 			"labels": ["gitlab", "issues"],


### PR DESCRIPTION
I wrote this plugin because the [existing similar plugin](https://github.com/ExplodingCabbage/sublime-gitignorer) uses a timer to check for ignored files.
This plugin uses events, and a couple tricks, to be more efficient.
