### PR TITLE
Restrict ST2 to older versions of Elm Language Support

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -489,7 +489,11 @@
 			"previous_names": ["Elm Syntax Highlighting"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<3092",
+					"tags": "st2-"
+				},
+				{
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
New versions of the Elm Language Support package include a .sublime-syntax file and therefore require ST3.

All ST2-compatible versions of Elm Language Support have been tagged with the "st2-" prefix, so that ST2 users can continue to install the older, compatible version of the package.