### PR TITLE
Add VEX and HScript packages

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -909,6 +909,17 @@
 			]
 		},
 		{
+			"name": "HScript",
+			"details": "https://github.com/teared/HScript",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3126",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "HSP",
 			"details": "https://github.com/potato4d/sublime-HSP",
 			"releases": [

--- a/repository/v.json
+++ b/repository/v.json
@@ -244,6 +244,17 @@
 			]
 		},
 		{
+			"name": "VEX",
+			"details": "https://github.com/teared/VEX",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3126",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "VEX Syntax",
 			"details": "https://github.com/WhileRomeBurns/VEX_Syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

Hm, It seems like both commits got joined into a single PR, though I tried to commit and made PRs separately. Hope it is not a problem.

## VEX
Houdini add-on, VEX part of it. Main focus of this add-on shifted towards writing and building VEX Expressions, which is a special syntax on top of VEX language, popular among community this days. "Pure" VEX is also fully supported, though. Also, integrates HScript part, ~which I'll PR shortly~. Relies on new features in syntax and popups, so, does not support old Sublimes.

## HScript
HScript and HScript Expressions part of the Houdini add-on. Defines couple of another syntaxes (inside one). I decided to split it from VEX add-on, so, they can be installed separately. I develop them as a single project [here].

[here]: https://github.com/teared/packages-dev