### PR TITLE
Update Syntax-highlighting-for-Sass package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -5147,7 +5147,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3103",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},

--- a/repository/s.json
+++ b/repository/s.json
@@ -5146,7 +5146,7 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3103",
 					"branch": "master"
 				}
 			]

--- a/repository/s.json
+++ b/repository/s.json
@@ -5146,6 +5146,10 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
+					"sublime_text": "<3103",
+					"branch": "ST2"
+				},
+				{
 					"sublime_text": ">=3103",
 					"tags": true
 				}


### PR DESCRIPTION
Restrict the required Sublime Text version to "build 3103"
Use "tags" instead of "branch"
Add Sublime Text 2 version

Thanks

<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
