### PR TITLE
Add VimModelines to Package Control

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -339,6 +339,18 @@
 			]
 		},
 		{
+			"name": "VimModelines",
+			"details": "https://github.com/pestilence669/VimModelines",
+			"author": "Paul Chandler",
+			"labels": ["vim", "indentation", "modeline", "formatting"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Vintage Escape",
 			"details": "https://github.com/tonymagro/VintageEscape",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
This plugin applies basic Vim commands (tab width, auto-indent, word wrapping, line endings, ...) set with modeline annotations in the headers and footers.

There is an existing plugin for Emacs modelines and another for vim-inspired Sublime modelines, but I couldn't find anything that parses Vim syntax natively.

I have a lot of source code that has the annotation in the header and it's always been ignored. Switching between PEP-8 and non-PEP-8 Python files, was a motivator as was extending functionality that one already has using Vim with CLI edits over SSH.