### PR TITLE
Rename tmux_open as tmux

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2170,19 +2170,8 @@
 			]
 		},
 		{
-			"name": "Tmux Syntax Highlight",
-			"previous_names": ["Tmux"],
-			"details": "https://github.com/keqh/sublime-tmux-syntax-highlight",
-			"labels": ["language syntax"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
-			"name": "tmux_open",
+			"name": "tmux",
+			"previous_names": ["tmux_open"],
 			"details": "https://github.com/huntie/sublime-tmux",
 			"labels": ["tmux", "terminal"],
 			"releases": [
@@ -2190,6 +2179,17 @@
 					"sublime_text": ">=3000",
 					"platforms": ["linux", "osx"],
 					"tags": true
+				}
+			]
+		},
+		{
+			"name": "Tmux Syntax Highlight",
+			"details": "https://github.com/keqh/sublime-tmux-syntax-highlight",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
 				}
 			]
 		},


### PR DESCRIPTION
This follows #6612. A `previous_names` entry has been added.

Many thanks,
Alex