### PR TITLE
Remove AutoFoldCode

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2067,17 +2067,6 @@
 			]
 		},
 		{
-			"name": "AutoFoldCode",
-			"details": "https://github.com/callodacity/AutoFoldCode",
-			"labels": ["foldcode", "fold", "region", "persistent"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "autogit",
 			"details": "https://github.com/chrisparnin/autogit-st",
 			"releases": [


### PR DESCRIPTION
I have stopped development on AutoFoldCode and have deleted the repository. It should therefore also be removed from Package Control.