### PR TITLE
Add Laravel Docs package for shortcuts to docs 

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -220,6 +220,16 @@
 			]
 		},
 		{
+			"name": "Laravel Docs",
+			"details": "https://github.com/austenc/sublime-laravel-docs",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Laravel Forms Bootstrap Snippets",
 			"details": "https://github.com/redgluten/laravel_forms_boostrap_snippets",
 			"labels": ["snippets"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

Hey there, I often find myself needing to access a _specfic_ section of the Laravel docs when I'm coding. I usually type the URL manually but it's pretty tedious and repetitive, so I wanted to share some shortcuts to the docs as I thought others would also find them useful. Thanks!