### PR TITLE
Added the PythonDebugTools on repository/dependencies.json

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -567,7 +567,10 @@
 		},
 		{
 			"name": "PythonDebugTools",
-			"details": "https://github.com/evandrocoan/PythonDebugTools",
+			"author": "evandrocoan",
+			"load_order": "10",
+			"description": "Alternate simplified logging support",
+			"issues": "https://github.com/evandrocoan/PythonDebugTools/issues",
 			"releases": [
 				{
 					"sublime_text": ">=3114",

--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -573,6 +573,7 @@
 			"issues": "https://github.com/evandrocoan/PythonDebugTools/issues",
 			"releases": [
 				{
+					"base": "https://github.com/evandrocoan/PythonDebugTools",
 					"sublime_text": ">=3114",
 					"tags": true
 				}

--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -566,6 +566,16 @@
 			]
 		},
 		{
+			"name": "PythonDebugTools",
+			"details": "https://github.com/evandrocoan/PythonDebugTools",
+			"releases": [
+				{
+					"sublime_text": ">=3114",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "pytz",
 			"load_order": "50",
 			"description": "Python pytz module",


### PR DESCRIPTION
Fixes https://github.com/evandrocoan/SublimeAMXX_Editor/issues/2

The package https://packagecontrol.io/packages/amxmodx now requires this as dependency, but it is missing on the default channel.