### PR TITLE
Remove nathos/sass-textmate-bundle package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -160,18 +160,6 @@
 			]
 		},
 		{
-			"name": "Sass",
-			"details": "https://github.com/nathos/sass-textmate-bundle/tree/sublime",
-			"labels": ["language syntax"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"base": "https://github.com/nathos/sass-textmate-bundle",
-					"branch": "sublime"
-				}
-			]
-		},
-		{
 			"name": "SASS Build",
 			"details": "https://github.com/jaumefontal/SASS-Build-SublimeText2",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

Hey friends 👋 

I'd like to remove my (long abandoned 😢) Sass package from the directory, as I haven't maintained it in years, and it's probably doing more harm than good at this point. There are newer/better/actually supported [packages for Sass](https://packagecontrol.io/packages/Syntax%20Highlighting%20for%20Sass) and Sublime Text 3 today.