### PR TITLE
Adding Markdown Complement Package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -470,6 +470,16 @@
 			]
 		},
 		{
+			"name": "MarkdownCompletion",
+			"details": "https://github.com/junShimoji/markdowncomplements",
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MarkdownEditing",
 			"details": "https://github.com/SublimeText-Markdown/MarkdownEditing",
 			"labels": ["markdown", "github markdown", "gfm", "multimarkdown", "color scheme"],

--- a/repository/m.json
+++ b/repository/m.json
@@ -470,8 +470,8 @@
 			]
 		},
 		{
-			"name": "MarkdownCompletion",
-			"details": "https://github.com/junShimoji/markdowncomplements",
+			"name": "MarkdownComplements",
+			"details": "https://github.com/junShimoji/MarkdownComplements",
 			"releases": [
 				{
 					"sublime_text": "<3000",


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

This plugin provides functions to complement markdown a list item making/changing or indent up/down.
Users need to set Key Bindings only, doesn't need to care extensions(.md,.mdown,.txt or like that).
Further more, although other similar plugins conflicts with Japanese Input method that selected characters are disappearing, this plugin doesn't occur such errors.
And you can change list items manually not connected with indent levels.

I tested with package_control_panel and results are followings:

```
$ python test.py
....
Ran 8213 tests in 0.992s

OK
````
