### PR TITLE
Remove dot from package name "wpseek.com WordPress Developer Assistant"

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -859,9 +859,9 @@
 			]
 		},
 		{
-			"name": "wpseek.com WordPress Developer Assistant",
+			"name": "wpseek WordPress Developer Assistant",
 			"details": "https://github.com/wpseek/sublime-text-2-wpseek",
-			"previous_names": ["wpseek.com WordPress Function Lookup"],
+			"previous_names": ["wpseek.com WordPress Developer Assistant", "wpseek.com WordPress Function Lookup"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
Updated package name as proposed in #2524.

Closes wpseek/sublime-text-2-wpseek#6