### PR TITLE
Add Swift autocomplete

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -4907,6 +4907,18 @@
 			]
 		},
 		{
+			"name": "Swift Autocomplete",
+			"details": "https://github.com/Dan2552/SublimeTextSwiftAutocomplete",
+			"labels": ["auto-complete", "completions", "documentation", "swift"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Swift Completion",
 			"details": "https://github.com/tushortz/Swift-Completion",
 			"labels": ["completions", "snippets", "completion", "Completion"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
Provides autocomplete and mouse-hover documentation for Swift, in a similar manner to Xcode or other IDEs by using SourceKitten.

A similar package to https://github.com/johncsnyder/SwiftKitten, which doesn't really work anymore, and isn't maintained (I originally started with a pull request into this project before I went with a complete rewrite). My plugin, at least in my opinion, has surpassed the functionality provided by SwiftKitten.