### PR TITLE
Switch to tag based releases for Xdebug Client.

### DIFF
--- a/repository/x.json
+++ b/repository/x.json
@@ -61,7 +61,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Moving away from (deprecated) branch-based releases.