### PR TITLE
Add package: Default File Type 3

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -332,7 +332,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},

--- a/repository/d.json
+++ b/repository/d.json
@@ -321,7 +321,7 @@
 			"details": "https://github.com/spadgos/sublime-DefaultFileType",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<3000",
 					"branch": "master"
 				}
 			]

--- a/repository/d.json
+++ b/repository/d.json
@@ -327,6 +327,16 @@
 			]
 		},
 		{
+			"name": "Default File Type 3",
+			"details": "https://github.com/diegotf30/sublime-DefaultFileType",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "DelayedSaveAll",
 			"details": "https://github.com/shagabutdinov/sublime-delayed-save-all",
 			"donate": "https://github.com/shagabutdinov/sublime-enhanced/blob/master/readme-donations.md",


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
This package is a fork of https://github.com/spadgos/sublime-DefaultFileType, since it only works for Sublime 2, I made a version compatible only with Sublime 3. It allows to set a default syntax type to new windows.