### PR TITLE
Add yaml_macros_engine

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -887,6 +887,20 @@
 					"sublime_text": "*"
 				}
 			]
+		},
+		{
+			"name": "yaml_macros_engine",
+			"load_order": "50",
+			"description": "Engine for YAML Macros",
+			"author": "Thomas Smith",
+			"issues": "https://github.com/Thom1729/yaml-macros-engine/issues",
+			"releases": [
+				{
+					"base": "https://github.com/Thom1729/yaml-macros-engine",
+					"tags": true,
+					"sublime_text": ">=3000"
+				}
+			]
 		}
 	]
 }

--- a/repository/j.json
+++ b/repository/j.json
@@ -849,7 +849,7 @@
 			"labels": ["javascript", "syntax"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]

--- a/repository/j.json
+++ b/repository/j.json
@@ -844,6 +844,17 @@
 			]
 		},
 		{
+			"name": "JSCustom",
+			"details": "https://github.com/Thom1729/Sublime-JS-Custom",
+			"labels": ["javascript", "syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "JSDebug",
 			"details": "https://github.com/mbladel/JSDebug",
 			"labels": ["javascript", "debug"],


### PR DESCRIPTION
Includes the “guts” of [YAML Macros](https://github.com/Thom1729/YAML-Macros). Having this as a dependency will remove the hassle of having one package (e.g. JS Custom) require another.

A future version of YAML Macros will include this as a dependency.