### PR TITLE
Add Zig Language

### DIFF
--- a/repository/z.json
+++ b/repository/z.json
@@ -131,6 +131,17 @@
 			]
 		},
 		{
+			"name": "Zig Language",
+			"details": "https://github.com/zig-lang/sublime-zig-language",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Zimpl",
 			"details": "https://github.com/joneshf/sublime-zimpl",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Hi! I'd like to submit this syntax highlighting package for [Zig](http://ziglang.org/). In the course of submitting a PR to add this syntax to the github/linguist project, it made sense to make it available as a sublime package, as well. The package is [here](https://github.com/zig-lang/sublime-zig-language).

I haven't tagged a release yet. Does package control pick up on the most recent semver tag and serve that? 

Thanks!

Edit: I just went ahead and tagged this 1.0.0.