### PR TITLE
Add ElixirFormatter package

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -463,6 +463,16 @@
 			]
 		},
 		{
+			"name": "ElixirFormatter",
+			"details": "https://github.com/karolsluszniak/elixir-formatter-sublime",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ElixirPlayground",
 			"details": "https://github.com/gmcabrita/SublimeElixirPlayground",
 			"releases": [


### PR DESCRIPTION
Adds automatic formatting on save via Elixir formatter recently released in Elixir 1.6.

This is my first package release for Sublime and I'm not a regular Python developer so looking forward to any comments and change requests. Thank you.

In particular, I hope the way I've used threading goes ok with the way Sublime executes Python. It's threaded in order not to block editor during the formatting which takes ~0.5s after save, and yet to wait for formatting command result in order to log errors to Sublime console.