### PR TITLE
Added the package FixCommandPalette

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -964,6 +964,16 @@
 			]
 		},
 		{
+			"name": "FixCommandPalette",
+			"details": "https://github.com/evandrocoan/FixCommandPalette",
+			"releases": [
+				{
+					"sublime_text": ">=3126",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "FixMyJS",
 			"details": "https://github.com/addyosmani/sublime-fixmyjs",
 			"labels": ["formatting"],

--- a/repository/f.json
+++ b/repository/f.json
@@ -964,16 +964,6 @@
 			]
 		},
 		{
-			"name": "RememberCommandPaletteInput",
-			"details": "https://github.com/evandrocoan/RememberCommandPaletteInput",
-			"releases": [
-				{
-					"sublime_text": ">=3126",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "FixMyJS",
 			"details": "https://github.com/addyosmani/sublime-fixmyjs",
 			"labels": ["formatting"],

--- a/repository/f.json
+++ b/repository/f.json
@@ -964,8 +964,8 @@
 			]
 		},
 		{
-			"name": "FixCommandPalette",
-			"details": "https://github.com/evandrocoan/FixCommandPalette",
+			"name": "RememberCommandPaletteInput",
+			"details": "https://github.com/evandrocoan/RememberCommandPaletteInput",
 			"releases": [
 				{
 					"sublime_text": ">=3126",

--- a/repository/r.json
+++ b/repository/r.json
@@ -965,6 +965,16 @@
 			]
 		},
 		{
+			"name": "RememberCommandPaletteInput",
+			"details": "https://github.com/evandrocoan/RememberCommandPaletteInput",
+			"releases": [
+				{
+					"sublime_text": ">=3126",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Remify",
 			"details": "https://github.com/brousalis/remify",
 			"releases": [


### PR DESCRIPTION
Package: https://github.com/evandrocoan/FixCommandPalette

Force the Sublime Text command palette to remember the input text,
even after closing it after pressing the `escape` key, fixing the issue:

* https://github.com/SublimeTextIssues/Core/issues/1814 Command palette cleans the last command on escape key press

Also forces the command palette to make the initial text selected, fixing the regression created on
the Sublime Text build 3156:

* https://github.com/SublimeTextIssues/Core/issues/2083 Command palette text not selected between commands
