### PR TITLE
Add VSCodeColumnSelection

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -638,6 +638,16 @@
 			]
 		},
 		{
+			"name": "VSCodeColumnSelection",
+			"details": "https://github.com/acheronfail/VSCodeColumnSelection",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Vtex Snippets",
 			"details": "https://github.com/ricardodantas/Vtex-Snippets",
 			"releases": [


### PR DESCRIPTION
This package adds a mouse command that makes column selection similar to VSCode.
This will make it easier for those transitioning from that editor, or for those who regularly develop with both editors and sometimes find themselves getting confused between Sublime's column selection and VSCode's.

Basically, click once at "anchor" point, and then <kbd>shift</kbd> + <kbd>alt</kbd> + <kbd>click</kbd> at the other side of the column selection.

Example gif from package's [README](https://github.com/acheronfail/VSCodeColumnSelection):

![example gif](https://github.com/acheronfail/VSCodeColumnSelection/raw/master/example.gif)
