### PR TITLE
Add Syntax Package: SkoolkitZ80

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2045,6 +2045,17 @@
 			]
 		},
 		{
+			"name": "SkoolkitZ80",
+			"details": "https://github.com/mrcook/SkoolkitZ80",
+			"labels": ["language syntax", "z80", "assembly"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SLAB",
 			"details": "https://github.com/increpare/slab-markup-sublime",
 			"labels": ["language syntax"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -2050,7 +2050,7 @@
 			"labels": ["language syntax", "z80", "assembly"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

Z80 Assembly language syntax highlighting that is focused on the [Skoolkit](https://github.com/skoolkid/skoolkit) development environment.

The [z80asm](https://github.com/psbhlw/sublime-text-z80asm/tree/master/z80asm) package does handle Z80 assembly, but it is quite a heavy package that requires build tools of very specific 3rd party applications.

`SkoolkitZ80`'s intention is to remain lightweight, only providing syntax highlighting for Skoolkit files -- no build tools, and no custom menu items.

Many thanks for your consideration.