### PR TITLE
Added the portalock dependency to repository/dependencies.json

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -480,6 +480,20 @@
 			]
 		},
 		{
+			"name": "PortalockerFiles",
+			"author": "evandroforks",
+			"load_order": "08",
+			"description": "An extended version of PortalockerFiles to lock files in Python using the with statement",
+			"issues": "https://github.com/evandroforks/PortalockerFiles/issues",
+			"releases": [
+				{
+					"base": "https://github.com/evandroforks/PortalockerFiles",
+					"sublime_text": ">=3114",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "psutil",
 			"load_order": "01",
 			"description": "Python psutil module",


### PR DESCRIPTION
1. https://github.com/evandroforks/concurrent-log-handler 

Is a dependency required by:

1. https://github.com/wbond/package_control_channel/pull/6919 Added the dependency concurrent-log-handler to dependencies.json
