### PR TITLE
Added the dependency concurrent-log-handler to dependencies.json

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -89,6 +89,20 @@
 			]
 		},
 		{
+			"name": "ConcurrentLogHandler",
+			"author": "evandroforks",
+			"load_order": "09",
+			"description": "An additional concurrent file log handler for Python's standard logging package",
+			"issues": "https://github.com/evandroforks/ConcurrentLogHandler/issues",
+			"releases": [
+				{
+					"base": "https://github.com/evandroforks/ConcurrentLogHandler",
+					"sublime_text": ">=3114",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "coverage",
 			"load_order": "15",
 			"description": "coverage.py - http://coverage.readthedocs.org/en/latest/",


### PR DESCRIPTION
1. https://github.com/evandroforks/concurrent-log-handler 

Is a recent dependency required by:

1. https://github.com/wbond/package_control_channel/pull/6818 Added the PythonDebugTools on repository/dependencies.json
