### PR TITLE
Add Carbon package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -297,6 +297,16 @@
 			]
 		},
 		{
+			"name": "Carbon",
+			"details": "https://github.com/stianmartinsen/sublime-carbon-now-sh",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Carto",
 			"details": "https://github.com/yohanboniface/Carto-sublime",
 			"labels": ["Carto", "CartoCSS", "Mapnik", "OpenStreetMap", "language syntax"],


### PR DESCRIPTION
A simple package that sends the currently selected editor content to carbon.now.sh