### PR TITLE
add CMakeFormat (autoformatter for cmake)

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1509,6 +1509,17 @@
 			]
 		},
 		{
+			"name": "CMakeFormat",
+			"details": "https://github.com/jasjuang/sublime_cmake_format",
+			"labels": ["Format", "Beautifier", "Formatter", "CMake"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CMakeSnippets",
 			"details": "https://bitbucket.org/sevas/sublime_cmake_snippets",
 			"labels": ["snippets", "completion", "auto-complete"],


### PR DESCRIPTION
This is an autoformatter for CMake related files. It makes developer's life a lot easier. Please look at the [README](https://github.com/jasjuang/sublime_cmake_format) for more details.
