### PR TITLE
Add File Icons

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -589,6 +589,17 @@
 			]
 		},
 		{
+			"name": "FileIcons",
+			"details": "https://github.com/braver/FileIcons",
+			"labels": ["file", "icons"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "FileList",
 			"details": "https://github.com/shagabutdinov/sublime-file-list",
 			"donate": "https://github.com/shagabutdinov/sublime-enhanced/blob/master/readme-donations.md",


### PR DESCRIPTION
Adds a simpler alternative to [A File Icon](https://packagecontrol.io/packages/A%20File%20Icon):

- Doesn't introduce "alias" languages like "Javascript (Gulpfile)"
- No runtime code: no manipulation of settings or themes, no restarting, no "zzz" folder shenanigans
- No configuration: just uses existing theme override behaviour
- Easier to understand and maintain

It's not that A File Icon is bad or unmaintained (well, it isn't maintained really, but whatever). IMO it's severely over engineered and does things that are really unwise. It messes with user space stuff like settings for other packages and it's super hard to contribute to. A lot of people probably won't care, but I do and sometimes the community is better if it has some choice. 