### PR TITLE
Added PlantUmlDiagrams package and PlantUmlConnection dependency

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -480,6 +480,20 @@
 			]
 		},
 		{
+			"name": "PlantUmlConnection",
+			"author": "evandrocoan",
+			"load_order": "50",
+			"description": "Python interface to a plantuml web service instead of having to run Java locally",
+			"issues": "https://github.com/evandrocoan/PlantUmlConnection/issues",
+			"releases": [
+				{
+					"base": "https://github.com/evandrocoan/PlantUmlConnection",
+					"sublime_text": ">=3114",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "psutil",
 			"load_order": "01",
 			"description": "Python psutil module",

--- a/repository/p.json
+++ b/repository/p.json
@@ -1469,6 +1469,18 @@
 			]
 		},
 		{
+			"name": "PlantUmlDiagrams",
+			"details": "https://github.com/evandrocoan/PlantUmlDiagrams",
+			"labels": ["uml", "plantuml"],
+			"author": ["jvantuyl", "evandrocoan"],
+			"releases": [
+				{
+					"sublime_text": ">=3114",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "PlasticSCM",
 			"details": "https://github.com/ccll/sublime-plasticscm",
 			"labels": ["scm", "vcs"],


### PR DESCRIPTION
I forked https://github.com/jvantuyl/sublime_diagram_plugin to https://github.com/evandrocoan/PlantUmlDiagrams adding a server dependency https://github.com/evandrocoan/PlantUmlConnection and rewrote the whole git history removing all the java binary files which have been added, reducing the repository size from `22.49 MB` to `204 KB`. So, now I cannot open a pull request to the original author because git points out:
```
jvantuyl:master and evandroforks:master are entirely different commit histories.
```
If @jvantuyl would like to receive such changes, he would have to override his master branch with mine. If he do not like that, I would like to add this as an another package under a new name. Otherwise I can close this pull request.

On this fork I already manually merged the pull request from @overlord pending for his repository:

1. https://github.com/jvantuyl/sublime_diagram_plugin/pull/59 support [png, svg, txt, utxt, latex] output image formats

I also fix jvantuyl/sublime_diagram_plugin#60 (Error Processing Diagram) the default example not compiling, also adding to output the error message from the `Plantuml` software.

This version now first attempts to contact the webserver accordingly to the new settings:
```javascript
    // valid values:
    // 'png'              generate images using PNG format
    // 'svg'              generate images using SVG format
    // 'txt'              generate images with ASCII art
    // 'utxt'             generate images with ASCII art using Unicode characters
    // 'latex'            generate images using LaTeX/Tikz format
    // 'latex:nopreamble' generate images using LaTeX/Tikz format without preamble
    //
    // These formats are also supported by plantUml, but they need some
    // prerequisite to be installed... PlantUml return_code = 1 on invocation:
    // 'pdf' generate images using PDF format
    // 'vdx' generate images using VDX format
    // 'eps' generate images using EPS format
    "output_format": "png",

    // It will first try to use the server, because is much more faster than
    // calling directly the jar. If you would like to run a local server,
    // you can install it from: https://github.com/plantuml/plantuml-server
    "plantuml_server": "http://www.plantuml.com/plantuml/",

    // The full path to the plantuml.jar file
    "jar_file": "C:/Users/plantuml.jar",
```