### PR TITLE
Inform 6 syntax highlighting for Sublime Text

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -558,6 +558,16 @@
 			]
 		},
 		{
+			"name": "Inform 6",
+			"details": "https://github.com/yandexx/sublime-inform6",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "INI",
 			"details": "https://github.com/clintberry/sublime-text-2-ini",
 			"releases": [


### PR DESCRIPTION
Syntax highlighting for Inform 6 didn't exist as a package before, but just as a file randomly passed around.