### PR TITLE
adding lazy unittester package entry

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -466,6 +466,17 @@
 			]
 		},
 		{
+			"name": "Lazy Unittester",
+			"details": "https://github.com/connor-philip/lazy_unit_tester",
+			"labels": ["Python", "Unittesting"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LazyTimeTracker",
 			"details": "https://github.com/Bwata/LazyTimeTracker",
 			"labels": ["Time", "tracking"],

--- a/repository/l.json
+++ b/repository/l.json
@@ -468,9 +468,8 @@
 		{
 			"name": "Lazy Unittester",
 			"author": "Connor Philip",
-			"description": "Creates Python unittest stubs",
 			"details": "https://github.com/connor-philip/lazy_unit_tester",
-			"labels": ["Python", "Unittesting"],
+			"labels": ["python", "testing"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/l.json
+++ b/repository/l.json
@@ -467,6 +467,7 @@
 		},
 		{
 			"name": "Lazy Unittester",
+			"description": "Creates Python unittest stubs",
 			"details": "https://github.com/connor-philip/lazy_unit_tester",
 			"labels": ["Python", "Unittesting"],
 			"releases": [

--- a/repository/l.json
+++ b/repository/l.json
@@ -467,6 +467,7 @@
 		},
 		{
 			"name": "Lazy Unittester",
+			"author": "Connor Philip",
 			"description": "Creates Python unittest stubs",
 			"details": "https://github.com/connor-philip/lazy_unit_tester",
 			"labels": ["Python", "Unittesting"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

### Lazy Unittester
This package creates python unittest stubs from a file containing your functions.
More details and example can be found [here](https://github.com/connor-philip/lazy_unit_tester).

I haven't updated the readme of the repo to include plugin details as of yet, as it's not officially an available plugin in package control. I plan to update the readme if this package is accepted.
