### PR TITLE
Adding Sf4Helpers to repo list

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1249,6 +1249,20 @@
 			]
 		},
 		{
+			"name": "Sf4Helpers",
+			"description": "Symfony 4 command line helpers for Sublime",
+			"details": "https://github.com/HeyIAmBob/sublime-sf4helpers",
+			"issues": "https://github.com/HeyIAmBob/sublime-sf4helpers/issues",
+			"labels": ["Symfony", "Symfony4"],
+			"releases": [
+				{
+					"platforms": ["osx"],
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SfCommand",
 			"details": "https://github.com/jtwebb/sfcommand",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -1250,10 +1250,8 @@
 		},
 		{
 			"name": "Sf4Helpers",
-			"description": "Symfony 4 command line helpers for Sublime",
 			"details": "https://github.com/HeyIAmBob/sublime-sf4helpers",
-			"issues": "https://github.com/HeyIAmBob/sublime-sf4helpers/issues",
-			"labels": ["Symfony", "Symfony4"],
+			"labels": ["Symfony", "Symfony4", "php"],
 			"releases": [
 				{
 					"platforms": ["osx"],


### PR DESCRIPTION
Symfony4 Helpers let you use Symfony4 main command line directly from Sublime Text via the command palette. All the commands available are listed in the github readme

As I know, it's the first plugin for symfony4, older version aren't compatible.

<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
