### PR TITLE
Move OverrideAudit to new package repository file

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -103,6 +103,7 @@
 		"https://raw.githubusercontent.com/sokolovstas/SublimeWebInspector/master/packages.json",
 		"https://raw.githubusercontent.com/soncy/AutoComments-for-Sublime-Text-2/master/packages.json",
 		"https://raw.githubusercontent.com/spectacles/CodeComplice/master/packages.json",
+		"https://raw.githubusercontent.com/STealthy-and-haSTy/SublimePackages/master/packages.json",
 		"https://raw.githubusercontent.com/SublimeLinter/package_control_channel/master/packages.json",
 		"https://raw.githubusercontent.com/superbob/SublimeTextLanguageFrench/master/packages.json",
 		"https://raw.githubusercontent.com/tbfisher/sublimetext-Pandoc/master/packages.json",

--- a/repository/o.json
+++ b/repository/o.json
@@ -866,16 +866,6 @@
 			]
 		},
 		{
-			"name": "OverrideAudit",
-			"details": "https://github.com/OdatNurd/OverrideAudit",
-			"releases": [
-				{
-					"sublime_text": ">=3092",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Owl Color Scheme",
 			"details": "https://github.com/omnus/owl_color_scheme/",
 			"releases": [


### PR DESCRIPTION
This adds a new organization specific package repository file to the
channel.json file and moves the existing OverrideAudit package entry
from the o.json file in this repository to the new repository file.

The OverrideAudit entry has been augmented with a specific README URL,
home page entry and some labels.

Channel Repository Tools has been used to verify that the new
repository file in the STealthy-and-haSTy organization is valid as
well as the changed made to the channel.json and o.json in the
default channel.

<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
