### PR TITLE
Add meta information for `UrlConverter` package.

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -484,6 +484,8 @@
 		{
 			"name": "UrlConverter",
 			"details": "https://github.com/gh640/SublimeUrlConverter",
+			"author": "Goto Hayato",
+			"labels": ["url", "link", "html", "markdown", "restructuredtext"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
I submitted a package named [`UrlConverter`](https://packagecontrol.io/packages/UrlConverter) before and I forgot to add the meta information like `author` and `labels` then... I'm sorry for taking your time but I'd like to submit this merge request to modify the information for the package. Thank you in advance.