### PR TITLE
add ACF Programmatic Fields Package

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -124,8 +124,8 @@
 			]
 		},
 		{
-			"name": "ACF Snippets",
-			"details": "https://github.com/iamhexcoder/acf_snippets",
+			"name": "ACF Programmatic Fields",
+			"details": "https://github.com/timlogemann/sublime-acf-snippets",
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -134,8 +134,8 @@
 			]
 		},
 		{
-			"name": "ACF Programmatic Fields",
-			"details": "https://github.com/timlogemann/sublime-acf-snippets",
+			"name": "ACF Snippets",
+			"details": "https://github.com/iamhexcoder/acf_snippets",
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/a.json
+++ b/repository/a.json
@@ -134,14 +134,14 @@
 			]
 		},
 		{
-		  "name": "ACF Programmatic Fields",
-		  "details": "https://github.com/timlogemann/sublime-acf-snippets",
-		  "releases": [
-		    {
-		      "sublime_text": "*",
-		      "tags": true
-		    }
-		  ]
+			"name": "ACF Programmatic Fields",
+			"details": "https://github.com/timlogemann/sublime-acf-snippets",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
 		},
 		{
 			"name": "Achievement",

--- a/repository/a.json
+++ b/repository/a.json
@@ -134,6 +134,16 @@
 			]
 		},
 		{
+		  "name": "ACF Programmatic Fields",
+		  "details": "https://github.com/timlogemann/sublime-acf-snippets",
+		  "releases": [
+		    {
+		      "sublime_text": "*",
+		      "tags": true
+		    }
+		  ]
+		},
+		{
 			"name": "Achievement",
 			"details": "https://github.com/airtoxin/Achievement",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->

Although similar to the existing ACF Snippets package, as they both add snippets for the WordPress plugin "Advanced Custom Fields", the difference is is in the snippets added, and their use cases.

The existing ACF snippets package allows the user to retreive data from fields. My package adds snippets to allow the user to create fields.
