### PR TITLE
Changing name of MinecraftCommandCode

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -630,6 +630,17 @@
 			]
 		},
 		{
+			"name": "Marshal Command Code",
+			"previous_names": ["MinecraftCommandCode"],
+			"details": "https://github.com/42iscool42/MCC",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags":true
+				}
+			]
+		},
+		{
 			"name": "Mask",
 			"details": "https://github.com/tenbits/sublime-mask",
 			"releases": [
@@ -1364,16 +1375,6 @@
 				{
 					"sublime_text": "*",
 					"tags": true
-				}
-			]
-		},
-		{
-			"name": "MinecraftCommandCode",
-			"details": "https://github.com/42iscool42/MCC",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags":true
 				}
 			]
 		},


### PR DESCRIPTION
We have changed the name of this project and hope to get this changed in package control.