### PR TITLE
Rename MBXTools -> PreTeXtual (retry)

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -957,18 +957,6 @@
 			]
 		},
 		{
-			"name": "MBXTools",
-			"details": "https://github.com/daverosoff/mbxtools",
-			"author": "Dave Rosoff",
-			"labels": ["mbx", "mathbook xml", "language syntax", "auto-complete"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "MCA Language",
 			"details": "https://github.com/toxic-spanner/MCA.tmLanguage",
 			"author": "mrfishie",

--- a/repository/p.json
+++ b/repository/p.json
@@ -1938,6 +1938,19 @@
 			]
 		},
 		{
+			"name": "PreTeXtual",
+			"previous_names": ["MBXTools"],
+			"details": "https://github.com/daverosoff/PreTeXtual",
+			"author": "Dave Rosoff",
+			"labels": ["mbx", "mathbook xml", "pretext", "ptx"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Pretty JSON",
 			"details": "https://github.com/dzhibas/SublimePrettyJson",
 			"labels": ["json", "pretty", "lint", "minify", "validate", "query", "json2xml"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
This is a rename request; previously (#6959) @FichteFoll asked me to fix the warning generated by a lack of `.tmLanguage` file matching the `.sublime-syntax` file. I have specified that ST needs version >=3092 to rectify this issue. Thanks.