### PR TITLE
Fixed STProjectMaker's entry

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3491,10 +3491,12 @@
 			]
 		},
 		{
-			"details": "https://github.com/bit101/STProjectMaker",
+			"name": "STProjectMaker",
+			"labels": ["project", "template", "jinja2"],
+			"details": "https://github.com/bit101/ProjectMaker/tree/20598b62dc8cb6450a0bd407f9ad6a50e2abe9bc",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3000",
 					"branch": "master"
 				}
 			]


### PR DESCRIPTION
The repository was recently renamed to `ProjectMaker` to give that plugin a cleaner name.
Subsequently it got missing from package control.
Unfortunately packagecontrol then fetched the unreleased, now backwards incompatible, master branch.
Until we release `ProjectMaker2.0`, I like packagecontrol to only fetch the last fully working commit.

<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
