### PR TITLE
Add Folder Aliaser

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1295,6 +1295,16 @@
 			]
 		},
 		{
+			"name": "Folder Aliaser",
+			"details": "https://github.com/tmelot2/folder-aliaser",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Folder List",
 			"details": "https://github.com/sheldon/sublime-text-2-folder-list",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
Allows you to alias your top-level project folders quickly and easily! 

There exists a similar project (FolderAlias by rablador, see Thanks section in readme) that is no longer maintained. The goal of this project was to have something simpler from both user and developer perspectives; and to have something that is maintained should issues arise. This project is currently more singular in focus and code easier to understand.