### PR TITLE
Update CommandOnSave

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2766,7 +2766,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},

--- a/repository/c.json
+++ b/repository/c.json
@@ -2762,10 +2762,10 @@
 		},
 		{
 			"name": "CommandOnSave",
-			"details": "https://github.com/klaascuvelier/ST2-CommandOnSave",
+			"details": "https://github.com/klaascuvelier/SublimeCommandOnSave",
 			"releases": [
 				{
-					"sublime_text": "<3000",
+					"sublime_text": ">=3000",
 					"branch": "master"
 				}
 			]


### PR DESCRIPTION
Updating the package CommandOnSave:
- Remove <3000 version and point to the newest repo
- Use tags instead