### PR TITLE
added OAT syntax highlighting package

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -13,6 +13,17 @@
 			]
 		},
 		{
+			"name": "OAT Syntax",
+			"details": "https://github.com/dylanmann/SublimeOatSyntaxHighlighting",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "objc .strings syntax language",
 			"details": "https://github.com/PaNaVTEC/Objc-Strings-Syntax-Language",
 			"labels": ["language syntax"],


### PR DESCRIPTION
This is a simple syntax highlighting file for OAT code, which is written in the undergraduate compilers class at Penn [(website here)](https://www.cis.upenn.edu/~cis341/current/).