### PR TITLE
add RSpec Buddy plugin

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1680,6 +1680,17 @@
 			]
 		},
 		{
+      "name": "RSpec Buddy",
+      "details": "https://github.com/glaucocustodio/rspec-buddy-for-sublime-text",
+      "labels": ["language syntax", "snippets"],
+      "releases": [
+        {
+          "sublime_text": ">=3000",
+          "branch": "master"
+        }
+      ]
+		},
+		{
 			"name": "RSpecNavigator",
 			"details": "https://github.com/jugyo/SublimeRSpecNavigator",
 			"releases": [

--- a/repository/r.json
+++ b/repository/r.json
@@ -1680,15 +1680,15 @@
 			]
 		},
 		{
-      "name": "RSpec Buddy",
-      "details": "https://github.com/glaucocustodio/rspec-buddy-for-sublime-text",
-      "labels": ["language syntax", "snippets"],
-      "releases": [
-        {
-          "sublime_text": ">=3000",
-          "tags": true
-        }
-      ]
+			"name": "RSpec Buddy",
+			"details": "https://github.com/glaucocustodio/rspec-buddy-for-sublime-text",
+			"labels": ["language syntax", "snippets"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
 		},
 		{
 			"name": "RSpecNavigator",

--- a/repository/r.json
+++ b/repository/r.json
@@ -1686,7 +1686,7 @@
       "releases": [
         {
           "sublime_text": ">=3000",
-          "branch": "master"
+          "tags": true
         }
       ]
 		},

--- a/repository/r.json
+++ b/repository/r.json
@@ -1660,6 +1660,17 @@
 			]
 		},
 		{
+			"name": "RSpec Buddy",
+			"details": "https://github.com/glaucocustodio/rspec-buddy-for-sublime-text",
+			"labels": ["language syntax", "snippets"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/kazshu/rspec-snippets",
 			"labels": ["snippets"],
 			"releases": [
@@ -1676,17 +1687,6 @@
 				{
 					"sublime_text": "<3000",
 					"branch": "master"
-				}
-			]
-		},
-		{
-			"name": "RSpec Buddy",
-			"details": "https://github.com/glaucocustodio/rspec-buddy-for-sublime-text",
-			"labels": ["language syntax", "snippets"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

Please ensure the automated reviews pass. Follow the instructions provided, if necessary.
You can speed up the process by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    ([versioning docs](https://packagecontrol.io/docs/submitting_a_package#Step_4))
 2. Added a readme to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You may proceed with a short description of what the package does and, 
in case a similar package already exists, 
why you believe it is needed
below this line. -->
RSpec syntax highlighting, implementation/spec toggling command, snippets and support for config file.

A modified fork of https://github.com/fnando/better-rspec-for-sublime-text.

What is different?

- the original seems to be unmantained since 2015
- it reads a .rspec-buddy file so you can customize the path to ignore when looking for spec and implementation files
- it has less snippets (just the ones I use often)
- some handy little tweaks
