### PR TITLE
Changes to "faclessuser" packages

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1458,10 +1458,6 @@
 			"details": "https://github.com/facelessuser/ApplySyntax",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"tags": "st2-"
-				},
-				{
 					"sublime_text": ">=3000",
 					"tags": "st3-"
 				}

--- a/repository/b.json
+++ b/repository/b.json
@@ -1193,10 +1193,6 @@
 			"details": "https://github.com/facelessuser/BracketHighlighter",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"tags": "st2-"
-				},
-				{
 					"sublime_text": ">=3000",
 					"tags": "st3-"
 				}

--- a/repository/e.json
+++ b/repository/e.json
@@ -1453,10 +1453,6 @@
 			"details": "https://github.com/facelessuser/ExportHtml",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"tags": "st2-"
-				},
-				{
 					"sublime_text": ">=3000",
 					"tags": "st3-"
 				}

--- a/repository/f.json
+++ b/repository/f.json
@@ -292,10 +292,6 @@
 			"details": "https://github.com/facelessuser/FavoriteFiles",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"tags": "st2-"
-				},
-				{
 					"sublime_text": ">=3000",
 					"tags": "st3-"
 				}
@@ -1750,10 +1746,6 @@
 		{
 			"details": "https://github.com/facelessuser/FuzzyFileNav",
 			"releases": [
-				{
-					"sublime_text": "<3000",
-					"tags": "st2-"
-				},
 				{
 					"sublime_text": ">=3000",
 					"tags": "st3-"

--- a/repository/h.json
+++ b/repository/h.json
@@ -456,10 +456,6 @@
 			"details": "https://github.com/facelessuser/HexViewer",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"tags": "st2-"
-				},
-				{
 					"sublime_text": ">=3000",
 					"tags": "st3-"
 				}

--- a/repository/m.json
+++ b/repository/m.json
@@ -421,18 +421,6 @@
 			]
 		},
 		{
-			"name": "MarkdownPreview",
-			"details": "https://github.com/facelessuser/MarkdownPreview",
-			"labels": ["markdown", "preview", "build"],
-			"previous_names": ["Markdown Preview"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": "st3-"
-				}
-			]
-		},
-		{
 			"name": "Markdown Slideshow",
 			"details": "https://github.com/ogom/sublimetext-markdown-slideshow",
 			"releases": [
@@ -553,6 +541,18 @@
 				{
 					"sublime_text": ">=3000",
 					"tags": true
+				}
+			]
+		},
+		{
+			"name": "MarkdownPreview",
+			"details": "https://github.com/facelessuser/MarkdownPreview",
+			"labels": ["markdown", "preview", "build"],
+			"previous_names": ["Markdown Preview"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": "st3-"
 				}
 			]
 		},

--- a/repository/m.json
+++ b/repository/m.json
@@ -421,13 +421,14 @@
 			]
 		},
 		{
-			"name": "Markdown Preview",
-			"details": "https://github.com/revolunet/sublimetext-markdown-preview",
+			"name": "MarkdownPreview",
+			"details": "https://github.com/facelessuser/MarkdownPreview",
 			"labels": ["markdown", "preview", "build"],
+			"previous_names": ["Markdown Preview"],
 			"releases": [
 				{
-					"sublime_text": "*",
-					"tags": true
+					"sublime_text": ">=3000",
+					"tags": "st3-"
 				}
 			]
 		},

--- a/repository/r.json
+++ b/repository/r.json
@@ -890,10 +890,6 @@
 			"details": "https://github.com/facelessuser/RegReplace",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"tags": "st2-"
-				},
-				{
 					"sublime_text": ">=3000",
 					"tags": "st3-"
 				}

--- a/repository/s.json
+++ b/repository/s.json
@@ -483,10 +483,6 @@
 			"details": "https://github.com/facelessuser/ScopeHunter",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"tags": "st2-"
-				},
-				{
 					"sublime_text": ">=3000",
 					"tags": "st3-"
 				}
@@ -1111,10 +1107,6 @@
 			"details": "https://github.com/facelessuser/SerializedDataConverter",
 			"previous_names": ["PlistJsonConverter"],
 			"releases": [
-				{
-					"sublime_text": "<3000",
-					"tags": "st2-"
-				},
 				{
 					"sublime_text": ">=3000",
 					"tags": "st3-"


### PR DESCRIPTION
- ST2 support has been removed from all "facelessuser" packages
- Markdown Preview is now under the support of "facelessuser" and has dropped ST2  support and been renamed to `MarkdownPreview`.
