### PR TITLE
Renaming Robot Framework Assistant to RobotFrameworkAssistant

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1475,7 +1475,7 @@
 			]
 		},
 		{
-			"name": "Robot Framework Assistant",
+			"name": "RobotFrameworkAssistant",
 			"details": "https://github.com/andriyko/sublime-robot-framework-assistant",
 			"releases": [
 				{

--- a/repository/r.json
+++ b/repository/r.json
@@ -1477,7 +1477,7 @@
 		{
 			"name": "RobotFrameworkAssistant",
 			"details": "https://github.com/andriyko/sublime-robot-framework-assistant",
-		  	"previous_names": ["Robot Framework Assistant"],
+			"previous_names": ["Robot Framework Assistant"],
 			"releases": [
 				{
 					"sublime_text": "<3000",

--- a/repository/r.json
+++ b/repository/r.json
@@ -1477,6 +1477,7 @@
 		{
 			"name": "RobotFrameworkAssistant",
 			"details": "https://github.com/andriyko/sublime-robot-framework-assistant",
+		  	"previous_names": ["Robot Framework Assistant"],
 			"releases": [
 				{
 					"sublime_text": "<3000",


### PR DESCRIPTION
To ease importing in package
