### PR TITLE
Add svelte syntax definition package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -4871,6 +4871,16 @@
 			]
 		},
 		{
+			"name": "Svelte",
+			"details": "https://github.com/corneliusio/svelte-sublime",
+			"releases": [
+				{
+					"sublime_text": ">=3153",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SVG Icon Snippets",
 			"details": "https://github.com/idleberg/sublime-svg-icons",
 			"labels": ["snippets", "auto-complete", "svg", "svg icons"],


### PR DESCRIPTION
This package adds syntax highlighting for components built with [Svelte](https://svelte.technology/).  
No such package exists yet.