### PR TITLE
Add NumberFormatter Plugin

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -1020,6 +1020,17 @@
 			]
 		},
 		{
+			"name": "NumberFormatter",
+			"details": "https://github.com/ilyakam/NumberFormatter",
+			"labels": ["format numbers", "unformat numbers", "thousands separator", "decimal separator"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Numix Theme",
 			"details": "https://github.com/nauzethc/sublime-text-numix",
 			"labels": ["numix", "theme"],


### PR DESCRIPTION
# NumberFormatter - A Sublime Text Plugin

This [Sublime Text](http://www.sublimetext.com/) plugin formats plain numbers by adding a thousands separator to them. It also unformats them in reverse. See the [Features](#features) section below for details.

## Features:

As long as the number is partially or fully selected, or while the cursor is on the number, this plugin will format or unformat it in the following way:

| Before      | After       |
| ----------- | ----------- |
| `12345`     | `12,345`    |
| `12,345`    | `12345`     |
| `12345.67`  | `12,345.67` |
| `12,345.67` | `12345.67`  |

This plugin supports multiple cursors and multiple selections. It can process both formatted and unformatted numbers in one go.

---

Please see [the plugin's homepage](https://github.com/ilyakam/NumberFormatter) for mode details.