### PR TITLE
Add Z80 Assembly syntax package

### DIFF
--- a/repository/z.json
+++ b/repository/z.json
@@ -13,6 +13,17 @@
 			]
 		},
 		{
+			"name": "Z80 Assembly",
+			"details": "https://github.com/mrcook/Z80Assembly",
+			"labels": ["language syntax", "z80", "assembly"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://bitbucket.org/abraly/zap-gremlins",
 			"releases": [
 				{


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->

A syntax highlighting package for the Z80 assembly language.

This package has been built to the [Pasmo assembler](http://pasmo.speccy.org/pasmodoc.html) specification, which itself is compatible with various other assemblers, so should be quite usable for anyone programming for the ZX Spectrum or other Z80 machines.

Many thanks for your consideration.
