### PR TITLE
constellation: require st3 3161+

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3060,7 +3060,7 @@
 			"details": "https://github.com/abathur/constellation",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=3161",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
@Thom1729 Sorry to make more work. This raises the version requirement to the one that was current when I started work on the extension.

After you merged #7052 I gave this a try on an old system that still had a ST3 install at 3143 and it's having API errors (not finding sublime_plugin.TextInputHandler) I had previously browsed the recent changenotes for anything that looked clearly related to the API features I'm using and didn't see much.
