### PR TITLE
FIX: retitle Chrome REPL > ChromeREPL to fix imports

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -998,7 +998,7 @@
 			]
 		},
 		{
-			"name": "Chrome REPL",
+			"name": "ChromeREPL",
 			"details": "https://github.com/acarabott/ChromeREPL",
 			"releases": [
 				{

--- a/repository/c.json
+++ b/repository/c.json
@@ -998,16 +998,6 @@
 			]
 		},
 		{
-			"name": "ChromeREPL",
-			"details": "https://github.com/acarabott/ChromeREPL",
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Chrome Snippets",
 			"details": "https://github.com/ismnoiet/ChromeSnippets",
 			"releases": [
@@ -1023,6 +1013,16 @@
 			"releases": [
 				{
 					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "ChromeREPL",
+			"details": "https://github.com/acarabott/ChromeREPL",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]
@@ -4309,7 +4309,7 @@
 					"tags": true
 				}
 			]
-		},		
+		},
 		{
 			"name": "Cycle Setting",
 			"details": "https://github.com/jmm/Sublime-Text-Cycle-Setting/tree/package-control",


### PR DESCRIPTION
Renamed the Package from "Chrome REPL" to "ChromeREPL" as the name determines the installed `.sublime-package` file, and thus imports such as `ChromeREPL.helpers` are broken.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
