### PR TITLE
add eslint fix

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -1113,6 +1113,16 @@
 			]
 		},
 		{
+			"name": "ESLint Fix",
+			"details": "https://github.com/kufii/Sublime-ESLint-Fix",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ESLint-Formatter",
 			"details": "https://github.com/TheSavior/ESLint-Formatter",
 			"releases": [


### PR DESCRIPTION
runs eslint --fix on the current file

This differs from the other ESLint plugins in the repository because it runs the fix on the current buffer, instead of the last saved instance. I tried creating PRs to other plugins before creating this plugin but they've been ignored for months.