### PR TITLE
Add Mojom syntax definition URL to channel.json

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -95,6 +95,7 @@
 		"https://raw.githubusercontent.com/royisme/SublimeOctopressTool/master/packages.json",
 		"https://raw.githubusercontent.com/rpowers/sublime_stata/master/packages.json",
 		"https://raw.githubusercontent.com/rse/sublime-scheme-rse/master/packages.json",
+		"https://raw.githubusercontent.com/sdefresne/sublime-mojom/master/packages.json",
 		"https://raw.githubusercontent.com/sdolard/sublime-jsrevival/master/packages.json",
 		"https://raw.githubusercontent.com/seanliang/ConvertToUTF8/master/packages.json",
 		"https://raw.githubusercontent.com/sentience/DokuWiki/master/packages.json",


### PR DESCRIPTION
This package provides syntax highlighting for [mojo binding definition files](https://chromium.googlesource.com/chromium/src/+/master/mojo/README.md).