### PR TITLE
Add VintageColor package

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -414,7 +414,7 @@
 		},
 		{
 			"name": "VintageColor",
-			"details": "https://github.com/acarabott/package_control_channel",
+			"details": "https://github.com/acarabott/VintageColor",
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/v.json
+++ b/repository/v.json
@@ -413,6 +413,16 @@
 			]
 		},
 		{
+			"name": "VintageColor",
+			"details": "https://github.com/acarabott/package_control_channel",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "VintageES",
 			"details": "https://github.com/SublimeText/Vintage-Extended-Support",
 			"releases": [


### PR DESCRIPTION
This package allows you to set different color schemes for the different Vintage modes: `Insert`, `Command` and `Visual`/`Visual Line`, making it easier to determine the current mode, and reducing errors.

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
