### PR TITLE
[DistractionFreeWindow] separate tag prefixes

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -807,8 +807,12 @@
 			"labels": ["fullscreen", "distraction-free"],
 			"releases": [
 				{
-					"sublime_text": "*",
-					"tags": true
+					"sublime_text": "<3000",
+					"tags": "st2-"
+				},
+				{
+					"sublime_text": ">=3000",
+					"tags": "st3-"
 				}
 			]
 		},


### PR DESCRIPTION
Separate releases by tag prefix for `DistractionFreeWindow`:

* <https://github.com/aziz/DistractionFreeWindow>
* <https://packagecontrol.io/packages/DistractionFreeWindow>