### PR TITLE
split FileIcons into color and mono releases

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -624,7 +624,19 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"tags": true
+					"tags": "color-"
+				}
+			]
+		},
+		{
+			"name": "FileIcons Mono",
+			"details": "https://github.com/braver/FileIcons",
+			"readme": "https://raw.githubusercontent.com/braver/FileIcons/mono/README.md",
+			"labels": ["file", "icons"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": "mono-"
 				}
 			]
 		},


### PR DESCRIPTION
I hope I did this correctly. Monochrome releases are tagged on the `mono` branch and prefixed with `mono-`, the original color releases now also have `color-` prefixes to match.