### PR TITLE
add xcode colors

### DIFF
--- a/repository/x.json
+++ b/repository/x.json
@@ -45,6 +45,17 @@
 			]
 		},
 		{
+			"name": "Xcode Colors",
+			"details": "https://github.com/braver/XcodeColors",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": ">3174",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Xdebug",
 			"details": "https://github.com/Kindari/SublimeXdebug",
 			"releases": [


### PR DESCRIPTION
Adds color schemes (currently only one) inspired by color schemes built into Xcode. Primarily because Sublime lacks high contrast light color schemes and Xcode's default is pretty damn nice.