### PR TITLE
Add syntax highlighter for the eno notation language

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -909,6 +909,16 @@
 			]
 		},
 		{
+			"name": "eno",
+			"details": "https://github.com/eno-lang/sublime-eno",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Ensime",
 			"author": "The Ensime committers",
 			"details": "https://github.com/ensime/ensime-sublime",


### PR DESCRIPTION
This adds a package that offers syntax highlighting support for the eno notation language (https://eno-lang.org)

I'm deeply impressed that all of this is being reviewed manually. :bowing_man:
Thanks so much, you rock!