### PR TITLE
Renamed Amxmodx package to AmxxEditor

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -766,10 +766,9 @@
 			]
 		},
 		{
-			"name": "Amxmodx",
-			"details": "https://github.com/evandrocoan/AmxxEditor",
-			"labels": ["autocompletion", "auto-complete", "amxmodx", "amx mod x", "amxx", "pawn", "build system"],
-			"previous_names": ["amxmodx"],
+			"name": "Amxx Pawn",
+			"details": "https://github.com/evandrocoan/SublimeAmxxPawn",
+			"labels": ["language syntax", "amxmodx", "amx mod x"],
 			"releases": [
 				{
 					"sublime_text": ">=3114",
@@ -778,9 +777,10 @@
 			]
 		},
 		{
-			"name": "Amxx Pawn",
-			"details": "https://github.com/evandrocoan/SublimeAmxxPawn",
-			"labels": ["language syntax", "amxmodx", "amx mod x"],
+			"name": "AmxxEditor",
+			"details": "https://github.com/evandrocoan/AmxxEditor",
+			"labels": ["autocompletion", "auto-complete", "amxmodx", "amx mod x", "amxx", "pawn", "build system"],
+			"previous_names": ["Amxmodx"],
 			"releases": [
 				{
 					"sublime_text": ">=3114",


### PR DESCRIPTION
The original package I forked this is named `amxmodx` and it not available on package control, however they can install it externally: https://forums.alliedmods.net/showthread.php?p=2603984#post2603984

And it is causing the original package to be replaced with this. Then, I am renaming it to `AmxxEditor` and after a month this is merged, I am opening another pull request removing the previous names `Amxmodx`.

For now, I am orienting the users of the original package to add `Amxmodx` package to the `auto_upgrade_ignore` setting, until this is completely fixed.