### PR TITLE
Renamed Amxx Pawn to AmxxPawn

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -778,8 +778,9 @@
 			]
 		},
 		{
-			"name": "Amxx Pawn",
+			"name": "AmxxPawn",
 			"details": "https://github.com/evandrocoan/SublimeAmxxPawn",
+			"previous_names": ["Amxx Pawn"],
 			"labels": ["language syntax", "amxmodx", "amx mod x"],
 			"releases": [
 				{


### PR DESCRIPTION
I removed the space from the package name a long time ago, but forgot to update it here.