### PR TITLE
Removed "previous_names": ["BBCode"], from "BBCode Syntax"

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -218,7 +218,6 @@
 			"name": "BBCode Syntax",
 			"details": "https://github.com/chipotle/BBCode",
 			"labels": ["language syntax"],
-			"previous_names": ["BBCode"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
This renaming is quite annoying because I use a private channel where I have this package named `BBCode`. However, as I also have the standard channel, Package Control keeps renaming my package from `BBCode` to `BBCode Syntax`.

There is a long time this package was renamed. So, no one nowadays should be using it with his old name.