### PR TITLE
add SCSS and Sass package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -629,7 +629,7 @@
 			"labels": ["language syntax", "scss", "sass", "completions"],
 			"releases": [
 				{
-					"sublime_text": ">3000",
+					"sublime_text": ">3092",
 					"tags": true
 				}
 			]

--- a/repository/s.json
+++ b/repository/s.json
@@ -160,9 +160,8 @@
 			]
 		},
 		{
-			"name": "Sass",
+			"name": "Syntax Highlighting for Sass",
 			"details": "https://github.com/P233/Syntax-highlighting-for-Sass",
-			"previous_names": ["Syntax Highlighting for Sass"],
 			"labels": ["language syntax"],
 			"releases": [
 				{
@@ -624,7 +623,7 @@
 			]
 		},
 		{
-			"name": "SCSS and Sass",
+			"name": "Sass",
 			"details": "https://github.com/braver/SublimeSass",
 			"labels": ["language syntax", "scss", "sass", "completions", "snippets"],
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -624,6 +624,17 @@
 			]
 		},
 		{
+			"name": "SCSS and Sass",
+			"details": "https://github.com/braver/SublimeSass",
+			"labels": ["language syntax", "scss", "sass", "completions"],
+			"releases": [
+				{
+					"sublime_text": ">3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SCSS Compiler",
 			"details": "https://github.com/mattarnster/scsscompiler",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -626,7 +626,7 @@
 		{
 			"name": "SCSS and Sass",
 			"details": "https://github.com/braver/SublimeSass",
-			"labels": ["language syntax", "scss", "sass", "completions"],
+			"labels": ["language syntax", "scss", "sass", "completions", "snippets"],
 			"releases": [
 				{
 					"sublime_text": ">3092",

--- a/repository/s.json
+++ b/repository/s.json
@@ -160,16 +160,12 @@
 			]
 		},
 		{
-			"name": "Syntax Highlighting for Sass",
-			"details": "https://github.com/P233/Syntax-highlighting-for-Sass",
-			"labels": ["language syntax"],
+			"name": "Sass",
+			"details": "https://github.com/braver/SublimeSass",
+			"labels": ["language syntax", "scss", "sass", "completions", "snippets"],
 			"releases": [
 				{
-					"sublime_text": "<3103",
-					"branch": "ST2"
-				},
-				{
-					"sublime_text": ">=3103",
+					"sublime_text": ">3092",
 					"tags": true
 				}
 			]
@@ -619,17 +615,6 @@
 					"sublime_text": "*",
 					"base": "https://github.com/MarioRicalde/SCSS.tmbundle",
 					"branch": "SublimeText2"
-				}
-			]
-		},
-		{
-			"name": "Sass",
-			"details": "https://github.com/braver/SublimeSass",
-			"labels": ["language syntax", "scss", "sass", "completions", "snippets"],
-			"releases": [
-				{
-					"sublime_text": ">3092",
-					"tags": true
 				}
 			]
 		},
@@ -5407,6 +5392,21 @@
 			"releases": [
 				{
 					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "Syntax Highlighting for Sass",
+			"details": "https://github.com/P233/Syntax-highlighting-for-Sass",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "<3103",
+					"branch": "ST2"
+				},
+				{
+					"sublime_text": ">=3103",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This publishes a new package for [SCSS and Sass](https://sass-lang.com). 

There are currently several packages that provide syntax  definitions and completions for this language, none of which are actively maintained. 

- [SCSS](https://packagecontrol.io/packages/SCSS) is actually an old TextMate bundle, which given the current state of TM is of course RIP. I don't think it makes sense to replace this package, although it's a shame it's so popular because [it doesn't actually work](https://forum.sublimetext.com/t/best-setup-for-scss-editing/38091).
- I've been in touch with the maintainer of the [Sass](https://packagecontrol.io/packages/Sass) package, but he prefers to not change the highlighting (even though it's completely out of line with other CSS-like languages). So, we're not going to merge and replace that, even though chances of that package seeing an update are pretty much zilch.

So, yeah, I'd rather not add another package especially since ancient packages will forever rule the search results. But that's where we're at.