### PR TITLE
add isort-plugin update from thijsdezoete/sublime-text-isort-plugin 

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -1120,6 +1120,16 @@
 			]
 		},
 		{
+			"name": "isort-plugin",
+			"details": "https://github.com/DiegoGallegos4/sublime-text-isort-plugin",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "ITDCHelper",
 			"details": "https://github.com/akalongman/sublimetext-itdchelper",
 			"author": "Avtandil Kikabidze",


### PR DESCRIPTION
Original plugin was discontinued since 2015, updating isort version and maintining it. 