### PR TITLE
Added Gomod: syntax for go.mod files

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1189,6 +1189,17 @@
 			]
 		},
 		{
+			"name": "Gomod",
+			"details": "https://github.com/Mitranim/sublime-gomod",
+			"labels": ["golang", "go", "syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Google Apps Scripts",
 			"details": "https://github.com/revolunet/sublimetext-google-apps-scripts",
 			"labels": ["google", "scripts", "drive", "javascript"],


### PR DESCRIPTION
Support for `go.mod`, the new dependency manifest format for Go.

Since Sublime has a standard Go package, _maybe_ in the long run it should include this syntax. Maybe. For now, publishing this on PackageControl makes the syntax immediately available.

Package: https://github.com/Mitranim/sublime-gomod