### PR TITLE
Add TailwindCSSAutocomplete

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -220,6 +220,18 @@
 			]
 		},
 		{
+			"name": "TailwindCSSAutocomplete",
+			"details": "https://github.com/bradlc/sublime-tailwindcss",
+			"labels": ["tailwind", "auto-complete"],
+			"author": "Brad Cornes",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Takana",
 			"details": "https://github.com/mechio/takana-sublime",
 			"releases": [
@@ -769,7 +781,7 @@
 					"sublime_text": ">=3000",
 					"tags": true
 				}
-			]   
+			]
 		},
 		{
 			"name": "Theme - Argonaut",


### PR DESCRIPTION
This package adds autocompletion for [Tailwind CSS](https://tailwindcss.com/) class names in HTML and CSS files, based on the user’s Tailwind configuration file.