### PR TITLE
Add C and C++ base converter

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -13,6 +13,18 @@
 			]
 		},
 		{
+			"name": "C Base Converter",
+			"details": "https://github.com/flau/c-base-converter",
+			"author": ["Daniel Connolly"],
+			"labels": ["C", "C++", "formatting", "text manipulation", "base", "hex"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "C# Compile & Run",
 			"details": "https://github.com/chrokh/csharp-build-singlefile-sublime-text-2",
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -2,9 +2,10 @@
 	"schema_version": "3.0.0",
 	"packages": [
 		{
-			"name": "C Improved",
-			"details": "https://github.com/abusalimov/SublimeCImproved",
-			"labels": ["language syntax"],
+			"name": "C Base Converter",
+			"details": "https://github.com/flau/c-base-converter",
+			"author": ["Daniel Connolly"],
+			"labels": ["C", "C++", "formatting", "text manipulation", "base", "hex"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -13,10 +14,9 @@
 			]
 		},
 		{
-			"name": "C Base Converter",
-			"details": "https://github.com/flau/c-base-converter",
-			"author": ["Daniel Connolly"],
-			"labels": ["C", "C++", "formatting", "text manipulation", "base", "hex"],
+			"name": "C Improved",
+			"details": "https://github.com/abusalimov/SublimeCImproved",
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/c.json
+++ b/repository/c.json
@@ -8,7 +8,7 @@
 			"labels": ["C", "C++", "formatting", "text manipulation", "base", "hex"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->

![example](https://user-images.githubusercontent.com/13100166/45773257-c0e61380-bc41-11e8-943f-25876251ea02.gif)

Adds context and quick panel menu for converting selected regions between different integer literal bases in C and C++.

I was looking for something like this for work; the only thing I could find was https://packagecontrol.io/packages/Hex-Bin%20System but it has not been updated in over 5 years, does not support prefixes (0b... 0x... 0...) and requires selection of the initial base.

This package uses the C and C++ prefixes for integer literals instead, and has quick panel selection in addition to optional context menus. In addition, it also preserves C++ integer suffixes (ULL).