### PR TITLE
add sql-formatter

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3151,6 +3151,16 @@
 			]
 		},
 		{
+			"name": "sql-formatter",
+			"details": "https://github.com/kufii/sublime-sql-formatter",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SqlBeautifier",
 			"details": "https://github.com/zsong/SqlBeautifier",
 			"labels": ["sql", "formatting", "formatter"],


### PR DESCRIPTION
A plugin to run [this npm library](https://github.com/kufii/cli-sql-formatter) that I wrote on the current file. It in turn formats sql using [this npm library](https://github.com/zeroturnaround/sql-formatter).

Let me know if you have any comments