### PR TITLE
Update information for Brackets Color Scheme package

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -1223,9 +1223,10 @@
 		{
 			"name": "Brackets Color Scheme",
 			"details": "https://github.com/jwortmann/brackets-color-scheme",
+			"labels": ["color scheme"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3170",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
My package "Brackets Color Scheme" now uses the .sublime-color-scheme format, and I have removed the former used .tmTheme files. This pull request corrects the required version of Sublime Text. Additionally, I added the "color scheme" label.