### PR TITLE
Add "Freeze Ruby Files" package

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1617,6 +1617,17 @@
 			]
 		},
 		{
+			"name": "Freeze Ruby Files",
+			"details": "https://github.com/peagha/freeze_ruby_files",
+			"author": "Philippe Hardardt",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Freya",
 			"details": "https://github.com/mistydemeo/sublime_freya",
 			"releases": [


### PR DESCRIPTION
This plugin automatically adds the [magic Ruby comment](https://www.lucascaton.com.br/2016/01/19/what-is-frozen_string_literal-in-ruby/) to Ruby files when saving them:
before save:
```ruby
class MyRubyClass
end
```

after save:
```ruby
# frozen_string_literal: true

class MyRubyClass
end
```
Many linters require this comment and the developer has to remember to add it to every file. With this plugin the developer won't even have to remember ✨ 