### PR TITLE
Add 'Pandoc Converter'

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -201,6 +201,16 @@
 			]
 		},
 		{
+			"name": "Pandoc Converter",
+			"details": "https://github.com/klmp200/Pandoc-Converter",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Pandoc Referencer",
 			"details": "https://github.com/scotartt/PandocReferencr",
 			"releases": [


### PR DESCRIPTION
The goal of [this package](https://github.com/klmp200/Pandoc-Converter) is to prepare presets for the pandoc command and easily convert your markdown to pdf, html and whatever you want.