### PR TITLE
s.json: Seeing is Believing also support ST3

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -820,11 +820,11 @@
 		},
 		{
 			"name": "Seeing Is Believing",
-			"details": "https://github.com/JoshCheek/sublime-text-2-seeing-is-believing",
+			"details": "https://github.com/JoshCheek/sublime-text-2-and-3-seeing-is-believing",
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"branch": "master"
+					"sublime_text": ">=2000",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Update supported version of Seeing is Beliving
to ST3. The repo is now redirected to
https://github.com/JoshCheek/sublime-text-2-and-3-seeing-is-believing

See: https://github.com/JoshCheek/sublime-text-2-and-3-seeing-is-believing

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
cc: @JoshCheek 