### PR TITLE
Add JsModules plugin

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -1050,6 +1050,17 @@
 			]
 		},
 		{
+			"name": "JsModules",
+			"details": "https://github.com/luwes/SublimeJsModules",
+			"labels": ["javascript", "convert", "cjs", "es6"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "JSON Key-Value",
 			"details": "https://github.com/aurule/json-kv",
 			"labels": ["language syntax", "json"],


### PR DESCRIPTION
This change adds my JsModules plugin.
https://github.com/luwes/SublimeJsModules

> JsModules is a Sublime Text Plug-in to convert CJS modules to ES modules.