### PR TITLE
Add PyenvEnv package

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2558,6 +2558,17 @@
 			]
 		},
 		{
+			"name": "PyenvEnv",
+			"details": "https://github.com/jkr78/PyenvEnv",
+			"labels": ["python", "pyenv", "env", "virtualenv"],
+			"releases": [
+				{
+					"sublime_text": ">3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Pygame Completions",
 			"details": "https://github.com/tushortz/Pygame-Completions",
 			"labels": ["completions", "completion", "Completion", "python"],

--- a/repository/p.json
+++ b/repository/p.json
@@ -2560,7 +2560,7 @@
 		{
 			"name": "PyenvEnv",
 			"details": "https://github.com/jkr78/PyenvEnv",
-			"labels": ["python", "pyenv", "env", "virtualenv"],
+			"labels": ["python", "pyenv", "env", "virtualenv", "venv"],
 			"releases": [
 				{
 					"sublime_text": ">3000",


### PR DESCRIPTION
Finds pyenv python version per view/project and allows to set env variable to it.

Difference from other (similar) packages:
- it is pyenv specific
- supports pyenv-virtualenv
- can be used with .python-version file
