### PR TITLE
[YAMLJSON] add plugin to convert yaml to json and back

### DIFF
--- a/repository/y.json
+++ b/repository/y.json
@@ -22,6 +22,17 @@
 			]
 		},
 		{
+			"name": "YAMLJSON",
+			"details": "https://github.com/thomasmeeus/yamljson",
+			"labels": ["yaml", "json", "convertor"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "YAMLMacros",
 			"previous_names": ["YAML Macros"],
 			"details": "https://github.com/Thom1729/YAML-Macros",


### PR DESCRIPTION
Hi,

this is a plugin which allows converting json snippets to yaml and back via the Command Palette. I use this functionality a lot when working with Openshift objects.

It's currently just a working draft. Additional features can be added when required.