### PR TITLE
Add ExecInput package

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -1466,6 +1466,17 @@
 			]
 		},
 		{
+			"name": "ExecInput",
+			"details": "https://github.com/mheinzler/ExecInput",
+			"labels": ["input", "stdin", "build system"],
+			"releases": [
+				{
+					"sublime_text": ">=3176",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "exercism",
 			"previous_names": ["STexercism"],
 			"details": "https://github.com/thosgood/STexercism",


### PR DESCRIPTION
This adds the ExecInput package that allows sending input to a process run through the standard build system.

It differs from other packages like [Sublime Input](https://packagecontrol.io/packages/Sublime%20Input) in that it doesn't require any changes to a project's build system or a file's source code.