### PR TITLE
Added WrapAsYouType

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -965,6 +965,16 @@
 			]
 		},
 		{
+			"name": "WrapAsYouType",
+			"details": "https://github.com/btrekkie/WrapAsYouType",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "WrapIt",
 			"description": "Wrap Contents With Specific Code",
 			"details": "https://github.com/pyking2/WrapIt",


### PR DESCRIPTION
This adds https://github.com/btrekkie/WrapAsYouType to the default channel.

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->

WrapAsYouType automatically performs hard word wrapping within specified sections of a file, in real time as the user types.  For example, WrapAsYouType could limit lines of C++ code contained in block comments (between /* and */) and sequences of line comments (after //) to a width of 80 columns.

There is one existing package that is similar: Auto (Hard) Wrap ( https://github.com/randy3k/AutoWrap ).  However, that package has considerably less functionality and customizability; see https://github.com/btrekkie/WrapAsYouType#comparison-with-auto-hard-wrap for details.  The author of Auto (Hard) Wrap only recommends it for plain text documents (see https://github.com/randy3k/AutoWrap/issues/17#issuecomment-301229018 ), whereas WrapAsYouType is designed to work well with source code.

(Note: I would have named it "AutoWrap" rather than "WrapAsYouType", but the name "AutoWrap" was taken.)