### PR TITLE
EasyClangComplete: add homepage link and labels 

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -79,9 +79,26 @@
 		{
 			"name": "EasyClangComplete",
 			"details": "https://github.com/niosus/EasyClangComplete",
+			"homepage": "https://niosus.github.io/EasyClangComplete",
 			"readme": "https://raw.githubusercontent.com/niosus/EasyClangComplete/master/docs/pc_readme.md",
 			"donate": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=2QLY7J4Q944HS",
-			"labels": ["auto-complete", "linting", "language syntax"],
+			"labels": [
+				"auto-complete",
+				"autocompletion",
+				"clang",
+				"ide",
+				"intellisense",
+				"completion",
+				"Completion",
+				"completions",
+				"linting",
+				"c",
+				"c++",
+				"C",
+				"C++",
+				"cmake",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3070",


### PR DESCRIPTION
This is a follow up from #7323 where the PR had to be reverted by @Thom1729 due to the misunderstanding in where to set the link to the homepage as briefly discussed in #7361 

This PR adds a proper `"homepage"` tag with the link to Github io pages for the plugin and updates the labels to reflect the functionality better.