### PR TITLE
Register RON syntax plugin

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1616,6 +1616,18 @@
 			]
 		},
 		{
+			"name": "RON",
+			"description": "Rusty Object Notation syntax scheme",
+			"author": "kvark",
+			"details": "https://github.com/ron-rs/sublime-ron",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Ros Snippets",
 			"details": "https://github.com/ckrooss/ros_snippets",
 			"labels": ["snippets", "build system", "language syntax"],


### PR DESCRIPTION
This is a RON syntax highlighter we developed and have been using for a while: https://github.com/ron-rs/ron
RON is used in WebRender, Amethyst engine, and a few other libraries in Rust.