### PR TITLE
Add Blame Explorer

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -854,6 +854,16 @@
 			]
 		},
 		{
+			"name": "Blame Explorer",
+			"details": "https://github.com/gatopeich/sublame",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "BlameHighlighter",
 			"details": "https://github.com/skyronic/BlameHighlighter",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->

Blame Explorer pops-up full details of the change where a line was last modified by just hovering over its number on the gutter.

Thus it greatly facilitates work where you are not familiar with the original intention behind strange or complex pieces of code.

It works with SVN and GIT, and I am planning making it configurable for other VCS.

Additionally, it displays the diff chunk if the line number belongs into an uncommitted change.

Supersedes other "blame" packages which don't show details and require special keystrokes or are just less seamless.

Combines well with packages that use the gutter to display VCS info, cause they lack "blame" functionality and the way I implemented it mixes well (at least with Modific and VCS Gutter)