### PR TITLE
Add Formatter plugin

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1496,6 +1496,17 @@
 			]
 		},
 		{
+			"name": "Formatter",
+			"details": "https://github.com/bitst0rm-pub/Formatter",
+			"labels": ["formatting", "beautify", "minify", "css", "scss", "sass", "less", "html", "xml", "javascript", "json", "markdown", "perl", "php", "python", "ruby", "bash", "c", "c++", "c#", "d", "objc", "java"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Fortify Highlighter",
 			"details": "https://github.com/pwntester/FortifyHighlighter",
 			"releases": [


### PR DESCRIPTION
Formatter is a Sublime Text 3 plugin to beautify and minify source code.

Features:
  - Support more than 20 major languages
  - Format whole file, single or multi selections
  - Config files available for each 3rd party plugins
  - Work offline

https://github.com/bitst0rm-pub/Formatter

@Thom1729 my previous commit #7421 has been accidentally updates by the pull bot, so it was auto empty. I uninstalled it now. Could you please review again, Thank you.