### PR TITLE
Adjust support version for ShowDefinitionEx

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1519,7 +1519,7 @@
 			"details": "https://github.com/jk4837/ShowDefinitionEx",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3124",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
ShowDefinitionEx use on_hover function and base on build in function "Show Definition", so it's not competible with ST2 and ST3(ver <3124).