### PR TITLE
Updated GraphQL syntax

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1885,7 +1885,6 @@
 			"releases": [
 				{
 					"sublime_text": ">=3092",
-					"platforms": ["*"],
 					"tags": true
 				}
 			]

--- a/repository/g.json
+++ b/repository/g.json
@@ -1880,6 +1880,17 @@
 			]
 		},
 		{
+			"name": "GraphQL Syntax",
+			"details": "https://github.com/fermads/GraphQL-SublimeText3",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"platforms": ["*"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Graphvizer",
 			"details": "https://github.com/hao-lee/Graphvizer",
 			"author": "Hao Lee",


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->

Forked from [dncrews/GraphQL-SublimeText3](https://github.com/dncrews/GraphQL-SublimeText3) this package has support for newer GraphQL syntax (triple quotes / block strings). I've created a [PR on the original project](https://github.com/dncrews/GraphQL-SublimeText3/pull/6)  ~ 2 months ago but seems like the project is not being maintained. 

As per [GraphQL RFC](https://facebook.github.io/graphql/draft/#sec-String-Value) and its [implementation](https://github.com/facebook/graphql/pull/327), doc strings are here since 2017 and are the preferred (and only) way to add documentation to GraphQL.

Without this change, using bloc strings breaks the syntax highlighting on Sublime.
