### PR TITLE
Add OpenContextPath

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -686,6 +686,22 @@
 			]
 		},
 		{
+			"name": "OpenContextPath",
+			"details": "https://github.com/mheinzler/OpenContextPath",
+			"labels": [
+				"file navigation",
+				"open files",
+				"open paths",
+				"context menu"
+			],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "OpenedFiles",
 			"details": "https://github.com/qiray/SublimeOpenedFiles",
 			"labels": ["file navigation", "file open", "sidebar"],


### PR DESCRIPTION
This package gives the ability to quickly open paths within a text by using the context menu or a keyboard shortcut.

I couldn't find any other plugin which provides the same functionality.