### PR TITLE
Add package AutoSetIndentation

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2310,6 +2310,16 @@
 			]
 		},
 		{
+			"name": "AutoSetIndentation",
+			"details": "https://github.com/jfcherng/Sublime-AutoSetIndentation",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "AutoSetSyntax",
 			"details": "https://github.com/jfcherng/Sublime-AutoSetSyntax",
 			"releases": [


### PR DESCRIPTION
[Sublime-AutoSetIndentation](https://github.com/jfcherng/Sublime-AutoSetIndentation)
==========================

This plugin automatically detects and sets the indentation for you, by default, when a file is loaded.


Why Do I Make This?
===================

Sublime Text detects the indentation when a file is loaded if `detect_indentation` is set to `true`, which is the default settings.

However, its detection is wrong sometimes. You could give following cases a try!

- Files under the [problem_files/](https://github.com/jfcherng/Sublime-AutoSetIndentation/tree/master/problem_files)
- https://github.com/SublimeTextIssues/Core/issues/354
- https://github.com/SublimeTextIssues/Core/issues/1459
- https://github.com/SublimeTextIssues/Core/issues/1640
- Maybe more but I am lazy to find out and test them

I find that [Indent Finder](http://www.freehackers.org/Indent_Finder) detects above files correctly so I make it into this plugin.
