### PR TITLE
Add SNMP MIB Syntax package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2633,7 +2633,7 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]

--- a/repository/s.json
+++ b/repository/s.json
@@ -2627,6 +2627,18 @@
 			]
 		},
 		{
+			"name": "SNMP MIB Syntax",
+			"description": "Syntax Highlighting for SNMP MIB files (SMIv2)",
+			"details": "https://github.com/stevenkaras/Sublime-SNMP-MIB",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Snowball Syntax",
 			"description": "Syntax Highlighting for Snowball framwork destinated to stemming",
 			"details": "https://github.com/assem-ch/snowball-sublime-syntax",


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
This package adds basic syntax highlighting and comment support for SNMP MIB files.

These files are published by vendors of networking and computing equipment to provide semantic names and descriptions to SNMP OIDs.