### PR TITLE
Added Peeko to the list of packages

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -665,6 +665,16 @@
 			]
 		},
 		{
+			"name": "Peeko",
+			"details": "https://github.com/anxor/Peeko",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "PEG.js",
 			"details": "https://github.com/alexstrat/PEGjs.tmbundle",
 			"releases": [


### PR DESCRIPTION
This is a plugin that helps with opening cart files from the [Pico8](https://www.lexaloffle.com/pico-8.php) fantasy console.

The carts are in a text format made of delimited parts, only one of them contains the actual code so this plugin removes the unwanted parts and reinserts them on saving, providing a more seamless experience.

There's already another [package](https://packagecontrol.io/packages/PICO-8) for the Pico8, but it's focused on the editing / running aspect, while Peeko is merely a loading / saving helper.