### PR TITLE
added International Keymap plugin

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -838,6 +838,16 @@
 			]
 		},
 		{
+			"name": "International Keymap",
+			"details": "https://bitbucket.org/hxss/internationalkeymap",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Internet Search",
 			"details": "https://github.com/krasun/SublimeInternetSearch",
 			"releases": [


### PR DESCRIPTION
[Bitbucket](https://bitbucket.org/hxss/internationalkeymap/src/1.0.0/)
Creates localised keymaps based on sublime keymaps files.

Related discussions:
[Get merged current keymap](https://forum.sublimetext.com/t/get-merged-current-keymap/38767)
[On keymap changed event?](https://forum.sublimetext.com/t/on-keymap-changed-event/42149)