### PR TITLE
MOHAA: Drop ST2 support

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1907,7 +1907,7 @@
 			"labels": ["mohaa", "scr", "morpheus script", "language syntax", "snippets", "completions"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3084",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Drop ST2 support, since now is using `.sublime-syntax` extension.
