### PR TITLE
Add Launch package

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -469,6 +469,17 @@
 			]
 		},
 		{
+			"name": "Launch",
+			"details": "https://github.com/zinefer/sublime-launch",
+			"labels": ["launch", "execute", "run", "terminal", "open", "gui", "runner", "opener"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "lay-out Syntax",
 			"details": "https://github.com/CREEATION/lay-out-syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION
This package is designed to be used to launch gui applications with project or file context.

There are other packages that are similar, mainly, `Run Apps`. I started out by adding `cwd` functionality to that package but I also needed the `Popen` call not to redirect any of the output. Adding this to the package as well I started to really dislike the way the options of the package interacted to build out the command passed to `Popen`. At this point I was refactoring pretty much the entire package and I didn't want to submit a pull-request that changed the way the package operated and every line of code to a repository that hadn't been touched in 3 years. I did my best to make the code and operation as simple as possible and tried not to tread on packages designed to redirect output like `shell-command`.

I've tested this on Windows, Mac and Ubuntu.