### PR TITLE
Add citetex package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1266,6 +1266,19 @@
 			]
 		},
 		{
+			"name" : "CiteTeX",
+			"details": "https://github.com/alex1632/citetex",
+			"labels": ["LaTeX", "tex", "cite"],
+			"author": "Alexander K.",
+			"releases": [
+				{
+					"platforms": ["osx", "linux"],
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Civic Color Scheme",
 			"details": "https://github.com/AntoineBoulanger/civic",
 			"labels": ["color scheme"],


### PR DESCRIPTION
Add a new package "CiteTeX". Its goal is to add additional features currently missing in LaTeXTools. Most important features are:
 - Display a Popup when hovering over \cite{} containing information about a bib-resource, a Link to the original paper if specified and a link to quickly open a resource if stored locally.
- autocomplete references \ref{} using a quick select menu displaying full titles, not just labels.
- conversion of DOI links to bibtex entries and inserting them.
- Inline display of the source's title after \cite{} as phantom (can be deactivated)

I hope this little plugin helps researchers and students with their scientific writing work.