### PR TITLE
Add EdgeDB plugin.

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -298,6 +298,16 @@
 			]
 		},
 		{
+			"name": "EdgeDB",
+			"details": "https://github.com/edgedb/edgedb-editor-plugin",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "EdgeOS",
 			"description": "Syntax highlighting for EdgeMax EdgeOS.",
 			"details": "https://github.com/lojoja/sublime-syntax-edgeos",


### PR DESCRIPTION
A syntax plugin for EdgeDB (https://edgedb.com).

The plugin is of high quality -- we have CI and tests to ensure that the syntax actually works.  The plugin is already available for Atom (https://atom.io/packages/edgedb) and VSCode (https://marketplace.visualstudio.com/items?itemName=magicstack.edgedb).