### PR TITLE
Add Octave Support

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -141,6 +141,17 @@
 			]
 		},
 		{
+			"name": "OctaveSupport",
+			"details": "https://github.com/apjanke/OctaveSupport",
+			"labels": ["language syntax", "snippets"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Octo",
 			"details": "https://github.com/mattmikolay/octo-sublime",
 			"labels": ["language syntax", "chip8"],


### PR DESCRIPTION
This package provides syntax definitions, indent settings, and snippets for GNU Octave.

There's an existing [GNU Octave Completions](https://github.com/tushortz/GNU-Octave-Completions) package, but that only does completions; this package has additional functionality.