### PR TITLE
Update required ST version for CNC SINUMERIK 840D package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1734,7 +1734,7 @@
 			"labels": ["language syntax", "snippets", "completion"],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3153",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
The `CNC SINUMERIK 840D language support` package will make use of the `embed` keyword in several syntax definitions. Hence the compatibility level needs to be adjusted to ST3153 which introduced that feature.

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
