### PR TITLE
[SSH Config] Update author and add <3.1 maint tag

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3377,6 +3377,7 @@
 		{
 			"name": "SSH Config",
 			"details": "https://github.com/robballou/sublimetext-sshconfig",
+			"author": ["michaelblyons", "robballou"],
 			"labels": ["language syntax", "snippets", "completions"],
 			"releases": [
 				{
@@ -3384,7 +3385,11 @@
 					"tags": "st2-"
 				},
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "3000 - 3155",
+					"tags": "st3.0-"
+				},
+				{
+					"sublime_text": ">=3156",
 					"tags": "st3-"
 				}
 			]


### PR DESCRIPTION
Thanks to @FichteFoll for answering https://github.com/wbond/package_control_channel/issues/7464. This commit also removes `chmod +x` from `s.json`.