### PR TITLE
Add Rubyfmt - autoformatter for Ruby

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -2062,6 +2062,17 @@
 			]
 		},
 		{
+			"name": "Rubyfmt",
+			"labels": ["formatting", "text manipulation"],
+			"details": "https://github.com/toreriklinnerud/sublime-rubyfmt",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/zmbacker/RubyFormat",
 			"releases": [
 				{


### PR DESCRIPTION
This implement auto format support for ruby using the new [rubyfmt](https://github.com/samphippen/rubyfmt) project inspired by gofmt. I believe this is the first general purpose auto formatting tool for ruby.