### PR TITLE
add "MacShell"

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -79,6 +79,18 @@
 			]
 		},
 		{
+			"name": "MacShell",
+			"details": "https://github.com/james2doyle/MacShell",
+			"labels": ["shell", "env", "profile", "PATH", "bin", "environment"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Madebyphunky Color Scheme",
 			"details": "https://github.com/Phunky/madebyphunky",
 			"labels": ["color scheme"],


### PR DESCRIPTION
This is a fork of https://github.com/tedmiston/SublimeFixMacPath which in turn is a fork of https://github.com/int3h/SublimeFixMacPath which has been since abandoned.

The fork added some extra checks, remove deprecated functionality, and also cleaned up some of the code.

The author (and fork author) never published new tags so the repo has to be cloned in order to be on the latest version. This fork renames the package from the original and also tags a new version so there are no conflicts with the original.