### PR TITLE
Add LSP-vue plugin

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1598,6 +1598,16 @@
 			]
 		},
 		{
+			"name": "LSP-vue",
+			"details": "https://github.com/sublimelsp/LSP-vue",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Lua Dev",
 			"details": "https://github.com/rorydriscoll/LuaSublime",
 			"labels": ["lua"],


### PR DESCRIPTION
Vue support for Sublime's LSP plugin.

Currently a user needs to manual configure the vue language server, which is not error prone.
This plugin (language handler) will automate that step.

If you need more info, please say.