### PR TITLE
update SasSubmit: add support for osx platform

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -246,7 +246,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["windows"],
+					"platforms": ["windows","osx"],
 					"tags": true
 				}
 			]


### PR DESCRIPTION
The original SasSubmit package only runs on windows platform. I have added functions to allow this package to run on osx platform. 