### PR TITLE
Add isort package

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -1163,6 +1163,17 @@
 			]
 		},
 		{
+			"name": "iSort Python Imports",
+			"details": "https://github.com/onanypoint/iSort-Python-Imports",
+			"labels": ["python", "formatting"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ITDCHelper",
 			"details": "https://github.com/akalongman/sublimetext-itdchelper",
 			"author": "Avtandil Kikabidze",


### PR DESCRIPTION
Package for the [isort](https://github.com/timothycrosley/isort) command.

Compared to other packages available for this command, it doesn't include the library itself. It uses the user installed on instead (configurable using the settings).

Also, the available packages for this command seems to be currently unmaintained ([thijsdezoete/sublime-text-isort-plugin](https://github.com/thijsdezoete/sublime-text-isort-plugin) for example). By removing the direct inclusion of the isort library, this plugin is less likely to be out of sync with the mainline isort command.

In the pull request #7240  a suggestion was made to "replace the existing isort package instead of adding a clone under a different name". As this is not an updated version of the [thijsdezoete](https://github.com/thijsdezoete/sublime-text-isort-plugin) package, I don't know if this proposition is applicable here.

This is my first package, feedbacks are welcome.