### PR TITLE
Add Z80 Assembly (RGBDS)

### DIFF
--- a/repository/z.json
+++ b/repository/z.json
@@ -29,7 +29,7 @@
 			"labels": ["language syntax", "z80", "assembly"],
 			"releases": [
 				{
-					"sublime_text": ">=3084",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]

--- a/repository/z.json
+++ b/repository/z.json
@@ -24,6 +24,17 @@
 			]
 		},
 		{
+			"name": "Z80 Assembly (RGBDS)",
+			"details": "https://github.com/shinmai/sublime_z80_rgbds",
+			"labels": ["language syntax", "z80", "assembly"],
+			"releases": [
+				{
+					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://bitbucket.org/abraly/zap-gremlins",
 			"releases": [
 				{


### PR DESCRIPTION
A Z80 Assembly syntax definitions for the [RGBDS](https://github.com/rednex/rgbds) Game Boy development toolchain.
There is a Z80 syntax definition package available, but it's for the Pasmo cross-assembler, which has a wildly different syntax to rgbasm. Obviously there are dozens of Z80 assemblers, and it probably doesn't make sense to have definitions for each one separately, but I believe RGBDS is popular enough among Game Boy homebrew enthusiasts to warrant this packages existence.