### PR TITLE
Add InsertAnyDate

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -758,6 +758,17 @@
 			]
 		},
 		{
+			"name": "InsertAnyDate",
+			"details": "https://github.com/Fire-Dragon-DoL/sublime-InsertAnyDate",
+			"labels": ["text manipulation"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Inspired GitHub Color Scheme",
 			"details": "https://github.com/sethlopezme/InspiredGitHub.tmtheme",
 			"labels": ["color scheme"],


### PR DESCRIPTION
This plugin allows to easily insert dates in text files at the cursor position.
The current date can be inserted, as well as a user-provided (through prompt) date.
The usage is for text files that work like logs and require consistently entering dates in the same format.

The date is formatted according to the user settings.

The other packages all work on the current date, writing it in a variety of formats, but still the current date.

This plugin provides the ability to specify the date so that it can be used even when modifying older files and the need to write a date in a common format arises.