### PR TITLE
Add "Ignore Unable to Open File Error" package

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -183,6 +183,16 @@
 			]
 		},
 		{
+			"name": "Ignore Unable to Open File Error",
+			"details": "https://github.com/everyonesdesign/IgnoreErrorUnableToOpenFile",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Ignore Words",
 			"details": "https://github.com/zcold/ignore_words",
 			"releases": [


### PR DESCRIPTION
The package removes "ERROR: Unable to open file" error from search results (e.g. for symlinks), because the behaviour is undesirable for some users. 

E.g. see [this discussion](https://forum.sublimetext.com/t/dont-show-files-that-are-unable-to-open-in-find-results/20499/16) on Sublime Forum.

Repo: https://github.com/everyonesdesign/IgnoreErrorUnableToOpenFile

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
