### PR TITLE
add MaterialUi React Component Snippet Autocomplete

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -844,6 +844,19 @@
 			]
 		},
 		{
+			"name": "MaterialUi React Component Snippet Autocomplete",
+			"details": "https://github.com/Pushpamk/MaterialUi-React-Component-Snippet-Autocomplete",
+			"readme": "https://github.com/Pushpamk/MaterialUi-React-Component-Snippet-Autocomplete/blob/master/README.md",
+			"author": "Pushpam Kumar",
+			"labels": ["material","react","component","snippet","autocomplete"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Math Notes",
 			"details": "https://github.com/LemonPi/math-notes",
 			"labels": ["language syntax", "documentation", "notes"],

--- a/repository/m.json
+++ b/repository/m.json
@@ -845,8 +845,8 @@
 		},
 		{
 			"name": "MaterialUi React Component Snippet Autocomplete",
-			"details": "https://github.com/Pushpamk/MaterialUi-React-Component-Snippet-Autocomplete",
-			"readme": "https://github.com/Pushpamk/MaterialUi-React-Component-Snippet-Autocomplete/blob/master/README.md",
+			"details": "https://github.com/Pushpamk/materialui-react-component-snippet-autocomplete",
+			"readme": "https://github.com/Pushpamk/materialui-react-component-snippet-autocomplete/blob/master/README.md",
 			"author": "Pushpam Kumar",
 			"labels": ["material","react","component","snippet","autocomplete"],
 			"releases": [


### PR DESCRIPTION
MaterialUi React Component Snippet Autocomplete contains Material-Ui React component snippet,  MaterialUi properties autocomplete.

see more info [README](https://github.com/Pushpamk/materialui-react-component-snippet-autocomplete/blob/master/README.md)