### PR TITLE
Add monokaiC theme for MarkdownEditing

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -2147,6 +2147,17 @@
 			]
 		},
 		{
+			"name": "MonokaiC",
+			"details": "https://github.com/avivace/monokaiC",
+			"labels": ["monokai", "color scheme", "markdown", "preview"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MonokaiFree",
 			"details": "https://github.com/gerardroche/sublime-monokai-free",
 			"labels": ["color scheme"],


### PR DESCRIPTION
This is a monokai theme for the MarkdownEditing package for Sublime Text 3. It provides *both* Coloured and text-style preview for Markdown files, including language-specific palettes for the bode blocks.

It already has an userbase and some traffic (released in 2016, never published on Package Control).

Screenshot:

![screenshot](https://user-images.githubusercontent.com/14352721/59159362-dac5d000-8ac8-11e9-81a4-f6daf0f2eb8f.png)
