### PR TITLE
Add 'Elvish Syntax' package

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -628,6 +628,16 @@
 			]
 		},
 		{
+			"name": "Elvish Syntax",
+			"details": "https://github.com/href/elvish_syntax_for_sublime",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Emacs Pro Essentials",
 			"previous_names": ["sublemacspro"],
 			"details": "https://github.com/sublime-emacs/sublemacspro",

--- a/repository/e.json
+++ b/repository/e.json
@@ -632,7 +632,7 @@
 			"details": "https://github.com/href/elvish_syntax_for_sublime",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This package adds syntax highlighting for the [Elvish](https://elv.sh) shell.

There is no such package yet for Sublime Text.

Thanks for your consideration! 🤞