### PR TITLE
Add DreamMaker Language Client

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -1412,6 +1412,17 @@
 			]
 		},
 		{
+			"name": "DreamMaker Language Client",
+			"details": "https://github.com/SpaceManiac/sublime-dm-langclient",
+			"labels": ["language syntax", "linting", "auto-complete", "build system"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Drive Color Scheme",
 			"details": "https://github.com/lsjroberts/drive-colour-scheme",
 			"labels": ["color scheme"],


### PR DESCRIPTION
This package extends [LSP](https://packagecontrol.io/packages/LSP) with support for the [DreamMaker Language Server](https://github.com/SpaceManiac/SpacemanDMM/tree/master/src/langserver#dreammaker-language-server).

It also provides an integrated browser for the language's reference, a project "object tree" view with the assistance of the language server, and a command to toggle whether a file is included in the project or not.

There are two existing packages which provide syntax highlighting and a build system:
* [BYOND](https://packagecontrol.io/packages/BYOND)
* [Dream Maker](https://packagecontrol.io/packages/Dream%20Maker)

This package is intended to act as a full replacement and thus also provides syntax highlighting, as well as a build system which integrates more tightly with the language server support.
