### PR TITLE
Add YASMJinja2 plugin for YASM syntax highlight

### DIFF
--- a/repository/y.json
+++ b/repository/y.json
@@ -110,6 +110,17 @@
 			]
 		},
 		{
+			"name": "YASMJinja2",
+			"details": "https://github.com/m-messiah/yasm-jinja2",
+			"labels": ["yasm", "jinja2", "yandex", "formatting", "syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Yate",
 			"details": "https://github.com/mctep/yate-textmate",
 			"releases": [


### PR DESCRIPTION
Plugin for syntax highlight of YASM modified Jinja2 syntax, which uses `<` brackets instead of `{` for readable JSON templates