### PR TITLE
Add Notedown package

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -834,6 +834,16 @@
 			]
 		},
 		{
+			"name": "Notedown",
+			"details": "https://github.com/darryllawson/sublime-notedown",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Notepad++ Color Scheme",
 			"details": "https://github.com/evandrocoan/SublimeNotepadPlusPlusTheme",
 			"labels": ["color scheme", "notepad++"],


### PR DESCRIPTION
Notedown helps you use manage a collection of notes stored as Markdown files. Maybe call it a Personal Wiki? The key feature this adds is **linking between notes**.

Similar packages:

- PlainNotes: https://packagecontrol.io/packages/PlainNotes
  - Different design philosophy.
- Notes: https://packagecontrol.io/packages/Notes
  - Just a syntax highlighting scheme. Doesn't use Markdown.
- Wiki: https://packagecontrol.io/packages/Wiki
  - No longer maintained. Different design philosophy. Does not use Markdown.

PlainNotes is similar but has a different design philosophy; my Notedown package is designed to augment Sublime Text builtin features, not wrap them. E.g. Use the normal Command-P for opening note files, rather provide a different mecahnism.