### PR TITLE
 Add an updated 65c816 assembly syntax

### DIFF
--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -112,8 +112,8 @@
 			]
 		},{
 			"name": "65c816 Assembly",
-                        "labels": ["language syntax"],
 			"details": "https://github.com/camden7306/65c816Assembly/",
+                        "labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -111,7 +111,7 @@
 				}
 			]
 		},{
-			"name": "65c816 Assembly",
+			"name": "65c816 Assembly Syntax",
 			"details": "https://github.com/camden7306/65c816Assembly/",
 			"labels": ["language syntax"],
 			"releases": [

--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -112,8 +112,8 @@
 			]
 		},{
 			"name": "65c816 Assembly",
+                        "labels": ["language syntax"],
 			"details": "https://github.com/camden7306/65c816Assembly/",
-			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -111,7 +111,7 @@
 				}
 			]
 		},{
-			"name": "65c816 Assembly Syntax",
+			"name": "65c816 Assembly",
 			"details": "https://github.com/camden7306/65c816Assembly/",
 			"labels": ["language syntax"],
 			"releases": [

--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -110,6 +110,16 @@
 					"tags": true
 				}
 			]
+		},{
+			"name": "65c816 Assembly",
+			"details": "https://github.com/camden7306/65c816Assembly/",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
 		}
 	]
 }

--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -113,7 +113,7 @@
 		},{
 			"name": "65c816 Assembly",
 			"details": "https://github.com/camden7306/65c816Assembly/",
-                        "labels": ["language syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
While there already is a 65816 package, this package extends on the syntax, adding highlighting support for hex/numbers, labels, and registers.