### PR TITLE
Add "bst syntax" package

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -1507,6 +1507,17 @@
 			]
 		},
 		{
+			"name": "bst syntax",
+			"details": "https://github.com/hadisfr/bst-sublime-syntax",
+			"labels": ["language syntax", "LaTeX", "tex", "bibtex"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Bubububububad and Boneyfied Color Schemes",
 			"details": "https://github.com/eibbors/Bubububububad",
 			"labels": ["color scheme"],


### PR DESCRIPTION
Add "bst syntax" package: sublime syntax definition for LaTeX Bibliography Style (bst) files