### PR TITLE
Add MarkdownLink

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -546,6 +546,17 @@
 			]
 		},
 		{
+			"name": "MarkdownLink",
+			"details": "https://github.com/unlight/sublime-markdown-link",
+			"labels": ["markdown", "links", "urls"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MarkdownLivePreview",
 			"details": "https://github.com/math2001/MarkdownLivePreview",
 			"labels": ["markdown", "preview"],


### PR DESCRIPTION
**MarkdownLink** - Convert url to markdown link where description is title from remote url
https://github.com/unlight/sublime-markdown-link

1. Unit exists and tests are passed https://github.com/unlight/sublime-markdown-link/runs/174182925
2. `.no-sublime-package` is necessary because of 3rd party libs, and import does not work in .sublime-package 