### PR TITLE
Require version 3.1 for Witness color scheme.

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -610,7 +610,7 @@
 			"author": "Ryan McQuen",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3170",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This color scheme uses the new JSON format, therefore it is only compatible with `>=3170`.