### PR TITLE
Add google-java-formatter

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1312,18 +1312,6 @@
 			]
 		},
 		{
-			"name": "GoogleJavaFormatter",
-			"details": "https://github.com/ankitshubham97/google-java-format-sublime",
-			"labels": ["google", "java", "formatter"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"platforms": ["osx", "linux"],
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Google Reader",
 			"details": "https://github.com/speg/SublimeGReader",
 			"releases": [
@@ -1386,6 +1374,18 @@
 				{
 					"sublime_text": "<3000",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "GoogleJavaFormatter",
+			"details": "https://github.com/ankitshubham97/google-java-format-sublime",
+			"labels": ["google", "java", "formatter"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx", "linux"],
+					"tags": true
 				}
 			]
 		},

--- a/repository/g.json
+++ b/repository/g.json
@@ -1312,6 +1312,18 @@
 			]
 		},
 		{
+			"name": "Google Java Formatter",
+			"details": "https://github.com/ankitshubham97/google-java-format-sublime",
+			"labels": ["google", "java", "formatter"],
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Google Reader",
 			"details": "https://github.com/speg/SublimeGReader",
 			"releases": [

--- a/repository/g.json
+++ b/repository/g.json
@@ -1312,13 +1312,13 @@
 			]
 		},
 		{
-			"name": "Google Java Formatter",
+			"name": "GoogleJavaFormatter",
 			"details": "https://github.com/ankitshubham97/google-java-format-sublime",
 			"labels": ["google", "java", "formatter"],
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"platforms": ["osx"],
+					"sublime_text": "*",
+					"platforms": ["osx", "linux"],
 					"tags": true
 				}
 			]


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
Currently, there is no plugin in Sublime Text which provides the functionality of formatting the java code according to Google's google-java-formatter. This formatter is considered standard by many java programmers. This will come in handy for the java programmers who use Sublime Text and are conscious about formatting. Most probably, they would be running this formatter manually as of now to format the code. It would be helpful for such programmers to have a plugin for the same in Sublime Text. I am starting it slow for now, with support for only OSX and Linux(Ubuntu). But I am sure that this project will gain traction and we will make it very resilient soon.