### PR TITLE
Remove "Yii Framework Docs Search" repository

### DIFF
--- a/repository/y.json
+++ b/repository/y.json
@@ -186,16 +186,6 @@
 			]
 		},
 		{
-			"name": "Yii Framework Docs Search",
-			"details": "https://github.com/d3th/sublime-text2-yii-docs",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "Yii2 Auto-complete",
 			"details": "https://github.com/udokmeci/sublime-yii2-autocomplete",
 			"labels": ["auto-complete"],


### PR DESCRIPTION
This extension does not work anymore.
