### PR TITLE
Add package: OpenUri

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -880,6 +880,17 @@
 			]
 		},
 		{
+			"name": "OpenUri",
+			"details": "https://github.com/jfcherng/Sublime-OpenUri",
+			"labels": ["shortcut", "url", "uri", "browser"],
+			"releases": [
+				{
+					"sublime_text": ">=3118",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "OpenVPN",
 			"details": "https://github.com/idleberg/sublime-openvpn",
 			"labels": ["language syntax", "snippets", "build system"],


### PR DESCRIPTION
ST >= 3118 for Phantom API. (mandatory)

ST >= 3170 for `view.style_for_scope()` API. (optional)

---

At the beginning, I was adding some features to [Open In Browser](https://packagecontrol.io/packages/Open%20In%20Browser). But eventually I realize that mine is a fully re-write and no longer shares the same codebase.