### PR TITLE
rename "Elm Language Support" to "Elm Syntax Highlighting" / add "Elm Format on Save"

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -603,17 +603,12 @@
 			]
 		},
 		{
-			"name": "Elm Language Support",
-			"details": "https://github.com/elm-community/SublimeElmLanguageSupport",
-			"labels": ["language syntax"],
-			"previous_names": ["Elm Syntax Highlighting"],
+			"name": "Elm Format on Save",
+			"details": "https://github.com/evancz/elm-format-on-save",
+			"labels": ["elm", "elm-format", "formatting"],
 			"releases": [
 				{
-					"sublime_text": "<3092",
-					"tags": "st2-"
-				},
-				{
-					"sublime_text": ">=3092",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]
@@ -622,6 +617,18 @@
 			"name": "Elm Snippets",
 			"details": "https://github.com/rudolfb/elm_snippets",
 			"labels": ["snippets", "elm"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "Elm Syntax Highlighting",
+			"details": "https://github.com/evancz/elm-syntax-highlighting",
+			"labels": ["elm", "language syntax", "highlighting"],
+			"previous_names": ["Elm Language Support"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/e.json
+++ b/repository/e.json
@@ -605,7 +605,7 @@
 		{
 			"name": "Elm Format on Save",
 			"details": "https://github.com/evancz/elm-format-on-save",
-			"labels": ["elm", "elm-format", "formatting"],
+			"labels": ["elm", "formatting"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -631,7 +631,7 @@
 			"previous_names": ["Elm Language Support"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->


## Context

I am the creator of Elm, and I want to have a super reliable Elm plugin that I can point people to from [The Official Guide](https://guide.elm-lang.org/). The initial Sublime Text package for Elm has had many maintainers over the past few years, and as a result, it would benefit from trimming down the features to be more minimal and reliable.


## Design

The design here is to split the most important functionality into two much simpler packages:

- https://github.com/evancz/elm-syntax-highlighting
- https://github.com/evancz/elm-format-on-save

The goal is to end up with (1) an extremely reliable plugin for syntax highlighting that will be easy to install for beginners and (2) have a secondary plugin for people who want a bit more from their workflow.


## Plan

This PR does two things:

1. Rename `Elm Language Support` back to `Elm Syntax Highlighting`
2. Add `Elm Format on Save`

The net effect is that the syntax highlighting part of `Elm Language Support` has been preserved, and the code needed to run `elm-format` on save has been improved quite a bit. All the other parts of the plugin have been trimmed out.

* * *

I have talked this through with @sentience who is the current maintainer of the existing Elm Language Support as listed [here](https://github.com/elm-community/Manifesto/blob/master/maintainers.md), and he has started the process of transferring maintainership to me [here](https://github.com/elm-community/Manifesto/pull/93).