### PR TITLE
Adjust "AutoSetSyntax" compatibility ST >= 3084

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2350,7 +2350,7 @@
 			"details": "https://github.com/jfcherng/Sublime-AutoSetSyntax",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=3084",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
As the title, I want to drop old ST because the latest stable release is already 3207 while 3084 is more than 1 year old.

People can still use an old version plugin by zip the repo by themself if they refuse the update their old ST3 somehow.

https://github.com/jfcherng/Sublime-AutoSetSyntax/commit/6ee50fe2f69f815e27ca427525e6749a91fbdf4e