### PR TITLE
Add new Xdebug package.

### DIFF
--- a/repository/x.json
+++ b/repository/x.json
@@ -77,6 +77,17 @@
 			]
 		},
 		{
+			"name": "Xdebug Client Plus",
+			"details": "https://github.com/ryanpcmcquen/SublimeTextXdebugPlus",
+			"labels": ["php", "xdebug"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Xkcd",
 			"details": "https://github.com/eivind88/xkcd",
 			"releases": [


### PR DESCRIPTION
This package exists to supersede/replace the unmaintained and broken 'Xdebug Client' (https://github.com/martomo/SublimeTextXdebug) for Sublime. It no longer works with any version of Xdebug released in the last year, and the author seems unreachable, many PRs have sat stagnant against the repo for over a year. I have made attempts to contact the author to no avail. This package merges all standing PRs without conflicts which resolve the showstopper bugs in the current version.