### PR TITLE
Add Persistent Status Bar Line Number package.

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -870,6 +870,16 @@
 			]
 		},
 		{
+			"name": "Persistent Status Bar Line Number",
+			"details": "https://github.com/ryanpcmcquen/sublime_text_persistent_status_bar_line_number",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/skuroda/PersistentRegexHighlight",
 			"releases": [
 				{


### PR DESCRIPTION
This package always shows the line number in the status bar, even when a search/find command is happening, it looks like this (the 31):

![Screen Shot 2019-08-20 at 2 10 07 PM](https://user-images.githubusercontent.com/772937/63385709-632ce080-c356-11e9-8508-f5af095d6022.png)