### PR TITLE
Add package: VisualizeZeroWidthChars

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -583,6 +583,16 @@
 			]
 		},
 		{
+			"name": "VisualizeZeroWidthChars",
+			"details": "https://github.com/jfcherng/Sublime-VisualizeZeroWidthChars",
+			"releases": [
+				{
+					"sublime_text": ">=3118",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Vlt",
 			"details": "https://github.com/tomalec/Sublime-Text-2-Vlt-Plugin",
 			"releases": [


### PR DESCRIPTION
[VisualizeZeroWidthChars](https://github.com/jfcherng/Sublime-VisualizeZeroWidthChars) is a Sublime Text 3 plugin which shows positions of zero-width chars.

![image](https://user-images.githubusercontent.com/6594915/63640583-64eb0100-c6d4-11e9-8801-3c606710ae3b.png)

Reference: https://forum.sublimetext.com/t/how-to-show-utf-8-line-separator-character-which-is-currently-not-displayed/45996/16