### PR TITLE
Added TextToSpeech package to repository/t.json

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -827,6 +827,19 @@
 			]
 		},
 		{
+			"name": "TextToSpeech",
+			"details": "https://github.com/scholer/TextToSpeech",
+			"author": "scholer",
+			"labels": ["tts", "text to speech", "speech synthesis", "voice", "sapi"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": "windows",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Theme - Afterglow",
 			"details": "https://github.com/YabataDesign/afterglow-theme",
 			"labels": ["theme"],


### PR DESCRIPTION
TextToSpeech is a small package that uses `win32com.client` (from the `python-pywin32` dependency) to invoke Windows' built-in TTS system to speak selected text out loud.

The package also provides pause/resume/skip/stop commands.

Installation and usage is described in README.md file.

I hope to add Mac and Linux support in the future - but for now, this is a Windows-only package.

ChannelRepositoryTools: Test Default Channel -> OK.
