### PR TITLE
Add package: Lit-Element Syntax Highlighting

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1149,6 +1149,18 @@
 			]
 		},
 		{
+			"name": "LitElement Syntax Highlighting",
+			"details": "https://github.com/JeremyBernier/LitElement-Syntax-Highlighting",
+			"labels": ["language syntax", "javascript", "lit-element", "lit-html"],
+			"author": "Jeremy Bernier",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Lithium Snippets",
 			"details": "https://github.com/fitzagard/li3_sublime",
 			"labels": ["snippets"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
This package provides syntax highlighting for Google's lit-element and lit-html libraries. lit-html enables HTML templating within tagged template literal strings, but without syntax highlighting all the developer will see is a string. I did not find any libraries providing syntax highlighting for lit-html, so I created my own.