### PR TITLE
Removing clarkewd's Crontab package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3996,17 +3996,6 @@
 			]
 		},
 		{
-			"name": "Crontab Syntax",
-			"details": "https://github.com/clarkewd/SublimeCrontab",
-			"labels": ["language syntax"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Crypto",
 			"details": "https://github.com/mediaupstream/SublimeText-Crypto",
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -3987,6 +3987,7 @@
 		{
 			"name": "Crontab",
 			"details": "https://github.com/michaelblyons/CrontabSublime",
+			"previous_names": ["Crontab Syntax"],
 			"labels": ["language syntax"],
 			"releases": [
 				{


### PR DESCRIPTION
Hi, 

I'd like to deprecate @clarkewd's 'Crontab Syntax' package. It simply doesn't work as advertised anymore. It has been 5 years since it's last update, while the other Crontab package just had a major update last week and is significantly more feature complete.

This is the image on the project
![Claim](https://packagecontrol.io/readmes/img/4d50304ca2513d99a65bb75a7ae5dca84db9842a.png)

vs what the old package looks like when installed on a vanilla Sublime install
![Old Crontab Package](https://user-images.githubusercontent.com/1589119/67138588-8e1dad00-f291-11e9-9c50-6843ebc3032c.png)

When searching for Crontab packages for Sublime, you have 2 options presented to you, both at v1.0.0 and seemingly equal, but the difference is stark.

<img width="679" alt="CrontabHighlightSample" src="https://user-images.githubusercontent.com/1589119/67138807-aa6f1900-f294-11e9-8685-bdd056a8f546.png">


I think we want everyone using the old package to move onto the newer one. I still see a handful of installs for this package on https://packagecontrol.io/packages/Crontab%20Syntax and I can't imagine anyone installing this package is happy with it. 

I don't know what the protocol is to deprecate/remove a package, but I'd like to kick off the conversation