### PR TITLE
update package "Bootstrap 4 Snippets" with updated, not deprecated repository

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -1080,7 +1080,7 @@
 		},
 		{
 			"name": "Bootstrap 4 Snippets",
-			"details": "https://github.com/mdegoo/sublime-bootstrap4",
+			"details": "https://github.com/alexanderankin/sublime-bootstrap4",
 			"labels": ["snippets","Bootstrap","Bootstrap4"],
 			"releases": [
 				{


### PR DESCRIPTION
The url at https://github.com/mdegoo/sublime-bootstrap4 redirects now to https://github.com/degouville/sublime-bootstrap4 which is clearly marked "DEPRECATED | Bootstrap 4 - Sublime Plugin", so i am proposing that this be replaced with my fork - https://github.com/alexanderankin/sublime-bootstrap4.

This snippet workflow is part of my brain like an inextricable cancer. please i am suffering.

after i am opening this package, i am incorporating all of my local changes, and adding release tags to be version matching with bootstrap releases.