### PR TITLE
GitSavvy has moved to an org

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -780,7 +780,7 @@
 		},
 		{
 			"name": "GitSavvy",
-			"details": "https://github.com/divmain/GitSavvy",
+			"details": "https://github.com/timbrel/GitSavvy",
 			"labels": [
 				"git",
 				"dashboard",
@@ -788,7 +788,7 @@
 				"stage",
 				"patch"
 			],
-			"readme": "https://raw.githubusercontent.com/divmain/GitSavvy/master/README.md",
+			"readme": "https://raw.githubusercontent.com/timbrel/GitSavvy/master/README.md",
 			"author": "divmain",
 			"releases": [
 				{


### PR DESCRIPTION
As title, GitSavvy has moved to an org.

The original owner @divmain has moved it to an org.