### PR TITLE
Add Laravel Assertion Completions package

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -175,6 +175,17 @@
 			]
 		},
 		{
+			"name": "Laravel Assertion Completions",
+			"details": "https://github.com/builtbyeleven/laravel-assertion-completions",
+			"labels": ["laravel", "completions"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Laravel Blade AutoComplete",
 			"details": "https://github.com/ahmedash95/sublime-laravel-blade-autocomplete",
 			"releases": [


### PR DESCRIPTION
Add [Laravel assertion](https://laravel.com/docs/6.x/testing) completion to Sublime Text.

I already visit the search page and found no similar package available. 

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
