### PR TITLE
Add "RGBDS" package

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1464,6 +1464,7 @@
 			"name": "RGBDS",
 			"details": "https://github.com/ISSOtm/sublime-RGBDS",
 			"labels": ["language syntax", "game boy", "rgbds"],
+			"previous_names": ["Z80 Assembly (RGBDS)"],
 			"author": "Eldred Habert",
 			"releases": [
 				{

--- a/repository/r.json
+++ b/repository/r.json
@@ -1461,6 +1461,18 @@
 			]
 		},
 		{
+			"name": "RGBDS",
+			"details": "https://github.com/ISSOtm/sublime-RGBDS",
+			"labels": ["language syntax", "game boy", "rgbds"],
+			"author": "Eldred Habert",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "RhetosDSL",
 			"details": "https://github.com/Hugibeer/RhetosDSLSyntax",
 			"labels": ["language syntax"],

--- a/repository/z.json
+++ b/repository/z.json
@@ -24,17 +24,6 @@
 			]
 		},
 		{
-			"name": "Z80 Assembly (RGBDS)",
-			"details": "https://github.com/shinmai/sublime_z80_rgbds",
-			"labels": ["language syntax", "z80", "assembly"],
-			"releases": [
-				{
-					"sublime_text": ">=3092",
-					"tags": true
-				}
-			]
-		},
-		{
 			"details": "https://bitbucket.org/abraly/zap-gremlins",
 			"releases": [
 				{


### PR DESCRIPTION
This package provides a syntax definition, snippets/completions and a few more, all for [RGBDS](https://github.com/rednex/rgbds), currently the most popular Game Boy assembly toolchain.

There is already [another RGBDS package](https://github.com/shinmai/sublime_z80_rgbds/) (#7583), but it's very barebones, and mistakenly states RGBDS assembles z80 assembly (it doesn't, the Game Boy's CPU is [neither a 8080](https://youtu.be/HyzD8pNlpwI?t=779), [neither a z80](https://youtu.be/HyzD8pNlpwI?t=830)). Also, this package is much more complete.

I have made some choices about this package I'm not sure about, so feedback would be really appreciated, and I will do my best to correct any mistakes.

I also intend to provide snippets for common, well, snippets of code; I have asked around whether they should be included in this package, and the agreed answer was that they shouldn't unless they're relevant to the syntax itself. For this reason, I will submit another package containing those if this one gets accepted.