### PR TITLE
Add LSP-metals plugin

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1658,6 +1658,16 @@
 			]
 		},
 		{
+			"name": "LSP-metals",
+			"details": "https://github.com/scalameta/metals-sublime",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Lua Dev",
 			"details": "https://github.com/rorydriscoll/LuaSublime",
 			"labels": ["lua"],

--- a/repository/l.json
+++ b/repository/l.json
@@ -1648,8 +1648,8 @@
 			]
 		},
 		{
-			"name": "LSP-vue",
-			"details": "https://github.com/sublimelsp/LSP-vue",
+			"name": "LSP-metals",
+			"details": "https://github.com/scalameta/metals-sublime",
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1658,8 +1658,8 @@
 			]
 		},
 		{
-			"name": "LSP-metals",
-			"details": "https://github.com/scalameta/metals-sublime",
+			"name": "LSP-vue",
+			"details": "https://github.com/sublimelsp/LSP-vue",
 			"releases": [
 				{
 					"sublime_text": ">=3092",


### PR DESCRIPTION
[Metals](http://scalameta.org/metals) support for Sublime's [LSP](https://github.com/tomv564/LSP) plugin.
It is similar to other language handlers in https://github.com/sublimelsp (see https://github.com/wbond/package_control_channel/pull/7566, https://github.com/wbond/package_control_channel/pull/7568, https://github.com/wbond/package_control_channel/pull/7569 ) but for  [Metals](http://scalameta.org/metals). So far it provides: 
 - automatic installation for the server
 - handler custom server endpoints

More features are planned once the package published :)

cc @olafurpg 