### PR TITLE
Add Django Syntax

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -973,6 +973,16 @@
 			]
 		},
 		{
+			"name": "Django Syntax",
+			"details": "https://github.com/willstott101/django-sublime-syntax",
+			"releases": [
+				{
+					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Django Tags",
 			"details": "https://github.com/Jeewes/SublimeDjangoTags",
 			"releases": [

--- a/repository/d.json
+++ b/repository/d.json
@@ -977,7 +977,7 @@
 			"details": "https://github.com/willstott101/django-sublime-syntax",
 			"releases": [
 				{
-					"sublime_text": ">=3084",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This is a new set of syntax definitions for Django Templates using the sublime-syntax format. Intended to overcome some limitations in Djaneiro's TextMate definitions. It's intentionally a new package without any python script enhancements as I prefer syntax definitions and snippets to be separate in my packages.
