### PR TITLE
Update psutil repo

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -639,12 +639,12 @@
 			"name": "psutil",
 			"load_order": "10",
 			"description": "Python psutil module",
-			"author": "varp",
-			"issues": "https://github.com/varp/sublime-psutil/issues",
+			"author": "randy3k",
+			"issues": "https://github.com/packagecontrol/psutil/issues",
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"base": "https://github.com/varp/sublime-psutil",
+					"base": "https://github.com/packagecontrol/psutil",
 					"platforms": ["osx-x64", "windows-x32", "windows-x64", "linux-x64", "linux-x32"],
 					"tags": true
 				}


### PR DESCRIPTION
This PR redirects the psutil repo to https://github.com/packagecontrol

The existing psutil is bugged and doesn't work on windows, see https://github.com/varp/sublime-psutil/issues/3. The new repo has the following
improvements to the original repo

1. version bump to the newest 5.6.7
2. added ci tests to ensure the module could be loaded
3. the files are built automatically by github actions

Note that I didn't fork the original repo because it doesn't make a lot of sense to keep the commit history of binary files. I have also left a message to @varp about redirecting his repo (see https://github.com/varp/sublime-psutil/issues/3) , but so far I haven't heard from him.