### PR TITLE
Add package: Syntax Highlighting Scopes Showroom

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -5722,6 +5722,16 @@
 			]
 		},
 		{
+			"name": "Syntax Highlighting Scopes Showroom",
+			"details": "https://github.com/baleyko/syntax-highlighting-scopes-showroom",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Syntax History",
 			"details": "https://github.com/malexer/SyntaxHistory",
 			"labels": ["syntax", "syntax highlight"],


### PR DESCRIPTION
Syntax Highlighting Scopes Showroom - it's a package those could highlight syntax highlighting scopes, it helps build interop(Sublime, VSCode, Atom) syntax highlighting package
