### PR TITLE
Add the new Crates package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3912,6 +3912,17 @@
 			]
 		},
 		{
+			"name": "Crates",
+			"details": "https://github.com/Kerollmops/sublime-crates",
+			"labels": ["completions", "rust"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Create Backup Copy",
 			"details": "https://github.com/glutanimate/sublime-create-backup-copy",
 			"labels": ["backup", "file creation"],


### PR DESCRIPTION
I ran the _ChannelRepositoryTools: Test Default Channel_ test command and the 9152 tests passed.

This package helps Rustaceans retrieve the Rust crates versions. The user can either use the command palette to select a crate version to use in a the versions list, or select the names of multiple crates that will be appended with the last crate version available.
