### PR TITLE
New package to display numbers in pop-up

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -905,6 +905,16 @@
 			]
 		},
 		{
+			"name": "Display numbers",
+			"details": "https://github.com/nia40m/sublime-display-nums",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "DistractionFreeWindow",
 			"details": "https://github.com/aziz/DistractionFreeWindow",
 			"labels": ["fullscreen", "distraction-free"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->

My plugin convert and displays a highlighted number in different numeral systems in a pop-up window, what can be helpful to hardware programmers. I didn't found any similar package with a similar functionality.
Plugin can also convert it with a hot-keys, and there is a similar plugin in package list (https://packagecontrol.io/packages/C%20Base%20Converter), but in my plugin is not a main feature, just a bonus. And my plugin can work (display and convert) with only one highlighted number at once.