### PR TITLE
JSONComma moved to organization

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -1178,11 +1178,11 @@
 		},
 		{
 			"name": "JSONComma",
-			"details": "https://github.com/math2001/JSONComma",
+			"details": "https://github.com/jsoncomma/sublime-jsoncomma",
 			"labels": ["JSON", "comma", "text manipulation", "formatting", "formatter", "trailing"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
JSONComma is now at `github.com/jsoncomma/sublime-jsoncomma`.