### PR TITLE
add cidr_convert plugin

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1203,6 +1203,16 @@
 			]
 		},
 		{
+			"name": "CIDR Convert",
+			"details": "https://github.com/shenanigans123/cidr_convert",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CircleCi Status",
 			"details": "https://github.com/drazisil/sublime-circleci/",
 			"releases": [


### PR DESCRIPTION
Added a plugin:

Converts IPv4 addresses to/from cidr notation. Detects and converts addresses between the formats:
    192.168.1.0 255.255.255.0
    192.168.1.0/24

Acts on entire document if no text is selected, otherwise only acts within selected area.

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
