### PR TITLE
Add ST3 syntax definition for Bison

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -792,11 +792,11 @@
 		},
 		{
 			"name": "Bison",
-			"details": "https://bitbucket.org/artyom_smirnov/sublime-text-bison-highlighter",
-			"labels": ["language syntax"],
+			"details": "https://github.com/ISSOtm/sublime-Bison",
+			"labels": ["bison", "language syntax", "yacc"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3084",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Supersedes the [previous TextMate syntax](https://bitbucket.org/artyom_smirnov/sublime-text-bison-highlighter/src/master/). It used only regexes, causing breakage (for example, ignoring escaped quotes caused string contexts to run wild), and was not aware of the embedded C syntax, losing a lot of highlighting. Only a syntax definition is provided because the language is simple and little more than a grammar description, so I couldn't come up with useful snippets, etc.

This syntax is fairly heavy because it somewhat follows Bison's structure, making the highlighting more precise and context-aware. This works fine—coloration took less than half a second—for me on a 2241-line file.

I have not found a way to contact the current package's author, and it was last updated in 2014, so I thought it would be fine to take its place.