### PR TITLE
Use original repo for Specman syntax

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3114,7 +3114,7 @@
 		},
 		{
 			"name": "Specman",
-			"details": "https://github.com/blutsvente/Specman",
+			"details": "https://github.com/tsvi/Specman",
 			"labels": ["language syntax"],
 			"releases": [
 				{


### PR DESCRIPTION
We decided it would be better if we manage the Specman syntax from the original repo instead of from a forked version.
This change fixes this.

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
