### PR TITLE
Renamed Package

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -1032,17 +1032,6 @@
 			]
 		},
 		{
-			"name": "Environment Settings",
-			"details": "https://bitbucket.org/daniele-niero/environmentsettings",
-			"labels": ["environment", "variables", "project"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "EnvSwitcher",
 			"details": "https://github.com/SaschaMzH/EnvSwitcher",
 			"labels": ["environment", "project"],

--- a/repository/p.json
+++ b/repository/p.json
@@ -2354,18 +2354,6 @@
 			]
 		},
 		{
-			"name": "ProjectEnvironment",
-			"previous_names": ["Project Environment", "Environment Settings"],
-			"details": "https://bitbucket.org/daniele-niero/sublimeprojectenvironment",
-			"labels": ["environment", "variables", "project"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Project PHP ClassBrowser",
 			"details": "https://github.com/degami/ProjectPHPClassBrowser",
 			"releases": [
@@ -2434,6 +2422,18 @@
 			"releases": [
 				{
 					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "ProjectEnvironment",
+			"previous_names": ["Project Environment", "Environment Settings"],
+			"details": "https://bitbucket.org/daniele-niero/sublimeprojectenvironment",
+			"labels": ["environment", "variables", "project"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]

--- a/repository/p.json
+++ b/repository/p.json
@@ -2355,6 +2355,18 @@
 			]
 		},
 		{
+			"name": "Project Environment",
+			"previous_names": ["EnvironmentSettings"],
+			"details": "https://bitbucket.org/daniele-niero/sublimeprojectenvironment",
+			"labels": ["environment", "variables", "project"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Project PHP ClassBrowser",
 			"details": "https://github.com/degami/ProjectPHPClassBrowser",
 			"releases": [

--- a/repository/p.json
+++ b/repository/p.json
@@ -2356,7 +2356,7 @@
 		},
 		{
 			"name": "Project Environment",
-			"previous_names": ["EnvironmentSettings"],
+			"previous_names": ["Environment Settings"],
 			"details": "https://bitbucket.org/daniele-niero/sublimeprojectenvironment",
 			"labels": ["environment", "variables", "project"],
 			"releases": [

--- a/repository/p.json
+++ b/repository/p.json
@@ -2355,8 +2355,8 @@
 			]
 		},
 		{
-			"name": "Project Environment",
-			"previous_names": ["Environment Settings"],
+			"name": "ProjectEnvironment",
+			"previous_names": ["Project Environment", "Environment Settings"],
 			"details": "https://bitbucket.org/daniele-niero/sublimeprojectenvironment",
 			"labels": ["environment", "variables", "project"],
 			"releases": [


### PR DESCRIPTION
I just renamed "Project Environment" to "ProjectEnvironment".
It wasn't clever to use spaces in the package's name.
I think remove the space it's better for anyone using the package 