### PR TITLE
LSP tag split

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1659,12 +1659,12 @@
 			"labels": ["auto-complete", "linting", "formatting", "code navigation", "intellisense"],
 			"releases": [
 				{
-					"sublime_text": "3092 - 4065",
-					"tags": "st3-"
+					"sublime_text": "3154 - 4065",
+					"tags": "3154."
 				},
 				{
 					"sublime_text": ">=4065",
-					"tags": "st4-"
+					"tags": "4065."
 				}
 			]
 		},

--- a/repository/l.json
+++ b/repository/l.json
@@ -1656,10 +1656,15 @@
 		{
 			"name": "LSP",
 			"details": "https://github.com/sublimelsp/LSP",
+			"labels": ["auto-complete", "linting", "formatting", "code navigation", "intellisense"],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
-					"tags": true
+					"sublime_text": "3092 - 4065",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4065",
+					"tags": "st4-"
 				}
 			]
 		},

--- a/repository/l.json
+++ b/repository/l.json
@@ -1659,12 +1659,12 @@
 			"labels": ["auto-complete", "linting", "formatting", "code navigation", "intellisense"],
 			"releases": [
 				{
-					"sublime_text": "3154 - 4065",
+					"sublime_text": "3154 - 4069",
 					"tags": "3154."
 				},
 				{
-					"sublime_text": ">=4065",
-					"tags": "4065."
+					"sublime_text": ">=4070",
+					"tags": "4070."
 				}
 			]
 		},

--- a/repository/l.json
+++ b/repository/l.json
@@ -1660,11 +1660,11 @@
 			"releases": [
 				{
 					"sublime_text": "3154 - 4069",
-					"tags": "3154."
+					"tags": "3154-"
 				},
 				{
 					"sublime_text": ">=4070",
-					"tags": "4070."
+					"tags": "4070-"
 				}
 			]
 		},


### PR DESCRIPTION
Split up the LSP package into separate tags. The tag prefix is the major version number of the "semver", and it will denote the minimum required ST build version for this plugin to work.

- Will the tag prefixes in the PR work as expected?
- I have graciously stolen the "range" syntax (3154 - 4065) from LaTeXTools's entry, but I would like to verify from someone more knowledgeable on the matter whether this syntax actually works.
- What will Package Control do if there's no tag yet that matches any of the tag prefixes in this entry? Should we create a new release before merging this?