### PR TITLE
Fix project maker

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2453,7 +2453,7 @@
 		{
 			"name": "ProjectMaker",
 			"details": "https://github.com/bit101/ProjectMaker",
-			"labels": ["project", "template", "project-templates", "jinja2"],
+			"labels": ["project", "template", "project-templates", "cookiecutter", "jinja2"],
 			"previous_names" : ["STProjectMaker"],
 			"releases": [
 				{

--- a/repository/p.json
+++ b/repository/p.json
@@ -2453,7 +2453,7 @@
 		{
 			"name": "ProjectMaker",
 			"details": "https://github.com/bit101/ProjectMaker",
-			"labels": ["project", "template", "jinja2"],
+			"labels": ["project", "template", "project-templates", "jinja2"],
 			"previous_names" : ["STProjectMaker"],
 			"releases": [
 				{

--- a/repository/p.json
+++ b/repository/p.json
@@ -2451,6 +2451,18 @@
 			]
 		},
 		{
+			"name": "ProjectMaker",
+			"details": "https://github.com/bit101/ProjectMaker",
+			"labels": ["project", "template", "jinja2"],
+			"previous_names" : ["STProjectMaker"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ProjectTreeTemplater",
 			"details": "https://github.com/julianxhokaxhiu/sublime-projecttreetemplater",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -3865,15 +3865,6 @@
 			]
 		},
 		{
-			"details": "https://github.com/bit101/STProjectMaker",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "Strace Syntax",
 			"details": "https://github.com/djuretic/SublimeStrace",
 			"labels": ["language syntax"],


### PR DESCRIPTION
`STProjectMaker` got renamed to `ProjectMaker`.
This **PR** updates both name and URL to the package.
It also switches to tag-based release.

This is a successor to the previous **PR**: #7014 