### PR TITLE
Add ST3 syntax package for Mandoc

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -343,6 +343,17 @@
 			]
 		},
 		{
+			"name": "Mandoc",
+			"details": "https://github.com/ISSOtm/sublime-mandoc",
+			"labels": ["language syntax", "mandoc", "man", "man page"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ManiaScript",
 			"details": "https://github.com/Anthodev/Sublime-ManiaScript",
 			"labels": ["language syntax"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
This package provides a syntax definition and a couple commands for the [mandoc](https://mandoc.bsd.lv) markup language. Part of the aim was to be at least on par with [Man Page Support](https://packagecontrol.io/packages/Man%20Page%20Support).

This package does not duplicate nor supersede the one linked above: Mandoc is a very different language, that tries to eschew raw [gt]roff commands in favor of more semantic macros. And while the `mandoc` utility is able to process the man language (and I believe groff has some mandoc compatibility?), both languages are completely different.
As explained in a comment at the beginning of the syntax file, since direct roff usage is strongly discouraged in Mandoc documents, and the syntax is large enough as-is, that part is not supported (and will probably be considered "invalid" by the catch-all, which isn't entirely wrong).

All support I could extract from semantics should be provided, with the exception of parsing inline macros, because that's very annoying to do, and not *that* common afaik. There's a TODO comment for it if someone wants to contribute.