### PR TITLE
Add lsp_utils dependency module

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -377,6 +377,20 @@
 			]
 		},
 		{
+			"name": "lsp_utils",
+			"load_order": "10",
+			"description": "Module with LSP-related utilities",
+			"author": "rchl",
+			"issues": "https://github.com/sublimelsp/lsp_utils/issues",
+			"releases": [
+				{
+					"base": "https://github.com/sublimelsp/lsp_utils",
+					"tags": true,
+					"sublime_text": ">=3000"
+				}
+			]
+		},
+		{
 			"name": "lxml",
 			"load_order": "10",
 			"description": "lxml",


### PR DESCRIPTION
This dependency provides some LSP-related utilities with the intention of sharing those between multiple LSP-* packages providing various language servers.

Currently the only utility provided is `ServerNpmResource` which is for copying server resources from the original package into Sublime's cache directory and running them from there.