### PR TITLE
Adding bracex dependency

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -74,6 +74,20 @@
 			]
 		},
 		{
+			"name": "bracex",
+			"load_order": "50",
+			"description": "Bracex creates arbitrary strings via brace expansion much like Bash's.",
+			"author": "facelessuser",
+			"issues": "https://github.com/facelessuser/sublime-bracex/issues",
+			"releases": [
+				{
+					"sublime_text": ">=3006",
+					"base": "https://github.com/facelessuser/sublime-bracex",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "bs4",
 			"load_order": "51",
 			"description": "Beautiful Soup is a Python library for pulling data out of HTML and XML files - https://www.crummy.com/software/BeautifulSoup/",

--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -74,14 +74,15 @@
 			]
 		},
 		{
-			"name": "bracex",
+			"name": "
+			",
 			"load_order": "50",
 			"description": "Bracex creates arbitrary strings via brace expansion much like Bash's.",
 			"author": "facelessuser",
 			"issues": "https://github.com/facelessuser/sublime-bracex/issues",
 			"releases": [
 				{
-					"sublime_text": ">=3006",
+					"sublime_text": ">=3000",
 					"base": "https://github.com/facelessuser/sublime-bracex",
 					"tags": true
 				}

--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -74,8 +74,7 @@
 			]
 		},
 		{
-			"name": "
-			",
+			"name": "bracex",
 			"load_order": "50",
 			"description": "Bracex creates arbitrary strings via brace expansion much like Bash's.",
 			"author": "facelessuser",


### PR DESCRIPTION
**What**
Bracex is a brace expanding library (à la Bash) for Python. Brace expanding is used to generate arbitrary strings.

```bash
echo {{a,b},c}d
ad bd cd
```

Bracex adds this ability to Python:

```python
bracex.expand(r'file-{{a,b},c}d.txt')
['file-ad.txt', 'file-bd.txt', 'file-cd.txt']
```