### PR TITLE
Add the Create WebP Image package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3830,6 +3830,16 @@
 			]
 		},
 		{
+			"name": "Create WebP Image",
+			"details": "https://github.com/TomasBarry/Sublime-create-webp-image",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CreativeCrocodile",
 			"details": "https://github.com/Abban/CreativeCrocodile",
 			"releases": [


### PR DESCRIPTION
The `Create WebP Image` package is an interface to the [`CWebP`](https://developers.google.com/speed/webp/docs/using) tool. It can be used on `PNG`, `JPG`, `BMP`, and `GIF` files and it can optionally be opened in the browser to ensure that the conversion has created a good WebP image.
