### PR TITLE
Add GitCoAuthor package

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -475,6 +475,19 @@
 			]
 		},
 		{
+			"author": ["Tomas Barry"],
+			"name": "Git CoAuthor",
+			"description": "Auto-complete a git commit co-authorship",
+			"labels": ["git", "git commit", "co-author"],
+			"details": "https://github.com/TomasBarry/Sublime-git-co-author",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Git Commit Message Syntax",
 			"details": "https://github.com/adambullmer/sublime_git_commit_syntax",
 			"labels": [


### PR DESCRIPTION
Provide an autocomplete template (in git commit messages) for the co-authorship of the git message. It is a very easy string to mix up and a template will ensure that you don't get it wrong and can correctly share the blame on git commits!