### PR TITLE
Change TrailingSpaces to be ST3+ only

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2960,10 +2960,11 @@
 			]
 		},
 		{
+			"name": "TrailingSpaces",
 			"details": "https://github.com/SublimeText/TrailingSpaces",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3148",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
I don't even know if it was still ST2-compatible, but now it won't as
it will use `region.redish` color for highlighting trailing spaces.

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks, depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass. 
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can trigger @packagecontrol-bot to re-evaluate your pull request
by pushing a commit or closing and reopening your pull request.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"` 
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
 
You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists, 
why you believe it is different and needed
below this line. -->
