### PR TITLE
added Markdown Code Blocks

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -458,6 +458,17 @@
 			]
 		},
 		{
+			"name": "Markdown Code Packer",
+			"details": "https://github.com/motine/MarkdownCodePacker",
+			"labels": ["markdown"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Markdown Extended",
 			"details": "https://github.com/jonschlinkert/sublime-markdown-extended",
 			"releases": [


### PR DESCRIPTION
Added `Markdown Code Blocks`

This plugin packs code and files into markdown documents. This Sublime 3 plugin converts code blocks to compressed, single-line comments to improve visibility.

Please see more info in [here](https://github.com/motine/MarkdownCodePacker/blob/master/README.md).