### PR TITLE
Add GitUrl

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -851,6 +851,17 @@
 			]
 		},
 		{
+			"name": "GitUrl",
+			"details": "https://github.com/kurtmoser/sublime-giturl",
+			"labels": ["git"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "GL Shader Validator",
 			"details": "https://github.com/WebGLTools/GL-Shader-Validator",
 			"releases": [


### PR DESCRIPTION
Open git repos in browser directly from Sublime Text.

Supports GitHub, Bitbucket and GitLab repos out of the box as well as option to configure your own self-hosted git services. Files tracked by git will have context menu option to open url by using either branch or commit as a reference point. Latter is helpful as even if the file changes in the future, the link still keeps pointing to the originally intended part in the code.

---

Some random repos plugin can be tested with:
GitHub: https://github.com/SublimeText/TrailingSpaces
Bitbucket: https://bitbucket.org/atlassian/amps
GitLab: https://gitlab.com/gitlab-org/gitlab
Self-hosted: https://ec.europa.eu/cefdigital/code/projects/esig/repos/dss

Self-hosted git service above requires plugin to be configured (Preferences -> Package Settings -> GitUrl -> Settings) as follows:
```
{
    "domains": {
        "ec.europa.eu": {
            "url": "http://{domain}/cefdigital/code/projects/{user}/repos/{repo}/browse/{path}",
            "url_commit": "http://{domain}/cefdigital/code/projects/{user}/repos/{repo}/browse/{path}?at={revision}",
            "url_branch": "http://{domain}/cefdigital/code/projects/{user}/repos/{repo}/browse/{path}?at=refs/heads/{revision}",
            "line": "#{line}",
            "line_range": "#{line}-{line_end}"
        } 
    }
}
```