### PR TITLE
Adds Gluecodium package

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -949,6 +949,17 @@
 			]
 		},
 		{
+			"name": "Gluecodium",
+			"details": "https://github.com/Hsilgos/GluecodiumSyntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "GM Syntax",
 			"details": "https://github.com/andyp123/GMSyntax",
 			"releases": [


### PR DESCRIPTION
Gluecodium is open sources project which generates code to connect Java, Swift and Dart to C++. The main focus is Android and iOS. Gluecodium parses input files where entities are described in special language which is called `LimeIDL`. This package provides syntax highlighting for this language.