### PR TITLE
Update: Pretty Json → Tag Support → ST3/ST4 support

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2176,8 +2176,12 @@
 			"labels": ["json", "pretty", "lint", "minify", "validate", "query", "json2xml"],
 			"releases": [
 				{
-					"sublime_text": "*",
-					"branch": "master"
+					"sublime_text": "<4000",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
**What**: **Pretty Json**

1. Moved from branch to tag releases
2. Updated to support ST3 and ST4 tags
3. Remove `.no-sublime-package`