### PR TITLE
Add Better PHPunit

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -594,6 +594,17 @@
 			]
 		},
 		{
+			"name": "Better PHPUnit",
+			"details": "https://github.com/dinhquochan/better-phpunit",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Better RSpec",
 			"details": "https://github.com/fnando/better-rspec-for-sublime-text",
 			"labels": ["language syntax", "snippets"],


### PR DESCRIPTION
Better PHPUnit support run PHPUnit on macOS.
Support terminal: `Terminal.app`, `iTerm`, `Alacritty` and `Hyper`. 

