### PR TITLE
Add AttrFold plugin

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2074,6 +2074,17 @@
 			]
 		},
 		{
+			"name": "AttrFold",
+			"details": "https://github.com/druc/Sublime-AttrFold",
+			"labels": ["fold"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Attribute Grammar",
 			"details": "https://github.com/TiborIntelSoft/SublimeUUAGC",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Hey, 

When with utility-first css frameworks you end up with super long `class=` attributes, making it harder to make your way through the code when you're working on behaviour stuff (event handlers, v-models, ngModels, properties, etc);

This plugin offers a handy `super+option+k` / `ctrl+alt+k` binding that toggles folding for specific attributes.

I know Sublime already has a `fold_tag_attributes` command, but it folds *every* tag attribute, whereas this plugin allows you to configure which ones you want to be folded.

![attrfold](https://user-images.githubusercontent.com/13726728/80309522-43e82c00-87de-11ea-97d6-511d4eaab779.gif)
