### PR TITLE
Add ForceMoveToGroup Plugin

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1559,6 +1559,16 @@
 			]
 		},
 		{
+			"name": "ForceMoveToGroup",
+			"details": "https://github.com/tkotosz/SublimeForceMoveToGroup",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Foremark",
 			"details": "https://github.com/Foremark/Sublime-Foremark",
 			"labels": ["language syntax", "Foremark"],


### PR DESCRIPTION
Adds a simple command to allow moving tabs between groups a bit more easily than with the build in "move_to_group"