### PR TITLE
Deprecate ST2 for SublimePrettyYaml

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2211,8 +2211,12 @@
 			"details": "https://github.com/aukaost/SublimePrettyYAML",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3000",
 					"tags": true
+				},
+				{
+					"sublime_text": "<3000",
+					"tags": "st2-"
 				}
 			]
 		},


### PR DESCRIPTION
Deprecating Sublime Text 2 support via git tags.