### PR TITLE
Update package name: y0ssar1an/CSS3 -> ryboe/CSS3

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -4404,7 +4404,7 @@
 		},
 		{
 			"name": "CSS3",
-			"details": "https://github.com/y0ssar1an/CSS3",
+			"details": "https://github.com/ryboe/CSS3",
 			"labels": ["language syntax", "completions", "auto-complete", "reset", "linting"],
 			"releases": [
 				{


### PR DESCRIPTION
I've changed my GitHub username to something easier to type.

Note that `github.com/y0ssar1an/CSS3` still works. It redirects to `ryboe/CSS3`.