### PR TITLE
Add new package "Hansl-Gretl-Language"

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -168,10 +168,10 @@
 		{
 			"name": "Hansl-Gretl-Language",
 			"details": "https://github.com/atecon/Hansl-Gretl-Language",
-			"labels": ["language syntax", "snippets", "auto-complete"],
+			"labels": ["language syntax", "snippets", "completions"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]

--- a/repository/h.json
+++ b/repository/h.json
@@ -166,6 +166,17 @@
 			]
 		},
 		{
+			"name": "Hansl-Gretl-Language",
+			"details": "https://github.com/atecon/Hansl-Gretl-Language",
+			"labels": ["language syntax", "snippets", "auto-complete"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "HaoGist",
 			"details": "https://github.com/xjsender/HaoGist",
 			"labels": ["gist", "cache"],


### PR DESCRIPTION
Initial release of new sublime package for supporting the Gretl scripting language called Hansl.
Package's features are:
- Syntax-highlighting
- Auto-completion
- Snippets
- Gretl build-systems (Batch mode, CLI, REPL)

Gretl is an open-source statistics and econometrics software: http://gretl.sourceforge.net/
Hansl is a recursive acronym: it stands for "Hansl’s A Neat Scripting Language". For a primer on Hansl: https://sourceforge.net/projects/gretl/files/manual/hansl-primer-a4.pdf/download