### PR TITLE
Add new package "JapanWordStop"

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -121,6 +121,17 @@
 			]
 		},
 		{
+			"name": "JapanWordStop",
+			"details": "https://github.com/woodmix/JapanWordStop",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["windows", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Jasmin JVM Assembler",
 			"details": "https://github.com/funatsufumiya/jasmin-sublime",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->

This is a plugin to make word jumps such as ctrl+right appropriate for Japanese strings.

There are plugins for the same purpose, "JapaneseWordSeparator" and "Japanese Word Jump", but the logic for determining the jump stop position is completely different.
They use a library called "tinysegmenter", but "JapanWordStop" simply uses the character type to determine the stop position.

I'd like to offer this plugin as an expansion of choices, not a question of superiority or inferiority.