### PR TITLE
Add Notepad++ Tab Context plugin

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -920,7 +920,7 @@
 			"labels": ["tab context", "notepad++"],
 			"releases": [
 				{
-					"sublime_text": ">3211",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]

--- a/repository/n.json
+++ b/repository/n.json
@@ -915,6 +915,17 @@
 			]
 		},
 		{
+			"name": "Notepad++ Tab Context",
+			"details": "https://github.com/josephmorrill/SublimeNppTabContextPlugin",
+			"labels": ["tab context", "notepad++"],
+			"releases": [
+				{
+					"sublime_text": ">3211",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Notes",
 			"details": "https://github.com/tbh1/sublime-notes",
 			"labels": ["language syntax", "documentation", "notes"],


### PR DESCRIPTION
Adds some useful tab context menu commands from Notepad++:

- Close Tabs to the Left
- Save
- Save As...
- Rename
- Delete
- Open containing folder in file explorer
- Open containing folder in terminal
- Open in default viewer
- Copy file path
- Copy filename
- Copy directory path