### PR TITLE
Create ST3 branch for LSP-eslint

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1723,7 +1723,11 @@
 			"details": "https://github.com/sublimelsp/LSP-eslint",
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": "3092 - 3999",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
New version of eslint server replaces format-on-save with
code-actions-on-save and only LSP ST4 version will support that.