### PR TITLE
Add 'INTENS' language for syntax highlighting

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -907,6 +907,17 @@
 			]
 		},
 		{
+			"name": "INTENS Language",
+			"details": "https://github.com/anticultist/sublime-intenslang",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3103",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Interactive Data Language (IDL)",
 			"details": "https://github.com/cschreib/sublime-idl",
 			"releases": [


### PR DESCRIPTION
This package provides syntax highlighting for the so called [INTENS ](https://www.semafor.ch/en/products/intens/)language of the company Semafor AG.