### PR TITLE
Replace Zeal package with a fork

### DIFF
--- a/repository/z.json
+++ b/repository/z.json
@@ -34,12 +34,16 @@
 		},
 		{
 			"name": "Zeal",
-			"details": "https://github.com/vaanwd/Zeal",
-			"author": "vaanwd",
+			"details": "https://github.com/SublimeText/Zeal",
+			"author": ["vaanwd", "FichteFoll"],
 			"releases": [
 				{
-					"sublime_text": "*",
-					"branch": "master"
+					"sublime_text": "<3170",
+					"tags": "st2-v"
+				},
+				{
+					"sublime_text": ">=3170",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Replaces @vaanwd's Zeal package with a fork that I updated.

I submitted a PR 30 days ago at https://github.com/vaanwd/Zeal/pull/30 without a reply, so I'm suggesting to replace the package and offer to maintain it in the future, which is why I adopted it under the @SublimeText org umbrella.

@vaanwd, you may object to this change within the next 14 days.