### PR TITLE
Add dprint

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -1545,6 +1545,16 @@
 			]
 		},
 		{
+			"name": "dprint",
+			"details": "https://github.com/dprint/dprint-sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Dracula Color Scheme",
 			"details": "https://github.com/dracula/sublime",
 			"labels": ["color scheme"],


### PR DESCRIPTION
This adds a sublime editor extension for [dprint](https://github.com/dprint/dprint), which is a code formatter.