### PR TITLE
add map preview package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -408,7 +408,7 @@
 		},
 		{
 			"name": "MapPreview",
-			"details": "https://github.com/doneill/st3-map-preview",
+			"details": "https://github.com/doneill/MapPrevieww",
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/m.json
+++ b/repository/m.json
@@ -407,6 +407,16 @@
 			]
 		},
 		{
+			"name": "MapPreview",
+			"details": "https://github.com/doneill/st3-map-preview",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MapTool Syntax",
 			"details": "https://github.com/wwmoraes/Sublime-MapTool-Syntax",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->

This package provides ability to preview spatial map data files in your default web browser on a map.  Current supported map formats are [GeoJSON](https://geojson.org/) & [TopoJSON](https://github.com/topojson/topojson). Open a valid GeoJSON or TopoJSON file and run the Map Preview command from the command pallete, valid files will be parsed and displayed inside users default web browser overlayed a world map.  
