### PR TITLE
Add LSP-TexLab

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1813,6 +1813,17 @@
 			]
 		},
 		{
+			"name": "LSP-TexLab",
+			"details": "https://github.com/sublimelsp/LSP-TexLab",
+			"releases": [
+				{
+					"sublime_text": ">=4070",
+					"platforms": ["windows-x64", "osx-x64", "linux-x64"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LSP-typescript",
 			"details": "https://github.com/sublimelsp/LSP-typescript",
 			"releases": [


### PR DESCRIPTION
## Description

LaTeX support for Sublime's LSP plugin provided through [latex-lsp/texlab](https://github.com/latex-lsp/texlab).

- The official [language server](https://github.com/latex-lsp/texlab/releases) only provides x64 pre-builts.
- This plugin depends on LSP `st4000-exploration` branch, so it requires ST 4.


## Repo

https://github.com/sublimelsp/LSP-TexLab
