### PR TITLE
NoLine (Package Submission)

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -813,6 +813,17 @@
 			]
 		},
 		{
+			"name": "NoLine", 
+			"details": "https://github.com/Weilory/sublime-noline",
+			"labels": ["blank", "remove blank", "empty line"], 
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		}
+		{
 			"name": "Non Text Files",
 			"details": "https://github.com/bordaigorl/sublime-non-text-files",
 			"labels": ["file navigation", "preview", "file open"],

--- a/repository/n.json
+++ b/repository/n.json
@@ -822,7 +822,7 @@
 					"tags": true
 				}
 			]
-		}
+		},
 		{
 			"name": "Non Text Files",
 			"details": "https://github.com/bordaigorl/sublime-non-text-files",


### PR DESCRIPTION
Sublime Text does not handle white space and blank line generating among particular formats very well. For example, if I convert a txt file to a js file, it would add excess blanks between each line of code. Many stack overflow topics address this issue: https://stackoverflow.com/questions/12008986/sublime-text-2-how-to-delete-blank-empty-lines. 
After install, you can find `NoLine` in Menubar -> Edit. write some dummy codes separated by lines (one or more), then run `NoLine`, it should remove excess blanks meanwhile keep the indentation lines. 