### PR TITLE
Upgrade to Emmet 2

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -6,6 +6,7 @@
 		"https://bitbucket.org/klorenz/sublime_packages/raw/tip/packages.json",
 		"https://donkirkby.github.io/live-py-plugin/sublime-package/package.json",
 		"https://eoa-cdn.s3.amazonaws.com/extensions/packages.json",
+		"https://github.com/emmetio/sublime-text-plugin/releases/latest/download/registry.json",
 		"https://packagecontrol.io/packages_2.json",
 		"https://packages.monokai.pro/packages.json",
 		"https://raw.githubusercontent.com/20Tauri/DoxyDoxygen/master/DoxyDoxygen.json",

--- a/repository/e.json
+++ b/repository/e.json
@@ -846,16 +846,6 @@
 			]
 		},
 		{
-			"name": "Emmet",
-			"details": "https://github.com/sergeche/emmet-sublime",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "Emmet Css Snippets",
 			"details": "https://github.com/P233/Emmet-Css-Snippets-for-Sublime-Text-2",
 			"labels": ["snippets"],


### PR DESCRIPTION
This PR upgrades Emmet package to v2, which now uses different update strategy (via GitHub releases) and lives in new repo.
A follow-up of https://forum.sublimetext.com/t/best-strategy-to-update-emmet-plugin/53015