### PR TITLE
Adds the BetterTwig package.

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -681,6 +681,17 @@
 			]
 		},
 		{
+			"name": "BetterTwig",
+			"details": "https://github.com/Sublime-Instincts/BetterTwig",
+			"labels": ["syntax", "twig", "highlighting", "php"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "BeyondCompare",
 			"details": "https://github.com/npadley/BeyondCompare",
 			"labels": ["diff", "difference", "diff/merge", "file comparison"],

--- a/repository/b.json
+++ b/repository/b.json
@@ -626,6 +626,16 @@
 			]
 		},
 		{
+			"name": "BetterJinja",
+			"details": "https://github.com/Sublime-Instincts/BetterJinja",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "BetterSave",
 			"details": "https://github.com/adrian-tut/BetterSave",
 			"labels": ["save", "close"],

--- a/repository/b.json
+++ b/repository/b.json
@@ -628,6 +628,7 @@
 		{
 			"name": "BetterJinja",
 			"details": "https://github.com/Sublime-Instincts/BetterJinja",
+			"labels": ["syntax", "jinja2", "highlighting"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/b.json
+++ b/repository/b.json
@@ -670,17 +670,6 @@
 			]
 		},
 		{
-			"name": "BetterTwig",
-			"details": "https://github.com/Sublime-Instincts/BetterTwig",
-			"labels": ["syntax", "twig", "highlighting", "php"],
-			"releases": [
-				{
-					"sublime_text": ">=3092",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "BeyondCompare",
 			"details": "https://github.com/npadley/BeyondCompare",
 			"labels": ["diff", "difference", "diff/merge", "file comparison"],

--- a/repository/b.json
+++ b/repository/b.json
@@ -626,17 +626,6 @@
 			]
 		},
 		{
-			"name": "BetterJinja",
-			"details": "https://github.com/Sublime-Instincts/BetterJinja",
-			"labels": ["syntax", "jinja2", "highlighting"],
-			"releases": [
-				{
-					"sublime_text": ">=3092",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "BetterSave",
 			"details": "https://github.com/adrian-tut/BetterSave",
 			"labels": ["save", "close"],

--- a/repository/t.json
+++ b/repository/t.json
@@ -3357,11 +3357,17 @@
 		},
 		{
 			"name": "Twig",
-			"details": "https://github.com/purplefish32/sublime-text-2-twig",
+			"details": "https://github.com/Sublime-Instincts/BetterTwig",
+			"labels": ["Twig", "templates", "PHP", "syntax"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"base": "https://github.com/purplefish32/sublime-text-2-twig",
+					"sublime_text": "<3092",
 					"branch": "master"
+				},
+				{
+					"sublime_text": ">=3092",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
This PR adds the [BetterTwig](https://github.com/Sublime-Instincts/BetterTwig) Package to Package Control.

This package provides syntax highlighting, snippets, completions & more for PHP twig templates.

There is an existing package already which is [PHP-Twig](https://packagecontrol.io/packages/PHP-Twig), however the package hasn't been updated to keep up with latest syntax improvements via `.sublime-syntax` for ST3. So this package offers,

- An updated & tested syntax file which follows the official scope naming guidelines as closely as possible.
- Snippets for Twig code blocks.
- Completions for built in tests, filters, functions & loop variables.
- Ability to use <kbd>ctrl + /</kbd> for Twig comments.
- Certain key bindings to make life a little bit easier.

I decided to keep `BetterJinja` & this package separate because there are some differences between the templating languages.