### PR TITLE
Add INI Syntax package

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -679,6 +679,17 @@
 			]
 		},
 		{
+			"name": "INI Syntax",
+			"details": "https://github.com/jwortmann/ini-syntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Initializr",
 			"details": "https://github.com/drinks/sublime-initializr",
 			"labels": ["automation", "utils"],

--- a/repository/i.json
+++ b/repository/i.json
@@ -670,19 +670,14 @@
 		},
 		{
 			"name": "INI",
-			"details": "https://github.com/clintberry/sublime-text-2-ini",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
-			"name": "INI Syntax",
 			"details": "https://github.com/jwortmann/ini-syntax",
 			"labels": ["language syntax"],
 			"releases": [
+				{
+					"base": "https://github.com/clintberry/sublime-text-2-ini",
+					"sublime_text": "<3092",
+					"branch": "master"
+				},
 				{
 					"sublime_text": ">=3092",
 					"tags": true


### PR DESCRIPTION
This package provides syntax highlighting for INI and Windows Registry (.reg) files. There already exist two other packages for this (https://packagecontrol.io/packages/INI and https://packagecontrol.io/packages/REG), but they both use the old .tmLanguage format, provide only very minimalistic highlighting, and don't really follow the scope naming guidelines.