### PR TITLE
Add "st3" release branch for LSP-pyright

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1742,6 +1742,10 @@
 			"details": "https://github.com/sublimelsp/LSP-pyright",
 			"releases": [
 				{
+					"sublime_text": "3154 - 4069",
+					"tags": "st3-"
+				},
+				{
 					"sublime_text": ">=4070",
 					"tags": true
 				}


### PR DESCRIPTION
If a tag starts with `st3-`, it's for ST 3. Otherwise, it's for ST 4.