### PR TITLE
Add LSP-pyls

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1738,6 +1738,16 @@
 			]
 		},
 		{
+			"name": "LSP-pyls",
+			"details": "https://github.com/sublimelsp/LSP-pyls",
+			"releases": [
+				{
+					"sublime_text": ">=4070",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LSP-pyright",
 			"details": "https://github.com/sublimelsp/LSP-pyright",
 			"releases": [


### PR DESCRIPTION
This is a convenience package that installs/updates [Palantir's python-language-server](https://github.com/palantir/python-language-server) in a virtual environment in $DATA/Cache/LSP-pyls. It will also add the paths to `sublime.py` and `sublime_plugin.py` to Jedi's paths, as well as $DATA/Packages.