### PR TITLE
Add LSP-PowerShellEditorServices

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1728,6 +1728,16 @@
 			]
 		},
 		{
+			"name": "LSP-PowerShellEditorServices",
+			"details": "https://github.com/sublimelsp/LSP-PowerShellEditorServices",
+			"releases": [
+				{
+					"sublime_text": ">=4070",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LSP-promql",
 			"details": "https://github.com/prometheus-community/sublimelsp-promql",
 			"releases": [


### PR DESCRIPTION
This is a helper package that updates/installs [PowerShellEditorServices](https://github.com/PowerShell/PowerShellEditorServices), to be used with `source.powershell` base scopes.