### PR TITLE
Add LSP-SourceKit

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1762,6 +1762,17 @@
 			]
 		},
 		{
+			"name": "LSP-SourceKit",
+			"details": "https://github.com/sublimelsp/LSP-SourceKit",
+			"releases": [
+				{
+					"sublime_text": ">=4070",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LSP-stylelint",
 			"details": "https://github.com/sublimelsp/LSP-stylelint",
 			"releases": [


### PR DESCRIPTION
This is a convenience package for [Apple's SourceKit](https://github.com/apple/sourcekit-lsp) language server. It is applicable to the following base scopes:

- `source.swift`
- `source.c++`
- `source.c`
- `source.objc`
- `source.objc++`

The C, C++, Objective-C and Objective-C++ files have an empty `feature_selector` so that clangd or ccls is chosen over SourceKit, as the focus of SourceKit is obviously on support for the Swift language.

This package doesn't download any resources from the internet. Instead, it utilizes the language server executable bundled with Xcode. As such, any user wanting to use this package must have Xcode installed.