### PR TITLE
Add PHP CBF Package

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -987,6 +987,18 @@
 			]
 		},
 		{
+			"name": "PHP CBF",
+			"details": "https://github.com/andremacola/sublime-PHP_CBF",
+			"issues": "https://github.com/andremacola/sublime-PHP_CBF/issues",
+			"labels": ["php", "phpcs", "formatting"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "PHP Codebeautifier",
 			"details": "https://github.com/Ennosuke/PHP-Codebeautifier",
 			"releases": [


### PR DESCRIPTION
This is a lightweight ST Package to fix your php files with [PHP Codebeautifier](https://github.com/squizlabs/PHP_CodeSniffer/wiki/Fixing-Errors-Automatically) aka `phpcbf`. It is based on the original [PHP_CodeSniffer](https://github.com/andremacola/sublime-PHP_CodeSniffer) package without the `phpcs`.

The advantage of this plugin is that it acts directly in the Sublime Text buffer, avoiding file reloading thus being faster.

https://github.com/andremacola/sublime-PHP_CBF