### PR TITLE
Add LSP-Dart

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1644,6 +1644,16 @@
 			]
 		},
 		{
+			"name": "LSP-Dart",
+			"details": "https://github.com/sublimelsp/LSP-Dart",
+			"releases": [
+				{
+					"sublime_text": ">=4070",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LSP-dockerfile",
 			"details": "https://github.com/sublimelsp/LSP-dockerfile",
 			"releases": [


### PR DESCRIPTION
The Dart SDK, and the Flutter SDK, both ship with a bundled language server called the [Dart Analysis Server](https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec/README.md) written in Dart. This helper package utilizes that fact by searching for a `dart` executable in the SDK and an accompanying language server, and starts the process with those elements.