### PR TITLE
Add Oceanic Primal Color Scheme

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -120,6 +120,17 @@
 			]
 		},
 		{
+			"name": "Oceanic Primal Color Scheme",
+			"details": "https://github.com/barlog-m/oceanic-primal-sublime",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ocp-indent",
 			"details": "https://github.com/bluepichu/sublime-text-ocp-indent",
 			"releases": [


### PR DESCRIPTION
Oceanic Primal Color Scheme.
A minimalistic color scheme based on [Oceanic Primal palette](https://github.com/oceanic-primal/palette), inspired by [Oceanic Next Color Scheme](https://github.com/voronianski/oceanic-next-color-scheme).