### PR TITLE
Add Fmt package

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1283,6 +1283,16 @@
 			]
 		},
 		{
+			"name": "Fmt",
+			"details": "https://github.com/mitranim/sublime-fmt",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Fn",
 			"details": "https://github.com/jonnyarnold/fn-syntax",
 			"labels": ["fn", "language syntax"],


### PR DESCRIPTION
Link to repo: https://github.com/mitranim/sublime-fmt.

Motive (citing from the readme):

Why this exists?

Package Control has special-case formatter plugins for different languages, and the monstrous Formatter with too many batteries included. This makes it hard to add formatters: someone has to make and publish a new plugin every time, or fork a repo and make a PR, etc.

Many formatters just call a subprocess and use stdio. One plugin can handle them all, while letting the _user_ specify any new formatter for any new syntax! This works for `gofmt`, `rustfmt`, `clang-format`, and endless others.