### PR TITLE
Fix main branch rename for relikd repos

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -4578,7 +4578,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},

--- a/repository/p.json
+++ b/repository/p.json
@@ -1641,7 +1641,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Updated main branch, this PR uses tags instead