### PR TITLE
create st3- prefixed releases for LESS, Sass

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -729,7 +729,11 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": "<4000",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]

--- a/repository/s.json
+++ b/repository/s.json
@@ -169,7 +169,11 @@
 			"labels": ["language syntax", "scss", "sass", "completions", "snippets"],
 			"releases": [
 				{
-					"sublime_text": ">3092",
+					"sublime_text": "<4000",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Updates the entries for LESS and Sass to specific prefixed tags for SublimeText 3, while normal tags will continue to target ST4 and newer releases.