### PR TITLE
Add CloudWatchLogs plugin

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1591,7 +1591,19 @@
 					"tags": true
 				}
 			]
-		},{
+		},
+		{
+			"name": "CloudWatchLogs",
+			"details": "https://github.com/rnhurt/SublimeText-CloudWatchLogs",
+			"labels": ["aws", "cloudwatch", "logs"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CMake",
 			"details": "https://github.com/zyxar/Sublime-CMakeLists",
 			"labels": ["language syntax"],
@@ -2001,7 +2013,7 @@
 			]
 		},
 		{
-			"name": "CodeFall Color Scheme", 
+			"name": "CodeFall Color Scheme",
 			"details": "https://github.com/EncryptEx/CodeFall",
 			"labels": ["color scheme"],
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->

This simple plugin adds the ability to view AWS CloudWatch logs in a tab.  I checked for similar packages and couldn't find anything that was even remotely comparable.  

NOTE: Apparently, I also cleaned up a space at the end of line 2,004.  🤷 