### PR TITLE
fix: separate release for st3 and st4

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -714,8 +714,12 @@
 			"labels": ["theme", "scheme", "light", "dark", "github"],
 			"releases": [
 				{
-					"sublime_text": ">=3179",
-					"tags": true
+					"sublime_text": "3179 - 4069",
+					"tags": "3179-"
+				},
+				{
+					"sublime_text": ">=4070",
+					"tags": "4070-"
 				}
 			]
 		},

--- a/repository/m.json
+++ b/repository/m.json
@@ -1212,8 +1212,12 @@
 			"labels": ["theme", "scheme", "light", "dark"],
 			"releases": [
 				{
-					"sublime_text": ">=3179",
-					"tags": true
+					"sublime_text": "3179 - 4069",
+					"tags": "3179-"
+				},
+				{
+					"sublime_text": ">=4070",
+					"tags": "4070-"
 				}
 			]
 		},


### PR DESCRIPTION
Separate releases for  **Meetio Theme** and **Github Theme** to allow a possibility to update both themes w/out conflits.