### PR TITLE
Add TabNav package

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -63,7 +63,7 @@
 			"name": "TabNav",
 			"details": "https://github.com/mitchvm/tabnav",
 			"author": "Mitch Valdmanis-Miller",
-			"labels": ["text navigation", "text selection", "text", "markdown"],
+			"labels": ["text navigation", "text selection", "text", "markdown", "org mode", "textile"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/t.json
+++ b/repository/t.json
@@ -60,6 +60,18 @@
 			]
 		},
 		{
+			"name": "TabNav",
+			"details": "https://github.com/mitchvm/tabnav",
+			"author": "Mitch Valdmanis-Miller",
+			"labels": ["text navigation", "text selection", "text", "markdown"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "TabNine",
 			"details": "https://github.com/codota/tabnine-sublime",
 			"author": "Codota",


### PR DESCRIPTION
TabNav is a plugin for keyboard navigation of tabular text data. Quickly move and select "cells" of text in the following formats, without taking your hands off the keyboard:

* Markdown pipe tables
* Org Mode tables
* Textile tables
* CSV files

TabNav also provides the ability to copy only the contents of the table, excluding markup, in a format that can be readily-pasted into other programs, such as Excel.

![Demo](https://github.com/mitchvm/tabnav/blob/main/teaser.gif?raw=true)