### PR TITLE
add config for no-response-robot

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -6,8 +6,5 @@ daysUntilClose: 14
 responseRequiredLabel: "stale"
 # Comment to post when closing an Issue for lack of response. Set to `false` to disable
 closeComment: >
-  This issue has been automatically closed because there has been no response
-  to our request for more information from the original author. With only the
-  information that is currently in the issue, we don't have enough information
-  to take action. Please reach out if you have or find the answers we need so
-  that we can investigate further.
+  This pull request has been automatically closed because there has been no
+  response to our request for information or changes from the original author.

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,13 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 14
+# Label requiring a response
+responseRequiredLabel: "stale"
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.


### PR DESCRIPTION
This sets up a bot to close "stale" issues and PR's after two weeks automatically. It's a pretty simple and limited bot, but it's a convenient way to set a two week time bomb under issues where the author has gone AWOL. I use it everywhere in SublimeLinter repo's to keep things clean, it's a little time saver. It cannot apply the "timeout" label though, so it does kinda break our protocol in that sense, but overall I'd say it's a win and the "timeout" labels can always be manually applied afterwards.