### PR TITLE
Add AutoMatlab package

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2290,6 +2290,18 @@
 			]
 		},
 		{
+			"name": "AutoMatlab",
+			"details": "https://github.com/asparc/AutoMatlab",
+			"labels": ["auto-complete", "snippets", "documentation", "build system", "matlab"],
+			"releases": [
+				{
+					"platforms": ["windows"],
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "AutoPEP8",
 			"details": "https://github.com/wistful/SublimeAutoPEP8",
 			"labels": ["linting", "formatting"],


### PR DESCRIPTION
Short description:
Autocompletion, documentation generation and a command panel for Matlab.

Comparison to related packages:
The two other Matlab-related packages are relatively limited. One is a collection of snippets, and the other scans for function names in a project.
AutoMatlab does the same, and a lot more. 
- It generates autocompletion information from the user's Matlab installation, the project, the current folder(s) and/or the current file. On top of that, it includes elaborate function documentation with the autocompletion, presented in a popup. 
- It provides flexible and context-aware function documentation generation through customizable template snippets.
- It allows to run Matlab commands from within Sublime Text, through integration with AutoHotkey. This is for instance useful to run the current file in Matlab, or to repeat commands from the recent Matlab history through a custom command panel.
