### PR TITLE
Git Extensions Plugin 

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -557,9 +557,9 @@
 			]
 		},
 		{
-			"name": "Git Extenstions",
+			"name": "Git Extensions",
 			"details": "https://github.com/LinuxDevon/sublime-gitextensions",
-			"labels": ["gitextenstions", "git"],
+			"labels": ["gitextensions", "git"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/g.json
+++ b/repository/g.json
@@ -557,6 +557,17 @@
 			]
 		},
 		{
+			"name": "Git Extenstions",
+			"details": "https://github.com/LinuxDevon/sublime-gitextensions",
+			"labels": ["gitextenstions", "git"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Git Message Auto Save",
 			"previous_names": ["Git Commit Message Auto Save"],
 			"details": "https://github.com/franciscolourenco/sublime-git-message-auto-save",


### PR DESCRIPTION
Adding in "Git Extensions" repository that I forked. It wasn't being maintained and was broke so I decided to fix up the bugs. I would like this to be available on Package Control instead of using Github. I am hopeful this resolves the issue with not import default settings of the repository as well. Still not sure why it won't import these.

This plugin allows the user to open up the application `Git Extenstions` from sublime. It is useful when wanting to write commits, browse the repo, or any other git actions using the application.