### PR TITLE
Add ModernFortran

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1933,6 +1933,17 @@
 			]
 		},
 		{
+			"name": "ModernFortran",
+			"details": "https://github.com/eirik-kjonstad/modern-fortran-syntax",
+			"labels": ["language syntax", "fortran"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ModernPerl",
 			"details": "https://github.com/Blaizer/ModernPerl-sublime",
 			"labels": ["language syntax", "todo"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->
Adds a Fortran language syntax (called Modern-Fortran) that supports features introduced in the more recent Fortran language standards - the 2003, 2008, and 2018 standards.

The existing alternative package (Fortran) offers relatively good support for pre-2003 standards. But it does not fully support more recent functionality, such as the extensive object orientation additions of the 2003 and 2008 standards. The Modern-Fortran syntax should be useful for developers who make use of such features.