### PR TITLE
Add Forth

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1557,6 +1557,17 @@
 			]
 		},
 		{
+			"name": "Forth",
+			"details": "https://github.com/mitranim/sublime-forth",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Fortify Highlighter",
 			"details": "https://github.com/pwntester/FortifyHighlighter",
 			"releases": [


### PR DESCRIPTION
Should be self-explanatory. There doesn't seem to be a Forth syntax on Package Control, there will be now. 🙂