### PR TITLE
Add syntax mode to colour the CMHG used for building modules in RISC OS.

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1584,6 +1584,17 @@
 			]
 		},
 		{
+			"name": "RISC OS CMHG Syntax",
+			"details": "https://github.com/gerph/sublimetext-riscoscmhg-syntax",
+			"labels": ["syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "RISC OS Command Syntax",
 			"details": "https://github.com/gerph/sublimetext-riscoscommand-syntax",
 			"labels": ["syntax"],


### PR DESCRIPTION
RISC OS CMHG files are descriptions of the header that will be created
for modules written in C. They are a core part of the development
environment used by RISC OS.

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->
