### PR TITLE
Add BBC BASIC syntax mode.

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -268,6 +268,17 @@
 			]
 		},
 		{
+			"name": "BBC BASIC Syntax",
+			"details": "https://github.com/gerph/sublimetext-bbcbasic-syntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "BBCode Syntax",
 			"details": "https://github.com/chipotle/BBCode",
 			"labels": ["language syntax"],


### PR DESCRIPTION
BBC BASIC syntax mode is intended for use with the variants of BBC BASIC,
although it is specific to the BASIC V/VI variants.

It should work with...

  * BASIC versions up to 4 for the Electron, BBC Micro and BBC Master
    series (a subset of the keywords available in the syntax),
    usable with https://bbcmic.ro/
  * BBC BASIC for RISC OS.
  * Brandy BASIC (and variants such as Matrix Brandy Basic)
  * BBC BASIC for Windows (with some differences as its syntax has
    been extended).

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->
