### PR TITLE
Added entries for Maya and 3ds Max Debug Adapters

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -380,6 +380,27 @@
 					"tags": true
 				}
 			]
+		},{
+			"name": "Debugger - 3ds Max",
+			"details": "https://github.com/blurstudio/sublime_debugger-3dsMax",
+			"releases": [
+				{
+					"sublime_text": "<4000",
+					"platforms": ["windows"],
+					"tags": "st3-"
+				}
+			]
+		},
+		{
+			"name": "Debugger - Maya",
+			"details": "https://github.com/blurstudio/sublime_debugger-maya",
+			"releases": [
+				{
+					"sublime_text": "<4000",
+					"platforms": ["windows"],
+					"tags": "st3-"
+				}
+			]
 		},
 		{
 			"name": "Decent Color Scheme",

--- a/repository/d.json
+++ b/repository/d.json
@@ -389,6 +389,11 @@
 					"sublime_text": "<4000",
 					"platforms": ["windows"],
 					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
+					"platforms": ["windows"],
+					"tags": true
 				}
 			]
 		},
@@ -400,6 +405,11 @@
 					"sublime_text": "<4000",
 					"platforms": ["windows"],
 					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
+					"platforms": ["windows"],
+					"tags": true
 				}
 			]
 		},

--- a/repository/d.json
+++ b/repository/d.json
@@ -380,7 +380,8 @@
 					"tags": true
 				}
 			]
-		},{
+		},
+		{
 			"name": "Debugger - 3ds Max",
 			"details": "https://github.com/blurstudio/sublime_debugger-3dsMax",
 			"releases": [

--- a/repository/d.json
+++ b/repository/d.json
@@ -389,11 +389,6 @@
 					"sublime_text": "<4000",
 					"platforms": ["windows"],
 					"tags": "st3-"
-				},
-				{
-					"sublime_text": ">=4000",
-					"platforms": ["windows"],
-					"tags": true
 				}
 			]
 		},
@@ -405,11 +400,6 @@
 					"sublime_text": "<4000",
 					"platforms": ["windows"],
 					"tags": "st3-"
-				},
-				{
-					"sublime_text": ">=4000",
-					"platforms": ["windows"],
-					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
These two packages plug into the [Debugger plugin](https://github.com/daveleroy/sublime_debugger/releases), extending its functionality based on the users' needs.

- The [3ds Max plugin](https://github.com/blurstudio/sublime_debugger-3dsMax) allows users to debug Python 2 code running in Autodesk 3ds Max
- The [Maya plugin](https://github.com/blurstudio/sublime_debugger-maya) allows users to debug Python 2 code running in Autodesk Maya
