### PR TITLE
Takes over ElixirFormatter with new repo

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -593,7 +593,8 @@
 		},
 		{
 			"name": "ElixirFormatter",
-			"details": "https://github.com/karolsluszniak/elixir-formatter-sublime",
+			"details": "https://github.com/myskoach/sublime-elixir-formatter",
+			"labels": ["elixir", "formatting", "mix"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
A fork of [ElixirFormatter](https://github.com/karolsluszniak/elixir-formatter-sublime). That package has some issues, is unmaintained, and is [not accepting fixes](https://github.com/karolsluszniak/elixir-formatter-sublime/pull/5). So I pulled that fixed code, added some new features, and packaged it up again.

It's simply an auto-formatter for elixir code, using the language's official formatter.