### PR TITLE
Add Tailwind CSS syntax definition

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -278,6 +278,17 @@
 			]
 		},
 		{
+			"name": "Tailwind CSS",
+			"details": "https://github.com/SublimeText/TailwindCSS",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4092",
+					"tags": "4092-"
+				}
+			]
+		},
+		{
 			"name": "Tailwind CSS Autocomplete",
 			"details": "https://github.com/danklammer/tailwind-sublime-autocomplete",
 			"labels": ["auto-complete"],


### PR DESCRIPTION
This package adds Tailwind CSS syntax, which extends ST's default CSS.

It therefore requires ST 4 with CSS sublime-syntax version 2.

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->
