### PR TITLE
Add UCFHighlighter

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -37,6 +37,7 @@
 		{
 			"name": "UCFHighlighter",
 			"details": "https://github.com/LDprg/UCFHighlighter",
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/u.json
+++ b/repository/u.json
@@ -35,6 +35,16 @@
 			]
 		},
 		{
+			"name": "UCFHighlighter",
+			"details": "https://github.com/LDprg/UCFHighlighter",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "udev rules",
 			"details": "https://github.com/tijn/udev.tmLanguage",
 			"labels": ["language syntax"],

--- a/repository/u.json
+++ b/repository/u.json
@@ -39,7 +39,7 @@
 			"details": "https://github.com/LDprg/UCFHighlighter",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
UCFHighlighter is s syntax highlighter for xilinx ISE Ucf Files, which is used for the pinning of fpgas. Is very usefull for VHDL programmers, which are using Xilinx ISE.

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->
