### PR TITLE
Update edge extension source repo

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -320,7 +320,8 @@
 					"sublime_text": ">=3092",
 					"tags": true
 				}
-			]
+			],
+			"previous_names": ["Edge Syntax Highliter"]
 		},
 		{
 			"name": "Edge Theme",

--- a/repository/e.json
+++ b/repository/e.json
@@ -313,8 +313,8 @@
 			]
 		},
 		{
-			"name": "Edge Syntax Highliter",
-			"details": "https://github.com/poppinss/edge-sublime-syntax",
+			"name": "Edge templates extension",
+			"details": "https://github.com/edge-js/edge-sublime",
 			"releases": [
 				{
 					"sublime_text": ">=3092",


### PR DESCRIPTION
The edge template engine and all its related repos have been moved to its own organisation http://github.com/edge-js and hence the URL update is required.

Also, I have re-written the extension from scratch to improve the syntax highlighting, add completions and add support for symbols.

- [x] Followed https://packagecontrol.io/docs/submitting_a_package#Step_7
- [x] Repo has a README file
- [x] Releases are tagged

There are chances, that I may have missed something unknowingly. So please provide the feedback and I will be more than happy to work on it 🙂 