### PR TITLE
Add Coreboot Syntax package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3630,6 +3630,17 @@
 			]
 		},
 		{
+			"name": "Coreboot syntax",
+			"details": "https://github.com/coreboot/sublime-text-coreboot-syntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CoreBuilder",
 			"details": "https://github.com/rodrigoangeline/CoreBuilder_SublimeText",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Add the coreboot syntax package. This package will contain syntax definitions that will make working on coreboot and the linux kernel more user friendly.