### PR TITLE
Add POVRay syntax hilight

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1948,6 +1948,17 @@
 			]
 		},
 		{
+			"name": "PovRay",
+			"details": "https://github.com/leoheck/sublime-povray",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Power System Tools Syntax",
 			"details":"https://github.com/dparrini/sublime_powersystems",
 			"labels": ["language syntax", "auto-complete"],


### PR DESCRIPTION
This PR adds Pov-Ray syntax highlight.

This is a well-known project http://www.povray.org/ that does not have any indication of a syntax highlight or any other feature here for Sublime-Text.
