### PR TITLE
Add Darkdetect dependency

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -262,6 +262,20 @@
 			]
 		},
 		{
+			"name": "darkdetect",
+			"load_order": "01",
+			"description": "Python Darkdetect library https://github.com/albertosottile/darkdetect",
+			"author": "danielway",
+			"issues": "https://github.com/danielway/sublime-darkdetect/issues",
+			"releases": [
+				{
+					"base": "https://github.com/danielway/sublime-darkdetect",
+					"tags": true,
+					"sublime_text": "<4096"
+				}
+			]
+		},
+		{
 			"name": "dateutil",
 			"load_order": "50",
 			"description": "The dateutil module provides powerful extensions to the datetime module available in the Python standard library",


### PR DESCRIPTION
This adds the [Darkdetect](https://github.com/albertosottile/darkdetect) Python library developed by [Alberto Sottile](https://github.com/albertosottile) as an available dependency for Sublime Text packages. I intend to use this to develop a package which synchronizes Sublime Text's color scheme with my OS.