### PR TITLE
Add QuickView package

### DIFF
--- a/repository/q.json
+++ b/repository/q.json
@@ -368,6 +368,17 @@
 			]
 		},
 		{
+			"name": "QuickView",
+			"details": "https://github.com/jwortmann/quick-view",
+			"labels": ["color", "image", "preview"],
+			"releases": [
+				{
+					"sublime_text": ">=3170",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "QuickXDev",
 			"details": "https://github.com/leitwolf/QuickXDev",
 			"releases": [


### PR DESCRIPTION
This is a port of the Quick View feature which can be found in the Adobe Brackets editor to display preview popups on mouse hover for images and CSS colors.

There is already https://packagecontrol.io/packages/ImagePreview for image previews, but my package for example doesn't require disk write access for images from the internet, and the popup style and behavior are tweaked to be similar to Brackets.
And there are of course several packages for the color previews, but those which I tried all use either regions or phantoms, and not hover popups.
Also this is afaik the only package which is able to display the color boxes with a transparent checkboard pattern background for colors with alpha value ;-)