### PR TITLE
Change tag prefix for Slyblime, remove description

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2306,12 +2306,15 @@
 		},
 		{
 			"name": "Slyblime",
-			"description": "A rich Lisp development environment by integrating Sly's functionality.",
 			"details": "https://github.com/s-clerc/slyblime",
 			"labels": ["lisp", "auto-complete", "REPL", "references"],
 			"releases": [
 				{
-					"sublime_text": ">=4079",
+					"sublime_text": ">=4099",
+					"tags": "ST-"
+				},
+				{
+					"sublime_text": "<4099",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Same package as before, but I've changed the build process and now all ST builds have their tags start with `ST-` so I need to update the repo file.