### PR TITLE
New gitlab package: Jq wrapper

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -760,6 +760,17 @@
 			]
 		},
 		{
+			"name": "Jq",
+			"details": "https://gitlab.com/jiehong/sublime_jq",
+			"labels": ["interactive", "jq"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "JQ Syntax",
 			"details": "https://github.com/zogwarg/SublimeJQ",
 			"labels": ["language syntax", "jq", "stedolan"],


### PR DESCRIPTION
The test default channel does not pass, because it does not accept gitlab as a url. However, I saw a PR long ago saying gitlab is now supported.

https://github.com/wbond/package_control/pull/1481/files

So, from August 2020. Perhaps the test is not up to date?