### PR TITLE
Add TortoiseGit package

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2909,9 +2909,9 @@
 			]
 		},
 		{
-			"name": "TortoiseGIT",
-			"details": "https://github.com/fyneworks/sublime-TortoiseGIT",
-			"labels": ["GIT", "Tortoise", "TortoiseGIT"],
+			"name": "TortoiseGit",
+			"details": "https://github.com/wjtools/sublime-tortoise-git",
+			"labels": ["TortoiseGit", "Tortoise", "Git"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
Replace the original TortoiseGIT package,  because the package not implement TortoiseGIT function.