### PR TITLE
Fix tags for JS Custom.

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -945,12 +945,12 @@
 			"labels": ["javascript", "syntax"],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
-					"tags": true
+					"sublime_text": "<4000",
+					"tags": "st3-"
 				},
 				{
 					"sublime_text": ">=4000",
-					"tags": "st4-"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Ensure that the tag ranges are disjoint, and use un-prefixed tags for future releases.