### PR TITLE
Add Unicode Character Input plugin

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -210,6 +210,16 @@
 			]
 		},
 		{
+			"name": "Unicode Character Input",
+			"details": "https://github.com/NiavlysB/sublime-unicode-character-input",
+			"releases": [
+				{
+					"sublime_text": ">=3154",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Unicode Character Insert",
 			"details": "https://github.com/Sorbing/sublime-unicode-character-insert",
 			"releases": [

--- a/repository/u.json
+++ b/repository/u.json
@@ -215,7 +215,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3154",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
This package allows for inserting any Unicode character via its hexadecimal code point. The command opens an input handler that includes a preview of the character before inserting it. It also works with multiple cursors/selections.

![image](https://user-images.githubusercontent.com/3757523/116318742-89568500-a7b5-11eb-91cb-73bc6d3990b0.png)

Under Linux, there is a shortcut to do that, that works in most apps, except in Sublime Text. This plugin by default binds the command to that same shortcut (ctrl+shift+u).

Another package ([Unicode Character Insert](https://packagecontrol.io/packages/Unicode%20Character%20Insert)) sounds similar judging by its name, but it’s just displaying a table of ~65 hardcoded characters that you can then insert, you cannot chose any other character.