### PR TITLE
Switch Test Double package to use tags

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -731,7 +731,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
I'd like to switch this package to using tags. The "ChannelRepositoryTools: Test Default Channel" command in Sublime Text passes.

Note that [master](https://github.com/testdouble/sublime-test-double/tree/master) is even with [0.0.1](https://github.com/testdouble/sublime-test-double/tree/0.0.1) (the [only tag](https://github.com/testdouble/sublime-test-double/tags)), so there will actually be no changes.

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->
