### PR TITLE
add aaLogPanel

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -15,6 +15,18 @@
 			]
 		},
 		{
+			"name": "aaLogPanel",
+			"details": "https://github.com/gwenzek/LogPanel",
+			"author": ["gwenzek"],
+			"labels": ["logging"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ABAP",
 			"details": "https://github.com/flaiker/abap-st3",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Add LogPanel plugin.
This allows to configure logging of ST pacakges.
Logging configuration is using the standard Python configuration.

This plugins also provide log handlers to write the logs to a ST panel.
Takes care of the two plugins hosts.

https://github.com/gwenzek/LogPanel/

The pacakge is named aaLogPanel to be loaded first.
If you have other ideas on how to achieve this I'm interested.
(I also considered making this package a dependency, but I'm not sure it's simpler)
