### PR TITLE
Update MarkdownEditing

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -622,8 +622,16 @@
 			"labels": ["markdown", "github markdown", "gfm", "multimarkdown", "color scheme"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<3176",
 					"tags": true
+				},
+				{
+					"sublime_text": "3176 - 4106",
+					"tags": "3176-"
+				},
+				{
+					"sublime_text": ">=4107",
+					"tags": "4107-"
 				}
 			]
 		},


### PR DESCRIPTION
MarkdownEditing will receive some breaking changes which require at least ST3176 soon.

At this point future is to be prepared to update syntax definitions which use ST4 features. Thus preparing ST4 only releases, too.