### PR TITLE
Add Move Half Pages.

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -2490,6 +2490,16 @@
 			]
 		},
 		{
+			"name": "Move Half Pages",
+			"details": "https://github.com/Finnerale/Sublime-MoveHalfPages",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Move Tabs",
 			"details": "https://github.com/nh2/sublime-text-move-tabs",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->

This package adds a `move_half_pages` command, which behaves like `move` with `"by": "pages"` and an additional `percentage` parameter (0.5 by default).

I find the normal 100% page scroll quite distracting and this just feels a lot nicer to me. I was quite surprised that there was no such package for Sublime yet, so I thought I'd publish mine.

The package can be found here: https://github.com/Finnerale/Sublime-MoveHalfPages
