### PR TITLE
add LuauSyntaxHighlighting package

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1817,6 +1817,17 @@
 			]
 		},
 		{
+			"name": "LuauSyntaxHighlighting",
+			"details": "https://github.com/zainthemaynnn/luau-syntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LuaVEXT",
 			"details": "https://github.com/MajorVictory/LuaVEXT",
 			"labels": [


### PR DESCRIPTION
LuauSyntaxHighlighting package

this package intends to add syntax highlighting for the [luau subset of lua](https://roblox.github.io/luau/) which includes a bunch of extra globals and some keywords. although I'm aware that [this package already provides a similar purpose](https://packagecontrol.io/packages/ROBLOXLua) it's no longer maintained and the owner is inactive; this one stays up to date with network requests. while I thought about making a fork of it I had no interest in continuing support for snippets or anything like that. although I will be glad to do that if you'd prefer.