### PR TITLE
add python-black

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -3127,6 +3127,19 @@
 			]
 		},
 		{
+			"name": "python-black",
+			"details": "https://github.com/thep0y/python-black",
+			"labels": [
+				"formatter"
+			],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Python2UnicodeFixer",
 			"details": "https://github.com/allieus/Python2UnicodeFixer",
 			"releases": [


### PR DESCRIPTION
A `black`-based package with only one formatting function may be more elegant than other formatting packages.
There is an additional function: use the command to generate a black configuration file.