### PR TITLE
add `python-black`

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2311,11 +2311,10 @@
 			"details": "https://github.com/thep0y/SublimeAutoPEP8",
 			"labels": ["linting", "formatting"],
 			"readme": "https://raw.githubusercontent.com/thep0y/SublimeAutoPEP8/master/Readme.md",
-			"issues": "https://github.com/thep0y/SublimeAutoPEP8/issues",
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"tags": true
+					"branch": "master"
 				}
 			]
 		},

--- a/repository/a.json
+++ b/repository/a.json
@@ -2307,6 +2307,23 @@
 			]
 		},
 		{
+			"name": "AutoPEP8_2020",
+			"details": "https://github.com/thep0y/SublimeAutoPEP8",
+			"labels": ["linting", "formatting"],
+			"readme": "https://raw.githubusercontent.com/thep0y/SublimeAutoPEP8/master/Readme.md",
+			"issues": "https://github.com/thep0y/SublimeAutoPEP8/issues",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				},
+				{
+					"sublime_text": "<3000",
+					"tags": "st2-"
+				}
+			]
+		},
+		{
 			"name": "AutoPHPDollar",
 			"details": "https://github.com/graarh/sublime-AutoPHPDollar",
 			"releases": [

--- a/repository/a.json
+++ b/repository/a.json
@@ -2307,7 +2307,7 @@
 			]
 		},
 		{
-			"name": "AutoPEP8_2020",
+			"name": "AutoPEP8 2020",
 			"details": "https://github.com/thep0y/SublimeAutoPEP8",
 			"labels": ["linting", "formatting"],
 			"releases": [

--- a/repository/a.json
+++ b/repository/a.json
@@ -2310,7 +2310,6 @@
 			"name": "AutoPEP8_2020",
 			"details": "https://github.com/thep0y/SublimeAutoPEP8",
 			"labels": ["linting", "formatting"],
-			"readme": "https://raw.githubusercontent.com/thep0y/SublimeAutoPEP8/master/Readme.md",
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/a.json
+++ b/repository/a.json
@@ -2316,10 +2316,6 @@
 				{
 					"sublime_text": ">=3000",
 					"tags": true
-				},
-				{
-					"sublime_text": "<3000",
-					"tags": "st2-"
 				}
 			]
 		},

--- a/repository/a.json
+++ b/repository/a.json
@@ -2307,17 +2307,6 @@
 			]
 		},
 		{
-			"name": "AutoPEP8 2020",
-			"details": "https://github.com/thep0y/SublimeAutoPEP8",
-			"labels": ["linting", "formatting"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "AutoPHPDollar",
 			"details": "https://github.com/graarh/sublime-AutoPHPDollar",
 			"releases": [

--- a/repository/a.json
+++ b/repository/a.json
@@ -2314,7 +2314,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},

--- a/repository/p.json
+++ b/repository/p.json
@@ -4,9 +4,7 @@
 		{
 			"name": "P3 Assembly",
 			"details": "https://github.com/rgcv/p3assembly-sublime-syntax",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -27,17 +25,12 @@
 		{
 			"name": "P4Explorer",
 			"details": "https://github.com/ymengesha/P4Explorer",
-			"labels": [
-				"vcs",
-				"file navigation"
-			],
+			"labels": ["vcs", "file navigation"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
 					"tags": true,
-					"platforms": [
-						"windows"
-					]
+					"platforms": ["windows"]
 				}
 			]
 		},
@@ -64,12 +57,7 @@
 		{
 			"name": "Package Snippets",
 			"details": "https://github.com/frdmn/package-snippets",
-			"labels": [
-				"snippets",
-				"git",
-				"repository",
-				"package"
-			],
+			"labels": ["snippets", "git", "repository", "package"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -80,23 +68,19 @@
 		{
 			"name": "PackageDev",
 			"details": "https://github.com/SublimeText/PackageDev",
-			"previous_names": [
-				"AAAPackageDev"
-			],
-			"author": [
-				"FichteFoll"
-			],
+			"previous_names": ["AAAPackageDev"],
+			"author": ["FichteFoll"],
 			"releases": [
 				{
 					"sublime_text": "<3154",
 					"tags": "st2-"
 				},
 				{
-					"sublime_text": "<4084",
+					"sublime_text": "<4094",
 					"tags": "st3-v"
 				},
 				{
-					"sublime_text": ">=4084",
+					"sublime_text": ">=4094",
 					"tags": true
 				}
 			]
@@ -119,14 +103,7 @@
 			"name": "PackagesUI",
 			"details": "https://github.com/unknownuser88/PackagesUI",
 			"author": "David Bekoyan",
-			"labels": [
-				"package",
-				"utilities",
-				"dashboard",
-				"gui",
-				"inline",
-				"help system"
-			],
+			"labels": ["package", "utilities", "dashboard", "gui", "inline", "help system"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -137,12 +114,7 @@
 		{
 			"name": "PackageSync",
 			"details": "https://github.com/utkarsh9891/PackageSync",
-			"labels": [
-				"backup",
-				"restore",
-				"sync",
-				"package"
-			],
+			"labels": ["backup", "restore", "sync", "package"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -185,17 +157,11 @@
 		{
 			"name": "Padawan (PHP completion)",
 			"details": "https://github.com/padawan-php/padawan.sublime",
-			"labels": [
-				"auto-complete",
-				"php"
-			],
+			"labels": ["auto-complete", "php"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": [
-						"osx",
-						"linux"
-					],
+					"platforms": ["osx", "linux"],
 					"tags": true
 				}
 			]
@@ -213,12 +179,7 @@
 		{
 			"name": "PaletteFile",
 			"details": "https://github.com/vshotarov/PaletteFile",
-			"labels": [
-				"file creation",
-				"file navigation",
-				"directory creation",
-				"directory navigation"
-			],
+			"labels": ["file creation", "file navigation", "directory creation", "directory navigation"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -229,9 +190,7 @@
 		{
 			"name": "Panda Syntax Sublime",
 			"details": "https://github.com/siamak/panda-syntax-sublime",
-			"labels": [
-				"color scheme"
-			],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -344,10 +303,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": [
-						"osx",
-						"linux"
-					],
+					"platforms": ["osx", "linux"],
 					"tags": true
 				}
 			]
@@ -375,9 +331,7 @@
 		{
 			"name": "Paraiso Black Color Scheme",
 			"details": "https://github.com/idleberg/ParaisoBlack.tmTheme",
-			"labels": [
-				"color scheme"
-			],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -388,12 +342,8 @@
 		{
 			"name": "Paraiso Color Scheme",
 			"details": "https://github.com/idleberg/Paraiso.tmTheme",
-			"labels": [
-				"color scheme"
-			],
-			"previous_names": [
-				"Paraíso Color Scheme"
-			],
+			"labels": ["color scheme"],
+			"previous_names": ["Paraíso Color Scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -413,11 +363,7 @@
 		},
 		{
 			"details": "https://github.com/odyssomay/paredit",
-			"labels": [
-				"text manipulation",
-				"formatting",
-				"code navigation"
-			],
+			"labels": ["text manipulation", "formatting", "code navigation"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -427,10 +373,7 @@
 		},
 		{
 			"details": "https://github.com/ilyakam/ParentalControl",
-			"labels": [
-				"formatting",
-				"text manipulation"
-			],
+			"labels": ["formatting", "text manipulation"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -441,16 +384,7 @@
 		{
 			"name": "Parinfer",
 			"details": "https://github.com/oakmac/sublime-text-parinfer",
-			"labels": [
-				"parinfer",
-				"paredit",
-				"clojure",
-				"clojurescript",
-				"cljs",
-				"lisp",
-				"formatting",
-				"text manipulation"
-			],
+			"labels": ["parinfer", "paredit", "clojure", "clojurescript", "cljs", "lisp", "formatting", "text manipulation"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -461,16 +395,11 @@
 		{
 			"name": "Parquet",
 			"details": "https://github.com/yuj/sublime-parquet",
-			"labels": [
-				"parquet"
-			],
+			"labels": ["parquet"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": [
-						"osx",
-						"linux"
-					],
+					"platforms": ["osx", "linux"],
 					"tags": true
 				}
 			]
@@ -478,10 +407,7 @@
 		{
 			"name": "Particle Reverse Polish Language",
 			"details": "https://github.com/KubeRoot/Sublime-PRPL",
-			"labels": [
-				"language syntax",
-				"completions"
-			],
+			"labels": ["language syntax", "completions"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -491,10 +417,8 @@
 		},
 		{
 			"name": "Parva Syntax",
-			"details": "https://github.com/muskatel/Parva_Syntax",
-			"labels": [
-				"language syntax"
-			],
+			"details" : "https://github.com/muskatel/Parva_Syntax",
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -508,10 +432,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": [
-						"osx",
-						"linux"
-					],
+					"platforms": ["osx", "linux"],
 					"tags": true
 				}
 			]
@@ -547,6 +468,20 @@
 			]
 		},
 		{
+			"name": "Paste Plus",
+			"details": "https://github.com/ggets/Sublime_PastePlus",
+			"readme": "https://raw.githubusercontent.com/ggets/Sublime_PastePlus/main/README.md",
+			"labels": ["text manipulation", "clipboard", "paste"],
+			"author": "GGets",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["windows"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Paste to friendpaste.com",
 			"details": "https://github.com/martinsam/sublime-friendpaste",
 			"releases": [
@@ -569,9 +504,7 @@
 		{
 			"name": "PasteAhead",
 			"details": "https://github.com/mattst/PasteAhead",
-			"labels": [
-				"paste"
-			],
+			"labels": ["paste"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -583,9 +516,7 @@
 			"name": "PasteAsString",
 			"details": "https://github.com/mom1/PasteAsString",
 			"readme": "https://raw.githubusercontent.com/mom1/PasteAsString/master/README.md",
-			"labels": [
-				"text manipulation"
-			],
+			"labels": ["text manipulation"],
 			"author": "MOM",
 			"releases": [
 				{
@@ -608,16 +539,8 @@
 			"details": "https://github.com/Ociidii-Works/pastel_paws",
 			"author": "XenHat",
 			"description": "Colorful, low-saturation, supports several languages and plugins",
-			"labels": [
-				"color scheme",
-				"colorful",
-				"pastel",
-				"dark"
-			],
-			"previous_names": [
-				"Molokai-Pastel",
-				"Pastel-Paws Color Scheme"
-			],
+			"labels": ["color scheme", "colorful", "pastel", "dark"],
+			"previous_names": ["Molokai-Pastel", "Pastel-Paws Color Scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -648,10 +571,7 @@
 		{
 			"name": "PasteWrap",
 			"details": "https://github.com/daguej/sublime-pastewrap",
-			"labels": [
-				"text manipulation",
-				"clipboard"
-			],
+			"labels": ["text manipulation", "clipboard"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -662,18 +582,11 @@
 		{
 			"name": "Patch Apply",
 			"details": "https://github.com/kkujawinski/sublime-text-3-patch-apply",
-			"labels": [
-				"text manipulation",
-				"clipboard",
-				"code sharing"
-			],
+			"labels": ["text manipulation", "clipboard", "code sharing"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": [
-						"osx",
-						"linux"
-					],
+					"platforms": ["osx", "linux"],
 					"tags": true
 				}
 			]
@@ -712,10 +625,7 @@
 		{
 			"name": "Pawn syntax",
 			"details": "https://github.com/Southclaws/pawn-sublime-language",
-			"labels": [
-				"language syntax",
-				"auto-complete"
-			],
+			"labels": ["language syntax", "auto-complete"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -744,16 +654,6 @@
 			]
 		},
 		{
-			"name": "Peeko",
-			"details": "https://github.com/anxor/Peeko",
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "PEG.js",
 			"details": "https://github.com/alexstrat/PEGjs.tmbundle",
 			"releases": [
@@ -766,9 +666,7 @@
 		{
 			"name": "PEGjs CoffeeScript",
 			"details": "https://github.com/felixhao28/Sublime-PEGcoffee",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -779,9 +677,7 @@
 		{
 			"name": "PEGjs LiveScript",
 			"details": "https://github.com/tgrospic/sublime-pegjs-livescript",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -806,9 +702,7 @@
 		{
 			"name": "PeopleCodeTools",
 			"details": "https://github.com/Jatz/PeopleCodeTools",
-			"previous_names": [
-				"PeopleCode Tools"
-			],
+			"previous_names": ["PeopleCode Tools"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -819,10 +713,7 @@
 		{
 			"name": "PEPE Assembly",
 			"details": "https://github.com/patriq/Sublime-PEPE-Assembly",
-			"labels": [
-				"language syntax",
-				"snippets"
-			],
+			"labels": ["language syntax", "snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -843,12 +734,7 @@
 		{
 			"name": "Perfectionist",
 			"details": "https://github.com/yisibl/sublime-perfectionist",
-			"labels": [
-				"CSS",
-				"beautify",
-				"format",
-				"formatting"
-			],
+			"labels": ["CSS", "beautify", "format", "formatting"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -874,12 +760,7 @@
 		{
 			"name": "Perl Completions",
 			"details": "https://github.com/tushortz/Perl-Completions",
-			"labels": [
-				"perl",
-				"completions",
-				"completion",
-				"Completion"
-			],
+			"labels": ["perl", "completions", "completion", "Completion"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -890,12 +771,7 @@
 		{
 			"name": "perl-Test-Class",
 			"details": "https://github.com/jonasbn/SublimeText-Perl-Test-Class",
-			"labels": [
-				"auto-complete",
-				"formatting",
-				"language syntax",
-				"snippets"
-			],
+			"labels": ["auto-complete", "formatting", "language syntax", "snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -906,12 +782,7 @@
 		{
 			"name": "perl-Test-More",
 			"details": "https://github.com/jonasbn/SublimeText-Perl-Test-More",
-			"labels": [
-				"auto-complete",
-				"formatting",
-				"language syntax",
-				"snippets"
-			],
+			"labels": ["auto-complete", "formatting", "language syntax", "snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -933,10 +804,7 @@
 			"name": "PerlSubs",
 			"details": "https://github.com/semuel/Sublime-Text-Perl-Subs",
 			"description": "PerlSubs - Which Perl subroutine I am at now, again?",
-			"labels": [
-				"perl",
-				"text navigation"
-			],
+			"labels": ["perl", "text navigation"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -948,11 +816,7 @@
 			"name": "PerlTidy",
 			"details": "https://github.com/vifo/SublimePerlTidy",
 			"description": "perltidy/Perl::Tidy plugin - A Perl script indenter and reformatter.",
-			"labels": [
-				"formatting",
-				"perl",
-				"tidy"
-			],
+			"labels": ["formatting", "perl", "tidy"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -992,9 +856,7 @@
 		{
 			"name": "Perv - Color Scheme",
 			"details": "https://github.com/projectivetech/Perv-ColorScheme",
-			"labels": [
-				"color scheme"
-			],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1046,10 +908,7 @@
 		{
 			"name": "Phabricator",
 			"details": "https://github.com/uber/sublime-phabricator",
-			"labels": [
-				"browser integration",
-				"code sharing"
-			],
+			"labels": ["browser integration", "code sharing"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1060,10 +919,7 @@
 		{
 			"name": "PhalconPHP Completions",
 			"details": "https://github.com/james2doyle/phalconphp-completions",
-			"labels": [
-				"phalcon",
-				"php"
-			],
+			"labels": ["phalcon", "php"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1084,9 +940,7 @@
 		{
 			"name": "Phaser Snippets",
 			"details": "https://github.com/afk-mario/Phaser-Snippets",
-			"labels": [
-				"snippets"
-			],
+			"labels": ["snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1097,9 +951,7 @@
 		{
 			"name": "Phix Color Scheme",
 			"details": "https://github.com/stuartherbert/sublime-phix-color-scheme",
-			"labels": [
-				"color scheme"
-			],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1110,10 +962,7 @@
 		{
 			"name": "phJade",
 			"details": "https://github.com/konstantin24121/phJade",
-			"labels": [
-				"jade-php",
-				"syntax highlight"
-			],
+			"labels": ["jade-php", "syntax highlight"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1124,6 +973,17 @@
 		{
 			"name": "Phoenix Beagle",
 			"details": "https://github.com/noma4i/sublime-phoenix-beagle",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "Phoenix LiveView Snippets",
+			"details": "https://github.com/sardaukar/phoenix_liveview_snippets",
+			"labels": ["elixir", "phoenix", "liveview", "snippets"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1145,11 +1005,7 @@
 			"name": "PHP CBF",
 			"details": "https://github.com/andremacola/sublime-PHP_CBF",
 			"issues": "https://github.com/andremacola/sublime-PHP_CBF/issues",
-			"labels": [
-				"php",
-				"phpcs",
-				"formatting"
-			],
+			"labels": ["php", "phpcs", "formatting"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1190,11 +1046,7 @@
 		{
 			"name": "PHP Completions Kit",
 			"details": "https://github.com/gerardroche/sublime-phpck",
-			"labels": [
-				"php",
-				"auto-complete",
-				"completions"
-			],
+			"labels": ["php", "auto-complete", "completions"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1205,14 +1057,7 @@
 		{
 			"name": "PHP Constructors",
 			"details": "https://bitbucket.org/jltorresm/sublime-php-constructors",
-			"labels": [
-				"php",
-				"constructor",
-				"snippets",
-				"code generation",
-				"auto-complete",
-				"text manipulation"
-			],
+			"labels": ["php", "constructor", "snippets", "code generation", "auto-complete", "text manipulation"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1223,10 +1068,7 @@
 		{
 			"name": "PHP CS Fixer",
 			"details": "https://github.com/adael/SublimePhpCsFixer",
-			"labels": [
-				"php",
-				"formatting"
-			],
+			"labels": ["php", "formatting"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1237,15 +1079,7 @@
 		{
 			"name": "PHP Faker Completions",
 			"details": "https://github.com/james2doyle/php-faker-completions",
-			"labels": [
-				"php",
-				"fake",
-				"snippets",
-				"fzaninotto",
-				"test",
-				"factory",
-				"completions"
-			],
+			"labels": ["php", "fake", "snippets", "fzaninotto", "test", "factory", "completions"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1256,12 +1090,7 @@
 		{
 			"name": "PHP Form Builder",
 			"details": "https://github.com/migliori/sublime-phpformbuilder",
-			"labels": [
-				"auto-complete",
-				"bootstrap",
-				"form",
-				"php"
-			],
+			"labels": ["auto-complete", "bootstrap", "form", "php"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1312,10 +1141,7 @@
 		{
 			"name": "PHP Namespace Monkey",
 			"details": "https://github.com/underground-works/sublime-php-namespace-monkey",
-			"labels": [
-				"php",
-				"utilities"
-			],
+			"labels": ["php", "utilities"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1336,11 +1162,7 @@
 		{
 			"name": "PHP Source",
 			"details": "https://github.com/mjkaufer/PHP-Source",
-			"labels": [
-				"php",
-				"utilities",
-				"utils"
-			],
+			"labels": ["php", "utilities", "utils"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1392,11 +1214,7 @@
 			"name": "PhpArrayConverter",
 			"details": "https://github.com/gh640/SublimePhpArrayConverter",
 			"author": "Goto Hayato",
-			"labels": [
-				"php",
-				"formatter",
-				"formatting"
-			],
+			"labels": ["php", "formatter", "formatting"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1417,18 +1235,7 @@
 			"name": "PhpCodeGen",
 			"details": "https://bitbucket.org/bteryek/phpcodegen",
 			"homepage": "http://idevelopsolutions.com/PhpCodeGen",
-			"labels": [
-				"code gen",
-				"php code gen",
-				"php code generation",
-				"code generation",
-				"php",
-				"text manipulation",
-				"formatting",
-				"docblock",
-				"snippets",
-				"php snippets"
-			],
+			"labels": ["code gen", "php code gen", "php code generation", "code generation", "php", "text manipulation", "formatting", "docblock", "snippets", "php snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1439,11 +1246,7 @@
 		{
 			"name": "PhpConnector",
 			"details": "https://github.com/chigix/sublime-php-connector",
-			"labels": [
-				"php",
-				"plugin",
-				"develop"
-			],
+			"labels": ["php", "plugin", "develop"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1473,9 +1276,7 @@
 		{
 			"name": "phpDocumentor",
 			"details": "https://github.com/benmatselby/sublime-phpdocumentor",
-			"previous_names": [
-				"DocBlox"
-			],
+			"previous_names": ["DocBlox"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -1496,12 +1297,7 @@
 		{
 			"name": "phpfmt",
 			"details": "https://github.com/nanch/phpfmt_stable",
-			"labels": [
-				"language syntax",
-				"formatter",
-				"php",
-				"formatting"
-			],
+			"labels": ["language syntax", "formatter", "php", "formatting"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1513,16 +1309,8 @@
 		{
 			"name": "PHPGrammar",
 			"details": "https://github.com/gerardroche/sublime-php-grammar",
-			"labels": [
-				"php",
-				"auto-completion",
-				"completions",
-				"text manipulation",
-				"formatting"
-			],
-			"previous_names": [
-				"php-grammar"
-			],
+			"labels": ["php", "auto-completion", "completions", "text manipulation", "formatting"],
+			"previous_names": ["php-grammar"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1533,16 +1321,8 @@
 		{
 			"name": "PHPIntel",
 			"details": "https://github.com/jotson/SublimePHPIntel",
-			"labels": [
-				"php",
-				"auto-complete",
-				"autocomplete",
-				"intellisense",
-				"completion"
-			],
-			"previous_names": [
-				"MagentoIntel"
-			],
+			"labels": ["php", "auto-complete", "autocomplete", "intellisense", "completion"],
+			"previous_names": ["MagentoIntel"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -1581,9 +1361,7 @@
 		{
 			"name": "PhpNinJaManual",
 			"details": "https://github.com/yangweijie/SublimePHPNinJaManual",
-			"labels": [
-				"php manual"
-			],
+			"labels": ["php manual"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1604,13 +1382,8 @@
 		{
 			"name": "PHPSnippets",
 			"details": "https://github.com/gerardroche/sublime-php-snippets",
-			"labels": [
-				"php",
-				"snippets"
-			],
-			"previous_names": [
-				"php-snippets"
-			],
+			"labels": ["php", "snippets"],
+			"previous_names": ["php-snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1681,9 +1454,7 @@
 		{
 			"name": "PHPUnit Snippets",
 			"details": "https://github.com/florianeckerstorfer/fe-sublime-phpunit",
-			"labels": [
-				"snippets"
-			],
+			"labels": ["snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1694,15 +1465,8 @@
 		{
 			"name": "PHPUnitKit",
 			"details": "https://github.com/gerardroche/sublime-phpunit",
-			"labels": [
-				"php",
-				"phpunit",
-				"testing",
-				"tdd"
-			],
-			"previous_names": [
-				"phpunitkit"
-			],
+			"labels": ["php", "phpunit", "testing", "tdd"],
+			"previous_names": ["phpunitkit"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1723,13 +1487,7 @@
 		{
 			"name": "PICO-8",
 			"details": "https://github.com/Neko250/sublime-PICO-8",
-			"labels": [
-				"color scheme",
-				"editor emulation",
-				"language syntax",
-				"snippets",
-				"build system"
-			],
+			"labels": ["color scheme", "editor emulation", "language syntax", "snippets", "build system"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1740,9 +1498,7 @@
 		{
 			"name": "Pine",
 			"details": "https://github.com/gerardroche/sublime-pine",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1823,13 +1579,7 @@
 		{
 			"name": "PlainNotes",
 			"details": "https://github.com/aziz/PlainNotes",
-			"labels": [
-				"notes",
-				"note taking",
-				"authoring",
-				"todo",
-				"tasks"
-			],
+			"labels": ["notes", "note taking", "authoring", "todo", "tasks"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1839,10 +1589,7 @@
 		},
 		{
 			"details": "https://github.com/aziz/PlainTasks",
-			"labels": [
-				"todo",
-				"tasks"
-			],
+			"labels": ["todo", "tasks"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1853,14 +1600,8 @@
 		{
 			"name": "PlantUmlDiagrams",
 			"details": "https://github.com/evandrocoan/PlantUmlDiagrams",
-			"labels": [
-				"uml",
-				"plantuml"
-			],
-			"author": [
-				"jvantuyl",
-				"evandrocoan"
-			],
+			"labels": ["uml", "plantuml"],
+			"author": ["jvantuyl", "evandrocoan"],
 			"releases": [
 				{
 					"sublime_text": ">=3114",
@@ -1871,10 +1612,7 @@
 		{
 			"name": "PlasticSCM",
 			"details": "https://github.com/ccll/sublime-plasticscm",
-			"labels": [
-				"scm",
-				"vcs"
-			],
+			"labels": ["scm", "vcs"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1904,9 +1642,7 @@
 		{
 			"name": "plist",
 			"details": "https://bitbucket.org/fschwehn/sublime_plist",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1920,7 +1656,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},
@@ -1967,13 +1703,7 @@
 		{
 			"name": "Pmccabe",
 			"details": "https://github.com/mremallin/sublime-pmccabe",
-			"labels": [
-				"linting",
-				"C",
-				"c",
-				"C++",
-				"c++"
-			],
+			"labels": ["linting", "C", "c", "C++", "c++"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1995,18 +1725,11 @@
 		{
 			"name": "PogodaStatusBar",
 			"details": "https://github.com/bolknote/PogodaStatusBar",
-			"labels": [
-				"status bar",
-				"weather",
-				"info",
-				"utilities"
-			],
+			"labels": ["status bar", "weather", "info", "utilities"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": [
-						"osx"
-					],
+					"platforms": ["osx"],
 					"tags": true
 				}
 			]
@@ -2014,9 +1737,7 @@
 		{
 			"name": "PogoScript",
 			"details": "https://github.com/featurist/PogoScript.tmbundle",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2027,9 +1748,7 @@
 		{
 			"name": "Pointless",
 			"details": "https://github.com/pointless-lang/pointless-sublime/",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2040,9 +1759,7 @@
 		{
 			"name": "PokemonTeamSyntax",
 			"details": "https://github.com/forsureitsme/PokemonTeamSyntax",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2053,16 +1770,7 @@
 		{
 			"name": "polyfill",
 			"details": "https://github.com/gerardroche/sublime-polyfill",
-			"labels": [
-				"commands",
-				"ctrlp",
-				"file open",
-				"navigation",
-				"nerdtree",
-				"sidebar",
-				"toggles",
-				"vim"
-			],
+			"labels": ["commands", "ctrlp", "file open", "navigation", "nerdtree", "sidebar", "toggles", "vim"],
 			"releases": [
 				{
 					"sublime_text": ">=3083",
@@ -2075,10 +1783,7 @@
 			"author": "Tristano Ajmone",
 			"details": "https://github.com/tajmone/sublime-polygen",
 			"issues": "https://github.com/tajmone/sublime-polygen/issues",
-			"labels": [
-				"polygen",
-				"language syntax"
-			],
+			"labels": [ "polygen", "language syntax" ],
 			"releases": [
 				{
 					"sublime_text": ">=3149",
@@ -2099,9 +1804,7 @@
 		{
 			"name": "Polymer & Web Component Snippets",
 			"details": "https://github.com/robdodson/PolymerSnippets",
-			"labels": [
-				"snippets"
-			],
+			"labels": ["snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2112,11 +1815,7 @@
 		{
 			"name": "Polymer Syntax",
 			"details": "https://github.com/jaychsu/sublime-polymer-syntax",
-			"labels": [
-				"syntax",
-				"polymer",
-				"web component"
-			],
+			"labels": ["syntax", "polymer", "web component"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2127,9 +1826,7 @@
 		{
 			"name": "Pomodoro",
 			"details": "https://github.com/Neway6655/Sublime-Pomodoro",
-			"labels": [
-				"timer"
-			],
+			"labels": ["timer"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2150,9 +1847,7 @@
 		{
 			"name": "Poppins - Color Scheme",
 			"details": "https://github.com/praveenpuglia/color_scheme_poppins",
-			"labels": [
-				"color scheme"
-			],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2163,14 +1858,7 @@
 		{
 			"name": "Portage",
 			"details": "https://github.com/krizalys/sublime-portage",
-			"labels": [
-				"language syntax",
-				"portage",
-				"gentoo",
-				"funtoo",
-				"emerge",
-				"ebuild"
-			],
+			"labels": ["language syntax", "portage", "gentoo", "funtoo", "emerge", "ebuild"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2181,10 +1869,7 @@
 		{
 			"name": "Postap",
 			"details": "https://github.com/LPGhatguy/Postap",
-			"labels": [
-				"theme",
-				"color scheme"
-			],
+			"labels": ["theme", "color scheme"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2221,10 +1906,7 @@
 			"details": "https://github.com/mbnuqw/sublime-postfixer",
 			"readme": "https://raw.githubusercontent.com/mbnuqw/sublime-postfixer/master/README.md",
 			"issues": "https://github.com/mbnuqw/sublime-postfixer/issues",
-			"labels": [
-				"text manipulation",
-				"auto-complete"
-			],
+			"labels": ["text manipulation", "auto-complete"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2235,9 +1917,7 @@
 		{
 			"name": "Postgres PL pgSQL",
 			"details": "https://github.com/mulander/postgres.tmbundle",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2248,9 +1928,7 @@
 		{
 			"name": "PostgreSQL Syntax Highlighting",
 			"details": "https://github.com/tkopets/sublime-postgresql-syntax",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2261,9 +1939,7 @@
 		{
 			"name": "PostScript",
 			"details": "https://github.com/Briles/sublime-syntax-postscript",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2274,16 +1950,33 @@
 		{
 			"name": "PouchDB Snippets",
 			"details": "https://github.com/brenopolanski/pouchdb-sublime-snippets",
-			"labels": [
-				"db",
-				"pouchdb",
-				"couchdb",
-				"snippets"
-			],
+			"labels": ["db", "pouchdb", "couchdb", "snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "PovRay",
+			"details": "https://github.com/leoheck/sublime-povray",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "Power System Tools Syntax",
+			"details":"https://github.com/dparrini/sublime_powersystems",
+			"labels": ["language syntax", "auto-complete"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
 				}
 			]
 		},
@@ -2318,20 +2011,24 @@
 			]
 		},
 		{
+			"name": "PowerShell",
 			"details": "https://github.com/SublimeText/PowerShell",
+			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": "*",
-					"branch": "master"
+					"sublime_text": "<3156",
+					"tags": "version/st3155/"
+				},
+				{
+					"sublime_text": ">=3156",
+					"tags": "version/st/"
 				}
 			]
 		},
 		{
 			"name": "Powershell Help Generator",
 			"details": "https://github.com/sponte/sublime_powershell_help",
-			"labels": [
-				"help doc"
-			],
+			"labels": ["help doc"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2351,12 +2048,7 @@
 		{
 			"name": "PPCL Language Syntax and Editor",
 			"details": "https://github.com/blandfbt/PPCL",
-			"labels": [
-				"PPCL",
-				"syntax",
-				"siemens",
-				"apogee"
-			],
+			"labels": ["PPCL", "syntax", "siemens", "apogee"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2367,9 +2059,7 @@
 		{
 			"name": "Pre language syntax highlighting",
 			"details": "https://github.com/jonschlinkert/pre-sublime",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2380,10 +2070,7 @@
 		{
 			"name": "Predawn",
 			"details": "https://github.com/jamiewilson/predawn",
-			"labels": [
-				"theme",
-				"color scheme"
-			],
+			"labels": ["theme", "color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2394,9 +2081,7 @@
 		{
 			"name": "Predawn Monokai",
 			"details": "https://github.com/varemenos/sublime-predawn-monokai",
-			"labels": [
-				"color scheme"
-			],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2407,10 +2092,7 @@
 		{
 			"name": "Predawn Twilight Theme",
 			"details": "https://github.com/jrnewell/predawn-twilight-theme",
-			"labels": [
-				"theme",
-				"color scheme"
-			],
+			"labels": ["theme", "color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2421,10 +2103,7 @@
 		{
 			"name": "PreferenceSync",
 			"details": "https://github.com/devdinu/PreferenceSync",
-			"labels": [
-				"sync",
-				"preferences"
-			],
+			"labels": ["sync", "preferences"],
 			"releases": [
 				{
 					"sublime_text": ">3000",
@@ -2465,17 +2144,10 @@
 		},
 		{
 			"name": "PreTeXtual",
-			"previous_names": [
-				"MBXTools"
-			],
+			"previous_names": ["MBXTools"],
 			"details": "https://github.com/daverosoff/PreTeXtual",
 			"author": "Dave Rosoff",
-			"labels": [
-				"mbx",
-				"mathbook xml",
-				"pretext",
-				"ptx"
-			],
+			"labels": ["mbx", "mathbook xml", "pretext", "ptx"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2486,15 +2158,7 @@
 		{
 			"name": "Pretty JSON",
 			"details": "https://github.com/dzhibas/SublimePrettyJson",
-			"labels": [
-				"json",
-				"pretty",
-				"lint",
-				"minify",
-				"validate",
-				"query",
-				"json2xml"
-			],
+			"labels": ["json", "pretty", "lint", "minify", "validate", "query", "json2xml"],
 			"releases": [
 				{
 					"sublime_text": "<4000",
@@ -2519,15 +2183,7 @@
 		{
 			"name": "Pretty Shell",
 			"details": "https://github.com/aerobounce/Sublime-Pretty-Shell",
-			"labels": [
-				"shell",
-				"sh",
-				"posix",
-				"bash",
-				"formatting",
-				"pretty",
-				"minify"
-			],
+			"labels": ["shell", "sh", "posix", "bash", "formatting", "pretty", "minify"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2562,14 +2218,7 @@
 		{
 			"name": "Prevent Duplicate Windows",
 			"details": "https://github.com/franciscolourenco/sublime-prevent-duplicate-windows",
-			"labels": [
-				"terminal",
-				"file navigation",
-				"prevent",
-				"duplicate",
-				"windows",
-				"productivity"
-			],
+			"labels": ["terminal", "file navigation", "prevent", "duplicate", "windows", "productivity"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2599,13 +2248,7 @@
 		{
 			"name": "Print to HTML",
 			"details": "https://github.com/grubernaut/sublimetext-print-to-html",
-			"labels": [
-				"tasks",
-				"printing",
-				"utilities",
-				"utils",
-				"browser"
-			],
+			"labels": ["tasks", "printing", "utilities", "utils", "browser"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -2625,15 +2268,12 @@
 				{
 					"sublime_text": "*",
 					"tags": true
-				}
-			]
+				}]
 		},
 		{
 			"name": "Prismatic Color Scheme",
 			"details": "https://github.com/huijing/Prismatic",
-			"labels": [
-				"color scheme"
-			],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2664,9 +2304,7 @@
 		{
 			"name": "ProcessWire Snippets - Advanced",
 			"details": "https://github.com/evanmcd/SublimeProcessWireSnippetsAdvanced",
-			"labels": [
-				"snippets"
-			],
+			"labels": ["snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2677,9 +2315,7 @@
 		{
 			"name": "ProcessWire Snippets - Basic",
 			"details": "https://github.com/evanmcd/SublimeProcessWireSnippetsBasic",
-			"labels": [
-				"snippets"
-			],
+			"labels": ["snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2690,11 +2326,7 @@
 		{
 			"name": "ProductiveSnippetsERB",
 			"details": "https://github.com/janlelis/productive-sublime-snippets-erb",
-			"labels": [
-				"snippets",
-				"erb",
-				"ruby"
-			],
+			"labels": ["snippets", "erb", "ruby"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2705,10 +2337,20 @@
 		{
 			"name": "ProductiveSnippetsRuby",
 			"details": "https://github.com/janlelis/productive-sublime-snippets-ruby",
-			"labels": [
-				"snippets",
-				"ruby"
-			],
+			"labels": ["snippets", "ruby"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "Profile Switcher",
+			"details": "https://github.com/tonsky/sublime-profiles",
+			"donate": "https://www.patreon.com/tonsky",
+			"labels": ["preferences"],
+			"previous_names": ["Switch Settings"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2752,9 +2394,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": [
-						"windows"
-					],
+					"platforms": ["windows"],
 					"tags": true
 				}
 			]
@@ -2762,10 +2402,7 @@
 		{
 			"name": "Project Specific Syntax Settings",
 			"details": "https://github.com/reywood/sublime-project-specific-syntax",
-			"labels": [
-				"language syntax",
-				"project"
-			],
+			"labels": ["language syntax", "project"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2786,11 +2423,7 @@
 		{
 			"name": "ProjectCompletions",
 			"details": "https://github.com/bordaigorl/sublime-project-completions",
-			"labels": [
-				"completions",
-				"snippets",
-				"project"
-			],
+			"labels": ["completions", "snippets", "project"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2800,16 +2433,9 @@
 		},
 		{
 			"name": "ProjectEnvironment",
-			"previous_names": [
-				"Project Environment",
-				"Environment Settings"
-			],
+			"previous_names": ["Project Environment", "Environment Settings"],
 			"details": "https://bitbucket.org/daniele-niero/sublimeprojectenvironment",
-			"labels": [
-				"environment",
-				"variables",
-				"project"
-			],
+			"labels": ["environment", "variables", "project"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2821,10 +2447,7 @@
 			"name": "ProjectFiles",
 			"details": "https://github.com/shagabutdinov/sublime-project-files",
 			"donate": "https://github.com/shagabutdinov/sublime-enhanced/blob/master/readme-donations.md",
-			"labels": [
-				"sublime-enhanced",
-				"file navigation"
-			],
+			"labels": ["sublime-enhanced", "file navigation"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2835,16 +2458,8 @@
 		{
 			"name": "ProjectMaker",
 			"details": "https://github.com/bit101/ProjectMaker",
-			"labels": [
-				"project",
-				"template",
-				"project-templates",
-				"cookiecutter",
-				"jinja2"
-			],
-			"previous_names": [
-				"STProjectMaker"
-			],
+			"labels": ["project", "template", "project-templates", "cookiecutter", "jinja2"],
+			"previous_names" : ["STProjectMaker"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2866,10 +2481,7 @@
 			"name": "Prolog",
 			"details": "https://github.com/alnkpa/sublimeprolog",
 			"donate": "https://flattr.com/profile/alnkpa",
-			"labels": [
-				"build system",
-				"language syntax"
-			],
+			"labels": ["build system", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2880,10 +2492,7 @@
 		{
 			"name": "Promela_Spin",
 			"details": "https://github.com/corbanmailloux/sublime-promela-spin",
-			"labels": [
-				"build system",
-				"language syntax"
-			],
+			"labels": ["build system", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2894,10 +2503,7 @@
 		{
 			"name": "Propel",
 			"details": "https://github.com/smhg/sublime-propel",
-			"labels": [
-				"php",
-				"orm"
-			],
+			"labels": ["php", "orm"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2908,9 +2514,7 @@
 		{
 			"name": "Protobuf Syntax Hightlighting",
 			"details": "https://github.com/VcamX/protobuf-syntax-highlighting",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -2921,12 +2525,8 @@
 		{
 			"name": "ProtoBufCodeFormatter",
 			"details": "https://github.com/DirkBrand/ProtoBufCodeFormatter_Sublime",
-			"labels": [
-				"formatting"
-			],
-			"previous_names": [
-				"ProtoBuf Code Formatter"
-			],
+			"labels": ["formatting"],
+			"previous_names": ["ProtoBuf Code Formatter"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -2937,9 +2537,7 @@
 		{
 			"name": "Protocol Buffer Syntax",
 			"details": "https://github.com/vihangm/sublime-protobuf-syntax",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2980,9 +2578,7 @@
 		{
 			"name": "Pug",
 			"details": "https://github.com/davidrios/pug-tmbundle",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2993,9 +2589,7 @@
 		{
 			"name": "Pumpkin Color Scheme",
 			"details": "https://github.com/afonsopacifer/pumpkin",
-			"labels": [
-				"color scheme"
-			],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3006,9 +2600,7 @@
 		{
 			"name": "PunchMeInTheFace Color Scheme",
 			"details": "https://github.com/tashrifsanil/PunchMeInTheFace-Color-Scheme",
-			"labels": [
-				"color scheme"
-			],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3029,9 +2621,7 @@
 		{
 			"name": "Puppet Syntax checking",
 			"details": "https://github.com/Stubbs/sublime-puppet-syntax",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -3052,9 +2642,7 @@
 		{
 			"name": "PureCSS",
 			"details": "https://github.com/TCattd/PureCSS-sublime",
-			"labels": [
-				"auto-complete"
-			],
+			"labels": ["auto-complete"],
 			"releases": [
 				{
 					"sublime_text": ">3000",
@@ -3065,13 +2653,8 @@
 		{
 			"name": "PureScript",
 			"details": "https://github.com/b123400/purescript-ide-sublime",
-			"labels": [
-				"language syntax",
-				"ide"
-			],
-			"previous_names": [
-				"PureScript IDE"
-			],
+			"labels": ["language syntax", "ide"],
+			"previous_names": ["PureScript IDE"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3082,9 +2665,7 @@
 		{
 			"name": "PureScript Syntax",
 			"details": "https://github.com/tellnobody1/sublime-purescript-syntax",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">3092",
@@ -3095,9 +2676,7 @@
 		{
 			"name": "PurpleHaze",
 			"details": "https://github.com/klomontes/purple-haze-color-scheme",
-			"labels": [
-				"color scheme"
-			],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3108,9 +2687,7 @@
 		{
 			"name": "Pushb",
 			"details": "https://github.com/geovanisouza92/Pushb",
-			"labels": [
-				"pushbullet"
-			],
+			"labels": ["pushbullet"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3121,9 +2698,7 @@
 		{
 			"name": "Pushbullet",
 			"details": "https://github.com/xarnze/sublimepushbullet",
-			"labels": [
-				"pushbullet"
-			],
+			"labels": ["pushbullet"],
 			"releases": [
 				{
 					"sublime_text": ">3000",
@@ -3164,9 +2739,7 @@
 		{
 			"name": "PyCover",
 			"details": "https://github.com/perimosocordiae/PyCover",
-			"previous_names": [
-				"Python Coverage"
-			],
+			"previous_names": ["Python Coverage"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3187,13 +2760,7 @@
 		{
 			"name": "PyenvEnv",
 			"details": "https://github.com/jkr78/PyenvEnv",
-			"labels": [
-				"python",
-				"pyenv",
-				"env",
-				"virtualenv",
-				"venv"
-			],
+			"labels": ["python", "pyenv", "env", "virtualenv", "venv"],
 			"releases": [
 				{
 					"sublime_text": ">3000",
@@ -3204,12 +2771,7 @@
 		{
 			"name": "Pygame Completions",
 			"details": "https://github.com/tushortz/Pygame-Completions",
-			"labels": [
-				"completions",
-				"completion",
-				"Completion",
-				"python"
-			],
+			"labels": ["completions", "completion", "Completion", "python"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3219,9 +2781,7 @@
 		},
 		{
 			"details": "https://github.com/biermeester/Pylinter",
-			"labels": [
-				"linting"
-			],
+			"labels": ["linting"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3252,12 +2812,7 @@
 		{
 			"name": "Pynsist",
 			"details": "https://github.com/idleberg/sublime-pynsist",
-			"labels": [
-				"build-system",
-				"language syntax",
-				"nsis",
-				"python"
-			],
+			"labels": ["build-system", "language syntax", "nsis", "python"],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -3269,16 +2824,7 @@
 			"name": "PypiPackageInfo",
 			"details": "https://github.com/gh640/SublimePypiPackageInfo",
 			"author": "Goto Hayato",
-			"labels": [
-				"python",
-				"package",
-				"pypi",
-				"requirements.txt",
-				"pyproject.toml",
-				"poetry",
-				"pipfile",
-				"pipenv"
-			],
+			"labels": ["python", "package", "pypi", "requirements.txt", "pyproject.toml", "poetry", "pipfile", "pipenv"],
 			"releases": [
 				{
 					"sublime_text": ">=3124",
@@ -3299,15 +2845,7 @@
 		{
 			"name": "PyQt5 Completions",
 			"details": "https://github.com/tushortz/PyQt5-Completions",
-			"labels": [
-				"python",
-				"completions",
-				"auto-complete",
-				"completion",
-				"autocomplete",
-				"snippet",
-				"Completion"
-			],
+			"labels": ["python","completions", "auto-complete", "completion", "autocomplete", "snippet", "Completion"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3328,9 +2866,7 @@
 		{
 			"name": "PyroCMS Snippets",
 			"details": "https://github.com/Dixens/sublime-text-pyrocms-snippets",
-			"labels": [
-				"snippets"
-			],
+			"labels": ["snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3361,11 +2897,7 @@
 		{
 			"name": "PyTest",
 			"details": "https://github.com/kaste/PyTest",
-			"labels": [
-				"python",
-				"pytest",
-				"testing"
-			],
+			"labels": ["python", "pytest", "testing"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3376,9 +2908,7 @@
 		{
 			"name": "Pytest Snippets",
 			"details": "https://github.com/sloria/sublime-pytest-snippets",
-			"labels": [
-				"snippets"
-			],
+			"labels": ["snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3389,12 +2919,8 @@
 		{
 			"name": "Python 3",
 			"details": "https://github.com/petervaro/python",
-			"labels": [
-				"language syntax"
-			],
-			"previous_names": [
-				"Modern Python"
-			],
+			"labels": ["language syntax"],
+			"previous_names": ["Modern Python"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3425,9 +2951,7 @@
 		{
 			"name": "Python Checker",
 			"details": "https://github.com/patrys/PythonChecker",
-			"labels": [
-				"linting"
-			],
+			"labels": ["linting"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3437,14 +2961,9 @@
 		},
 		{
 			"name": "Python Completions",
-			"previous_names": [
-				"Python Auto-Complete"
-			],
+			"previous_names": ["Python Auto-Complete"],
 			"details": "https://github.com/eliquious/Python-Auto-Complete",
-			"labels": [
-				"python",
-				"completions"
-			],
+			"labels": ["python", "completions"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3485,9 +3004,7 @@
 		{
 			"name": "Python Flake8 Lint",
 			"details": "https://github.com/dreadatour/Flake8Lint",
-			"labels": [
-				"linting"
-			],
+			"labels": ["linting"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3518,9 +3035,7 @@
 		{
 			"name": "Python Improved",
 			"details": "https://github.com/MattDMo/PythonImproved",
-			"labels": [
-				"language syntax"
-			],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3531,9 +3046,7 @@
 		{
 			"name": "Python Nose Testing Snippets",
 			"details": "https://github.com/sloria/sublime-nose-snippets",
-			"labels": [
-				"snippets"
-			],
+			"labels": ["snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3564,13 +3077,11 @@
 		{
 			"name": "Python Path to Clipboard",
 			"details": "https://github.com/Mimino666/SublimeText2-python-package-to-clipboard",
-			"previous_names": [
-				"Python Package to Clipboard"
-			],
+			"previous_names": ["Python Package to Clipboard"],
 			"releases": [
 				{
-					"sublime_text": "<3000",
-					"branch": "master"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
@@ -3587,9 +3098,7 @@
 		{
 			"name": "Python Pep8 Lint",
 			"details": "https://github.com/dreadatour/Pep8Lint",
-			"labels": [
-				"linting"
-			],
+			"labels": ["linting"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -3643,13 +3152,7 @@
 		{
 			"name": "PythonNiceToHaveFeatures",
 			"details": "https://github.com/monobot/PythonNiceToHaveFeatures",
-			"labels": [
-				"python",
-				"refactor",
-				"relative path",
-				"package path",
-				"path"
-			],
+			"labels": ["python", "refactor", "relative path", "package path", "path"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3699,9 +3202,7 @@
 		{
 			"name": "PythonTraceback",
 			"details": "https://github.com/kedder/sublime-python-traceback",
-			"labels": [
-				"file navigation"
-			],
+			"labels": ["file navigation"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3711,19 +3212,12 @@
 		},
 		{
 			"name": "PythonVoiceCodingPlugin",
-			"details": "https://github.com/mpourmpoulis/PythonVoiceCodingPlugin",
-			"labels": [
-				"voice coding",
-				"accessibility",
-				"syntax tree",
-				"python",
-				"grammar",
-				"high level"
-			],
-			"releases": [
+			"details":"https://github.com/mpourmpoulis/PythonVoiceCodingPlugin",
+			"labels":["voice coding","accessibility","syntax tree","python","grammar","high level"],
+			"releases":[
 				{
-					"sublime_text": ">=3000",
-					"tags": true
+					"sublime_text":">=3000",
+					"tags":true
 				}
 			]
 		},
@@ -3750,10 +3244,7 @@
 		{
 			"name": "PyYapf Python Formatter",
 			"details": "https://github.com/jason-kane/PyYapf",
-			"labels": [
-				"python",
-				"formatting"
-			],
+			"labels": ["python", "formatting"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/p.json
+++ b/repository/p.json
@@ -4,7 +4,9 @@
 		{
 			"name": "P3 Assembly",
 			"details": "https://github.com/rgcv/p3assembly-sublime-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -25,12 +27,17 @@
 		{
 			"name": "P4Explorer",
 			"details": "https://github.com/ymengesha/P4Explorer",
-			"labels": ["vcs", "file navigation"],
+			"labels": [
+				"vcs",
+				"file navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
 					"tags": true,
-					"platforms": ["windows"]
+					"platforms": [
+						"windows"
+					]
 				}
 			]
 		},
@@ -57,7 +64,12 @@
 		{
 			"name": "Package Snippets",
 			"details": "https://github.com/frdmn/package-snippets",
-			"labels": ["snippets", "git", "repository", "package"],
+			"labels": [
+				"snippets",
+				"git",
+				"repository",
+				"package"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -68,8 +80,12 @@
 		{
 			"name": "PackageDev",
 			"details": "https://github.com/SublimeText/PackageDev",
-			"previous_names": ["AAAPackageDev"],
-			"author": ["FichteFoll"],
+			"previous_names": [
+				"AAAPackageDev"
+			],
+			"author": [
+				"FichteFoll"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3154",
@@ -103,7 +119,14 @@
 			"name": "PackagesUI",
 			"details": "https://github.com/unknownuser88/PackagesUI",
 			"author": "David Bekoyan",
-			"labels": ["package", "utilities", "dashboard", "gui", "inline", "help system"],
+			"labels": [
+				"package",
+				"utilities",
+				"dashboard",
+				"gui",
+				"inline",
+				"help system"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -114,7 +137,12 @@
 		{
 			"name": "PackageSync",
 			"details": "https://github.com/utkarsh9891/PackageSync",
-			"labels": ["backup", "restore", "sync", "package"],
+			"labels": [
+				"backup",
+				"restore",
+				"sync",
+				"package"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -157,11 +185,17 @@
 		{
 			"name": "Padawan (PHP completion)",
 			"details": "https://github.com/padawan-php/padawan.sublime",
-			"labels": ["auto-complete", "php"],
+			"labels": [
+				"auto-complete",
+				"php"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["osx", "linux"],
+					"platforms": [
+						"osx",
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -179,7 +213,12 @@
 		{
 			"name": "PaletteFile",
 			"details": "https://github.com/vshotarov/PaletteFile",
-			"labels": ["file creation", "file navigation", "directory creation", "directory navigation"],
+			"labels": [
+				"file creation",
+				"file navigation",
+				"directory creation",
+				"directory navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -190,7 +229,9 @@
 		{
 			"name": "Panda Syntax Sublime",
 			"details": "https://github.com/siamak/panda-syntax-sublime",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -303,7 +344,10 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx", "linux"],
+					"platforms": [
+						"osx",
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -331,7 +375,9 @@
 		{
 			"name": "Paraiso Black Color Scheme",
 			"details": "https://github.com/idleberg/ParaisoBlack.tmTheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -342,8 +388,12 @@
 		{
 			"name": "Paraiso Color Scheme",
 			"details": "https://github.com/idleberg/Paraiso.tmTheme",
-			"labels": ["color scheme"],
-			"previous_names": ["Paraíso Color Scheme"],
+			"labels": [
+				"color scheme"
+			],
+			"previous_names": [
+				"Paraíso Color Scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -363,7 +413,11 @@
 		},
 		{
 			"details": "https://github.com/odyssomay/paredit",
-			"labels": ["text manipulation", "formatting", "code navigation"],
+			"labels": [
+				"text manipulation",
+				"formatting",
+				"code navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -373,7 +427,10 @@
 		},
 		{
 			"details": "https://github.com/ilyakam/ParentalControl",
-			"labels": ["formatting", "text manipulation"],
+			"labels": [
+				"formatting",
+				"text manipulation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -384,7 +441,16 @@
 		{
 			"name": "Parinfer",
 			"details": "https://github.com/oakmac/sublime-text-parinfer",
-			"labels": ["parinfer", "paredit", "clojure", "clojurescript", "cljs", "lisp", "formatting", "text manipulation"],
+			"labels": [
+				"parinfer",
+				"paredit",
+				"clojure",
+				"clojurescript",
+				"cljs",
+				"lisp",
+				"formatting",
+				"text manipulation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -395,11 +461,16 @@
 		{
 			"name": "Parquet",
 			"details": "https://github.com/yuj/sublime-parquet",
-			"labels": ["parquet"],
+			"labels": [
+				"parquet"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx", "linux"],
+					"platforms": [
+						"osx",
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -407,7 +478,10 @@
 		{
 			"name": "Particle Reverse Polish Language",
 			"details": "https://github.com/KubeRoot/Sublime-PRPL",
-			"labels": ["language syntax", "completions"],
+			"labels": [
+				"language syntax",
+				"completions"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -417,8 +491,10 @@
 		},
 		{
 			"name": "Parva Syntax",
-			"details" : "https://github.com/muskatel/Parva_Syntax",
-			"labels": ["language syntax"],
+			"details": "https://github.com/muskatel/Parva_Syntax",
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -432,7 +508,10 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx", "linux"],
+					"platforms": [
+						"osx",
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -490,7 +569,9 @@
 		{
 			"name": "PasteAhead",
 			"details": "https://github.com/mattst/PasteAhead",
-			"labels": ["paste"],
+			"labels": [
+				"paste"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -502,7 +583,9 @@
 			"name": "PasteAsString",
 			"details": "https://github.com/mom1/PasteAsString",
 			"readme": "https://raw.githubusercontent.com/mom1/PasteAsString/master/README.md",
-			"labels": ["text manipulation"],
+			"labels": [
+				"text manipulation"
+			],
 			"author": "MOM",
 			"releases": [
 				{
@@ -525,8 +608,16 @@
 			"details": "https://github.com/Ociidii-Works/pastel_paws",
 			"author": "XenHat",
 			"description": "Colorful, low-saturation, supports several languages and plugins",
-			"labels": ["color scheme", "colorful", "pastel", "dark"],
-			"previous_names": ["Molokai-Pastel", "Pastel-Paws Color Scheme"],
+			"labels": [
+				"color scheme",
+				"colorful",
+				"pastel",
+				"dark"
+			],
+			"previous_names": [
+				"Molokai-Pastel",
+				"Pastel-Paws Color Scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -557,7 +648,10 @@
 		{
 			"name": "PasteWrap",
 			"details": "https://github.com/daguej/sublime-pastewrap",
-			"labels": ["text manipulation", "clipboard"],
+			"labels": [
+				"text manipulation",
+				"clipboard"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -568,11 +662,18 @@
 		{
 			"name": "Patch Apply",
 			"details": "https://github.com/kkujawinski/sublime-text-3-patch-apply",
-			"labels": ["text manipulation", "clipboard", "code sharing"],
+			"labels": [
+				"text manipulation",
+				"clipboard",
+				"code sharing"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx", "linux"],
+					"platforms": [
+						"osx",
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -611,7 +712,10 @@
 		{
 			"name": "Pawn syntax",
 			"details": "https://github.com/Southclaws/pawn-sublime-language",
-			"labels": ["language syntax", "auto-complete"],
+			"labels": [
+				"language syntax",
+				"auto-complete"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -662,7 +766,9 @@
 		{
 			"name": "PEGjs CoffeeScript",
 			"details": "https://github.com/felixhao28/Sublime-PEGcoffee",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -673,7 +779,9 @@
 		{
 			"name": "PEGjs LiveScript",
 			"details": "https://github.com/tgrospic/sublime-pegjs-livescript",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -698,7 +806,9 @@
 		{
 			"name": "PeopleCodeTools",
 			"details": "https://github.com/Jatz/PeopleCodeTools",
-			"previous_names": ["PeopleCode Tools"],
+			"previous_names": [
+				"PeopleCode Tools"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -709,7 +819,10 @@
 		{
 			"name": "PEPE Assembly",
 			"details": "https://github.com/patriq/Sublime-PEPE-Assembly",
-			"labels": ["language syntax", "snippets"],
+			"labels": [
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -730,7 +843,12 @@
 		{
 			"name": "Perfectionist",
 			"details": "https://github.com/yisibl/sublime-perfectionist",
-			"labels": ["CSS", "beautify", "format", "formatting"],
+			"labels": [
+				"CSS",
+				"beautify",
+				"format",
+				"formatting"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -756,7 +874,12 @@
 		{
 			"name": "Perl Completions",
 			"details": "https://github.com/tushortz/Perl-Completions",
-			"labels": ["perl", "completions", "completion", "Completion"],
+			"labels": [
+				"perl",
+				"completions",
+				"completion",
+				"Completion"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -767,7 +890,12 @@
 		{
 			"name": "perl-Test-Class",
 			"details": "https://github.com/jonasbn/SublimeText-Perl-Test-Class",
-			"labels": ["auto-complete", "formatting", "language syntax", "snippets"],
+			"labels": [
+				"auto-complete",
+				"formatting",
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -778,7 +906,12 @@
 		{
 			"name": "perl-Test-More",
 			"details": "https://github.com/jonasbn/SublimeText-Perl-Test-More",
-			"labels": ["auto-complete", "formatting", "language syntax", "snippets"],
+			"labels": [
+				"auto-complete",
+				"formatting",
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -800,7 +933,10 @@
 			"name": "PerlSubs",
 			"details": "https://github.com/semuel/Sublime-Text-Perl-Subs",
 			"description": "PerlSubs - Which Perl subroutine I am at now, again?",
-			"labels": ["perl", "text navigation"],
+			"labels": [
+				"perl",
+				"text navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -812,7 +948,11 @@
 			"name": "PerlTidy",
 			"details": "https://github.com/vifo/SublimePerlTidy",
 			"description": "perltidy/Perl::Tidy plugin - A Perl script indenter and reformatter.",
-			"labels": ["formatting", "perl", "tidy"],
+			"labels": [
+				"formatting",
+				"perl",
+				"tidy"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -852,7 +992,9 @@
 		{
 			"name": "Perv - Color Scheme",
 			"details": "https://github.com/projectivetech/Perv-ColorScheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -904,7 +1046,10 @@
 		{
 			"name": "Phabricator",
 			"details": "https://github.com/uber/sublime-phabricator",
-			"labels": ["browser integration", "code sharing"],
+			"labels": [
+				"browser integration",
+				"code sharing"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -915,7 +1060,10 @@
 		{
 			"name": "PhalconPHP Completions",
 			"details": "https://github.com/james2doyle/phalconphp-completions",
-			"labels": ["phalcon", "php"],
+			"labels": [
+				"phalcon",
+				"php"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -936,7 +1084,9 @@
 		{
 			"name": "Phaser Snippets",
 			"details": "https://github.com/afk-mario/Phaser-Snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -947,7 +1097,9 @@
 		{
 			"name": "Phix Color Scheme",
 			"details": "https://github.com/stuartherbert/sublime-phix-color-scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -958,7 +1110,10 @@
 		{
 			"name": "phJade",
 			"details": "https://github.com/konstantin24121/phJade",
-			"labels": ["jade-php", "syntax highlight"],
+			"labels": [
+				"jade-php",
+				"syntax highlight"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -990,7 +1145,11 @@
 			"name": "PHP CBF",
 			"details": "https://github.com/andremacola/sublime-PHP_CBF",
 			"issues": "https://github.com/andremacola/sublime-PHP_CBF/issues",
-			"labels": ["php", "phpcs", "formatting"],
+			"labels": [
+				"php",
+				"phpcs",
+				"formatting"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1031,7 +1190,11 @@
 		{
 			"name": "PHP Completions Kit",
 			"details": "https://github.com/gerardroche/sublime-phpck",
-			"labels": ["php", "auto-complete", "completions"],
+			"labels": [
+				"php",
+				"auto-complete",
+				"completions"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1042,7 +1205,14 @@
 		{
 			"name": "PHP Constructors",
 			"details": "https://bitbucket.org/jltorresm/sublime-php-constructors",
-			"labels": ["php", "constructor", "snippets", "code generation", "auto-complete", "text manipulation"],
+			"labels": [
+				"php",
+				"constructor",
+				"snippets",
+				"code generation",
+				"auto-complete",
+				"text manipulation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1053,7 +1223,10 @@
 		{
 			"name": "PHP CS Fixer",
 			"details": "https://github.com/adael/SublimePhpCsFixer",
-			"labels": ["php", "formatting"],
+			"labels": [
+				"php",
+				"formatting"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1064,7 +1237,15 @@
 		{
 			"name": "PHP Faker Completions",
 			"details": "https://github.com/james2doyle/php-faker-completions",
-			"labels": ["php", "fake", "snippets", "fzaninotto", "test", "factory", "completions"],
+			"labels": [
+				"php",
+				"fake",
+				"snippets",
+				"fzaninotto",
+				"test",
+				"factory",
+				"completions"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1075,7 +1256,12 @@
 		{
 			"name": "PHP Form Builder",
 			"details": "https://github.com/migliori/sublime-phpformbuilder",
-			"labels": ["auto-complete", "bootstrap", "form", "php"],
+			"labels": [
+				"auto-complete",
+				"bootstrap",
+				"form",
+				"php"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1126,7 +1312,10 @@
 		{
 			"name": "PHP Namespace Monkey",
 			"details": "https://github.com/underground-works/sublime-php-namespace-monkey",
-			"labels": ["php", "utilities"],
+			"labels": [
+				"php",
+				"utilities"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1147,7 +1336,11 @@
 		{
 			"name": "PHP Source",
 			"details": "https://github.com/mjkaufer/PHP-Source",
-			"labels": ["php", "utilities", "utils"],
+			"labels": [
+				"php",
+				"utilities",
+				"utils"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1199,7 +1392,11 @@
 			"name": "PhpArrayConverter",
 			"details": "https://github.com/gh640/SublimePhpArrayConverter",
 			"author": "Goto Hayato",
-			"labels": ["php", "formatter", "formatting"],
+			"labels": [
+				"php",
+				"formatter",
+				"formatting"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1220,7 +1417,18 @@
 			"name": "PhpCodeGen",
 			"details": "https://bitbucket.org/bteryek/phpcodegen",
 			"homepage": "http://idevelopsolutions.com/PhpCodeGen",
-			"labels": ["code gen", "php code gen", "php code generation", "code generation", "php", "text manipulation", "formatting", "docblock", "snippets", "php snippets"],
+			"labels": [
+				"code gen",
+				"php code gen",
+				"php code generation",
+				"code generation",
+				"php",
+				"text manipulation",
+				"formatting",
+				"docblock",
+				"snippets",
+				"php snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1231,7 +1439,11 @@
 		{
 			"name": "PhpConnector",
 			"details": "https://github.com/chigix/sublime-php-connector",
-			"labels": ["php", "plugin", "develop"],
+			"labels": [
+				"php",
+				"plugin",
+				"develop"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1261,7 +1473,9 @@
 		{
 			"name": "phpDocumentor",
 			"details": "https://github.com/benmatselby/sublime-phpdocumentor",
-			"previous_names": ["DocBlox"],
+			"previous_names": [
+				"DocBlox"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -1282,7 +1496,12 @@
 		{
 			"name": "phpfmt",
 			"details": "https://github.com/nanch/phpfmt_stable",
-			"labels": ["language syntax", "formatter", "php", "formatting"],
+			"labels": [
+				"language syntax",
+				"formatter",
+				"php",
+				"formatting"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1294,8 +1513,16 @@
 		{
 			"name": "PHPGrammar",
 			"details": "https://github.com/gerardroche/sublime-php-grammar",
-			"labels": ["php", "auto-completion", "completions", "text manipulation", "formatting"],
-			"previous_names": ["php-grammar"],
+			"labels": [
+				"php",
+				"auto-completion",
+				"completions",
+				"text manipulation",
+				"formatting"
+			],
+			"previous_names": [
+				"php-grammar"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1306,8 +1533,16 @@
 		{
 			"name": "PHPIntel",
 			"details": "https://github.com/jotson/SublimePHPIntel",
-			"labels": ["php", "auto-complete", "autocomplete", "intellisense", "completion"],
-			"previous_names": ["MagentoIntel"],
+			"labels": [
+				"php",
+				"auto-complete",
+				"autocomplete",
+				"intellisense",
+				"completion"
+			],
+			"previous_names": [
+				"MagentoIntel"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -1346,7 +1581,9 @@
 		{
 			"name": "PhpNinJaManual",
 			"details": "https://github.com/yangweijie/SublimePHPNinJaManual",
-			"labels": ["php manual"],
+			"labels": [
+				"php manual"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1367,8 +1604,13 @@
 		{
 			"name": "PHPSnippets",
 			"details": "https://github.com/gerardroche/sublime-php-snippets",
-			"labels": ["php", "snippets"],
-			"previous_names": ["php-snippets"],
+			"labels": [
+				"php",
+				"snippets"
+			],
+			"previous_names": [
+				"php-snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1439,7 +1681,9 @@
 		{
 			"name": "PHPUnit Snippets",
 			"details": "https://github.com/florianeckerstorfer/fe-sublime-phpunit",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1450,8 +1694,15 @@
 		{
 			"name": "PHPUnitKit",
 			"details": "https://github.com/gerardroche/sublime-phpunit",
-			"labels": ["php", "phpunit", "testing", "tdd"],
-			"previous_names": ["phpunitkit"],
+			"labels": [
+				"php",
+				"phpunit",
+				"testing",
+				"tdd"
+			],
+			"previous_names": [
+				"phpunitkit"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1472,7 +1723,13 @@
 		{
 			"name": "PICO-8",
 			"details": "https://github.com/Neko250/sublime-PICO-8",
-			"labels": ["color scheme", "editor emulation", "language syntax", "snippets", "build system"],
+			"labels": [
+				"color scheme",
+				"editor emulation",
+				"language syntax",
+				"snippets",
+				"build system"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1483,7 +1740,9 @@
 		{
 			"name": "Pine",
 			"details": "https://github.com/gerardroche/sublime-pine",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1564,7 +1823,13 @@
 		{
 			"name": "PlainNotes",
 			"details": "https://github.com/aziz/PlainNotes",
-			"labels": ["notes", "note taking", "authoring", "todo", "tasks"],
+			"labels": [
+				"notes",
+				"note taking",
+				"authoring",
+				"todo",
+				"tasks"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1574,7 +1839,10 @@
 		},
 		{
 			"details": "https://github.com/aziz/PlainTasks",
-			"labels": ["todo", "tasks"],
+			"labels": [
+				"todo",
+				"tasks"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1585,8 +1853,14 @@
 		{
 			"name": "PlantUmlDiagrams",
 			"details": "https://github.com/evandrocoan/PlantUmlDiagrams",
-			"labels": ["uml", "plantuml"],
-			"author": ["jvantuyl", "evandrocoan"],
+			"labels": [
+				"uml",
+				"plantuml"
+			],
+			"author": [
+				"jvantuyl",
+				"evandrocoan"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3114",
@@ -1597,7 +1871,10 @@
 		{
 			"name": "PlasticSCM",
 			"details": "https://github.com/ccll/sublime-plasticscm",
-			"labels": ["scm", "vcs"],
+			"labels": [
+				"scm",
+				"vcs"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1627,7 +1904,9 @@
 		{
 			"name": "plist",
 			"details": "https://bitbucket.org/fschwehn/sublime_plist",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1688,7 +1967,13 @@
 		{
 			"name": "Pmccabe",
 			"details": "https://github.com/mremallin/sublime-pmccabe",
-			"labels": ["linting", "C", "c", "C++", "c++"],
+			"labels": [
+				"linting",
+				"C",
+				"c",
+				"C++",
+				"c++"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1710,11 +1995,18 @@
 		{
 			"name": "PogodaStatusBar",
 			"details": "https://github.com/bolknote/PogodaStatusBar",
-			"labels": ["status bar", "weather", "info", "utilities"],
+			"labels": [
+				"status bar",
+				"weather",
+				"info",
+				"utilities"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx"],
+					"platforms": [
+						"osx"
+					],
 					"tags": true
 				}
 			]
@@ -1722,7 +2014,9 @@
 		{
 			"name": "PogoScript",
 			"details": "https://github.com/featurist/PogoScript.tmbundle",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1733,7 +2027,9 @@
 		{
 			"name": "Pointless",
 			"details": "https://github.com/pointless-lang/pointless-sublime/",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1744,7 +2040,9 @@
 		{
 			"name": "PokemonTeamSyntax",
 			"details": "https://github.com/forsureitsme/PokemonTeamSyntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1755,7 +2053,16 @@
 		{
 			"name": "polyfill",
 			"details": "https://github.com/gerardroche/sublime-polyfill",
-			"labels": ["commands", "ctrlp", "file open", "navigation", "nerdtree", "sidebar", "toggles", "vim"],
+			"labels": [
+				"commands",
+				"ctrlp",
+				"file open",
+				"navigation",
+				"nerdtree",
+				"sidebar",
+				"toggles",
+				"vim"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3083",
@@ -1768,7 +2075,10 @@
 			"author": "Tristano Ajmone",
 			"details": "https://github.com/tajmone/sublime-polygen",
 			"issues": "https://github.com/tajmone/sublime-polygen/issues",
-			"labels": [ "polygen", "language syntax" ],
+			"labels": [
+				"polygen",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3149",
@@ -1789,7 +2099,9 @@
 		{
 			"name": "Polymer & Web Component Snippets",
 			"details": "https://github.com/robdodson/PolymerSnippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1800,7 +2112,11 @@
 		{
 			"name": "Polymer Syntax",
 			"details": "https://github.com/jaychsu/sublime-polymer-syntax",
-			"labels": ["syntax", "polymer", "web component"],
+			"labels": [
+				"syntax",
+				"polymer",
+				"web component"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1811,7 +2127,9 @@
 		{
 			"name": "Pomodoro",
 			"details": "https://github.com/Neway6655/Sublime-Pomodoro",
-			"labels": ["timer"],
+			"labels": [
+				"timer"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1832,7 +2150,9 @@
 		{
 			"name": "Poppins - Color Scheme",
 			"details": "https://github.com/praveenpuglia/color_scheme_poppins",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1843,7 +2163,14 @@
 		{
 			"name": "Portage",
 			"details": "https://github.com/krizalys/sublime-portage",
-			"labels": ["language syntax", "portage", "gentoo", "funtoo", "emerge", "ebuild"],
+			"labels": [
+				"language syntax",
+				"portage",
+				"gentoo",
+				"funtoo",
+				"emerge",
+				"ebuild"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1854,7 +2181,10 @@
 		{
 			"name": "Postap",
 			"details": "https://github.com/LPGhatguy/Postap",
-			"labels": ["theme", "color scheme"],
+			"labels": [
+				"theme",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1891,7 +2221,10 @@
 			"details": "https://github.com/mbnuqw/sublime-postfixer",
 			"readme": "https://raw.githubusercontent.com/mbnuqw/sublime-postfixer/master/README.md",
 			"issues": "https://github.com/mbnuqw/sublime-postfixer/issues",
-			"labels": ["text manipulation", "auto-complete"],
+			"labels": [
+				"text manipulation",
+				"auto-complete"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1902,7 +2235,9 @@
 		{
 			"name": "Postgres PL pgSQL",
 			"details": "https://github.com/mulander/postgres.tmbundle",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1913,7 +2248,9 @@
 		{
 			"name": "PostgreSQL Syntax Highlighting",
 			"details": "https://github.com/tkopets/sublime-postgresql-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1924,7 +2261,9 @@
 		{
 			"name": "PostScript",
 			"details": "https://github.com/Briles/sublime-syntax-postscript",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1935,7 +2274,12 @@
 		{
 			"name": "PouchDB Snippets",
 			"details": "https://github.com/brenopolanski/pouchdb-sublime-snippets",
-			"labels": ["db", "pouchdb", "couchdb", "snippets"],
+			"labels": [
+				"db",
+				"pouchdb",
+				"couchdb",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1985,7 +2329,9 @@
 		{
 			"name": "Powershell Help Generator",
 			"details": "https://github.com/sponte/sublime_powershell_help",
-			"labels": ["help doc"],
+			"labels": [
+				"help doc"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2005,7 +2351,12 @@
 		{
 			"name": "PPCL Language Syntax and Editor",
 			"details": "https://github.com/blandfbt/PPCL",
-			"labels": ["PPCL", "syntax", "siemens", "apogee"],
+			"labels": [
+				"PPCL",
+				"syntax",
+				"siemens",
+				"apogee"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2016,7 +2367,9 @@
 		{
 			"name": "Pre language syntax highlighting",
 			"details": "https://github.com/jonschlinkert/pre-sublime",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2027,7 +2380,10 @@
 		{
 			"name": "Predawn",
 			"details": "https://github.com/jamiewilson/predawn",
-			"labels": ["theme", "color scheme"],
+			"labels": [
+				"theme",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2038,7 +2394,9 @@
 		{
 			"name": "Predawn Monokai",
 			"details": "https://github.com/varemenos/sublime-predawn-monokai",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2049,7 +2407,10 @@
 		{
 			"name": "Predawn Twilight Theme",
 			"details": "https://github.com/jrnewell/predawn-twilight-theme",
-			"labels": ["theme", "color scheme"],
+			"labels": [
+				"theme",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2060,7 +2421,10 @@
 		{
 			"name": "PreferenceSync",
 			"details": "https://github.com/devdinu/PreferenceSync",
-			"labels": ["sync", "preferences"],
+			"labels": [
+				"sync",
+				"preferences"
+			],
 			"releases": [
 				{
 					"sublime_text": ">3000",
@@ -2101,10 +2465,17 @@
 		},
 		{
 			"name": "PreTeXtual",
-			"previous_names": ["MBXTools"],
+			"previous_names": [
+				"MBXTools"
+			],
 			"details": "https://github.com/daverosoff/PreTeXtual",
 			"author": "Dave Rosoff",
-			"labels": ["mbx", "mathbook xml", "pretext", "ptx"],
+			"labels": [
+				"mbx",
+				"mathbook xml",
+				"pretext",
+				"ptx"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2115,7 +2486,15 @@
 		{
 			"name": "Pretty JSON",
 			"details": "https://github.com/dzhibas/SublimePrettyJson",
-			"labels": ["json", "pretty", "lint", "minify", "validate", "query", "json2xml"],
+			"labels": [
+				"json",
+				"pretty",
+				"lint",
+				"minify",
+				"validate",
+				"query",
+				"json2xml"
+			],
 			"releases": [
 				{
 					"sublime_text": "<4000",
@@ -2140,7 +2519,15 @@
 		{
 			"name": "Pretty Shell",
 			"details": "https://github.com/aerobounce/Sublime-Pretty-Shell",
-			"labels": ["shell", "sh", "posix", "bash", "formatting", "pretty", "minify"],
+			"labels": [
+				"shell",
+				"sh",
+				"posix",
+				"bash",
+				"formatting",
+				"pretty",
+				"minify"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2175,7 +2562,14 @@
 		{
 			"name": "Prevent Duplicate Windows",
 			"details": "https://github.com/franciscolourenco/sublime-prevent-duplicate-windows",
-			"labels": ["terminal", "file navigation", "prevent", "duplicate", "windows", "productivity"],
+			"labels": [
+				"terminal",
+				"file navigation",
+				"prevent",
+				"duplicate",
+				"windows",
+				"productivity"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2205,7 +2599,13 @@
 		{
 			"name": "Print to HTML",
 			"details": "https://github.com/grubernaut/sublimetext-print-to-html",
-			"labels": ["tasks", "printing", "utilities", "utils", "browser"],
+			"labels": [
+				"tasks",
+				"printing",
+				"utilities",
+				"utils",
+				"browser"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -2225,12 +2625,15 @@
 				{
 					"sublime_text": "*",
 					"tags": true
-				}]
+				}
+			]
 		},
 		{
 			"name": "Prismatic Color Scheme",
 			"details": "https://github.com/huijing/Prismatic",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2261,7 +2664,9 @@
 		{
 			"name": "ProcessWire Snippets - Advanced",
 			"details": "https://github.com/evanmcd/SublimeProcessWireSnippetsAdvanced",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2272,7 +2677,9 @@
 		{
 			"name": "ProcessWire Snippets - Basic",
 			"details": "https://github.com/evanmcd/SublimeProcessWireSnippetsBasic",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2283,7 +2690,11 @@
 		{
 			"name": "ProductiveSnippetsERB",
 			"details": "https://github.com/janlelis/productive-sublime-snippets-erb",
-			"labels": ["snippets", "erb", "ruby"],
+			"labels": [
+				"snippets",
+				"erb",
+				"ruby"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2294,7 +2705,10 @@
 		{
 			"name": "ProductiveSnippetsRuby",
 			"details": "https://github.com/janlelis/productive-sublime-snippets-ruby",
-			"labels": ["snippets", "ruby"],
+			"labels": [
+				"snippets",
+				"ruby"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2338,7 +2752,9 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["windows"],
+					"platforms": [
+						"windows"
+					],
 					"tags": true
 				}
 			]
@@ -2346,7 +2762,10 @@
 		{
 			"name": "Project Specific Syntax Settings",
 			"details": "https://github.com/reywood/sublime-project-specific-syntax",
-			"labels": ["language syntax", "project"],
+			"labels": [
+				"language syntax",
+				"project"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2367,7 +2786,11 @@
 		{
 			"name": "ProjectCompletions",
 			"details": "https://github.com/bordaigorl/sublime-project-completions",
-			"labels": ["completions", "snippets", "project"],
+			"labels": [
+				"completions",
+				"snippets",
+				"project"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2377,9 +2800,16 @@
 		},
 		{
 			"name": "ProjectEnvironment",
-			"previous_names": ["Project Environment", "Environment Settings"],
+			"previous_names": [
+				"Project Environment",
+				"Environment Settings"
+			],
 			"details": "https://bitbucket.org/daniele-niero/sublimeprojectenvironment",
-			"labels": ["environment", "variables", "project"],
+			"labels": [
+				"environment",
+				"variables",
+				"project"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2391,7 +2821,10 @@
 			"name": "ProjectFiles",
 			"details": "https://github.com/shagabutdinov/sublime-project-files",
 			"donate": "https://github.com/shagabutdinov/sublime-enhanced/blob/master/readme-donations.md",
-			"labels": ["sublime-enhanced", "file navigation"],
+			"labels": [
+				"sublime-enhanced",
+				"file navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2402,8 +2835,16 @@
 		{
 			"name": "ProjectMaker",
 			"details": "https://github.com/bit101/ProjectMaker",
-			"labels": ["project", "template", "project-templates", "cookiecutter", "jinja2"],
-			"previous_names" : ["STProjectMaker"],
+			"labels": [
+				"project",
+				"template",
+				"project-templates",
+				"cookiecutter",
+				"jinja2"
+			],
+			"previous_names": [
+				"STProjectMaker"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2425,7 +2866,10 @@
 			"name": "Prolog",
 			"details": "https://github.com/alnkpa/sublimeprolog",
 			"donate": "https://flattr.com/profile/alnkpa",
-			"labels": ["build system", "language syntax"],
+			"labels": [
+				"build system",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2436,7 +2880,10 @@
 		{
 			"name": "Promela_Spin",
 			"details": "https://github.com/corbanmailloux/sublime-promela-spin",
-			"labels": ["build system", "language syntax"],
+			"labels": [
+				"build system",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2447,7 +2894,10 @@
 		{
 			"name": "Propel",
 			"details": "https://github.com/smhg/sublime-propel",
-			"labels": ["php", "orm"],
+			"labels": [
+				"php",
+				"orm"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2458,7 +2908,9 @@
 		{
 			"name": "Protobuf Syntax Hightlighting",
 			"details": "https://github.com/VcamX/protobuf-syntax-highlighting",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -2469,8 +2921,12 @@
 		{
 			"name": "ProtoBufCodeFormatter",
 			"details": "https://github.com/DirkBrand/ProtoBufCodeFormatter_Sublime",
-			"labels": ["formatting"],
-			"previous_names": ["ProtoBuf Code Formatter"],
+			"labels": [
+				"formatting"
+			],
+			"previous_names": [
+				"ProtoBuf Code Formatter"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -2481,7 +2937,9 @@
 		{
 			"name": "Protocol Buffer Syntax",
 			"details": "https://github.com/vihangm/sublime-protobuf-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2522,7 +2980,9 @@
 		{
 			"name": "Pug",
 			"details": "https://github.com/davidrios/pug-tmbundle",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2533,7 +2993,9 @@
 		{
 			"name": "Pumpkin Color Scheme",
 			"details": "https://github.com/afonsopacifer/pumpkin",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2544,14 +3006,16 @@
 		{
 			"name": "PunchMeInTheFace Color Scheme",
 			"details": "https://github.com/tashrifsanil/PunchMeInTheFace-Color-Scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
 					"tags": true
 				}
 			]
-		},		
+		},
 		{
 			"name": "Puppet",
 			"details": "https://github.com/russCloak/SublimePuppet",
@@ -2565,7 +3029,9 @@
 		{
 			"name": "Puppet Syntax checking",
 			"details": "https://github.com/Stubbs/sublime-puppet-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -2586,7 +3052,9 @@
 		{
 			"name": "PureCSS",
 			"details": "https://github.com/TCattd/PureCSS-sublime",
-			"labels": ["auto-complete"],
+			"labels": [
+				"auto-complete"
+			],
 			"releases": [
 				{
 					"sublime_text": ">3000",
@@ -2597,8 +3065,13 @@
 		{
 			"name": "PureScript",
 			"details": "https://github.com/b123400/purescript-ide-sublime",
-			"labels": ["language syntax", "ide"],
-			"previous_names": ["PureScript IDE"],
+			"labels": [
+				"language syntax",
+				"ide"
+			],
+			"previous_names": [
+				"PureScript IDE"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2609,7 +3082,9 @@
 		{
 			"name": "PureScript Syntax",
 			"details": "https://github.com/tellnobody1/sublime-purescript-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">3092",
@@ -2620,7 +3095,9 @@
 		{
 			"name": "PurpleHaze",
 			"details": "https://github.com/klomontes/purple-haze-color-scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2631,7 +3108,9 @@
 		{
 			"name": "Pushb",
 			"details": "https://github.com/geovanisouza92/Pushb",
-			"labels": ["pushbullet"],
+			"labels": [
+				"pushbullet"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2642,7 +3121,9 @@
 		{
 			"name": "Pushbullet",
 			"details": "https://github.com/xarnze/sublimepushbullet",
-			"labels": ["pushbullet"],
+			"labels": [
+				"pushbullet"
+			],
 			"releases": [
 				{
 					"sublime_text": ">3000",
@@ -2683,7 +3164,9 @@
 		{
 			"name": "PyCover",
 			"details": "https://github.com/perimosocordiae/PyCover",
-			"previous_names": ["Python Coverage"],
+			"previous_names": [
+				"Python Coverage"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2704,7 +3187,13 @@
 		{
 			"name": "PyenvEnv",
 			"details": "https://github.com/jkr78/PyenvEnv",
-			"labels": ["python", "pyenv", "env", "virtualenv", "venv"],
+			"labels": [
+				"python",
+				"pyenv",
+				"env",
+				"virtualenv",
+				"venv"
+			],
 			"releases": [
 				{
 					"sublime_text": ">3000",
@@ -2715,7 +3204,12 @@
 		{
 			"name": "Pygame Completions",
 			"details": "https://github.com/tushortz/Pygame-Completions",
-			"labels": ["completions", "completion", "Completion", "python"],
+			"labels": [
+				"completions",
+				"completion",
+				"Completion",
+				"python"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2725,7 +3219,9 @@
 		},
 		{
 			"details": "https://github.com/biermeester/Pylinter",
-			"labels": ["linting"],
+			"labels": [
+				"linting"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2756,7 +3252,12 @@
 		{
 			"name": "Pynsist",
 			"details": "https://github.com/idleberg/sublime-pynsist",
-			"labels": ["build-system", "language syntax", "nsis", "python"],
+			"labels": [
+				"build-system",
+				"language syntax",
+				"nsis",
+				"python"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -2768,7 +3269,16 @@
 			"name": "PypiPackageInfo",
 			"details": "https://github.com/gh640/SublimePypiPackageInfo",
 			"author": "Goto Hayato",
-			"labels": ["python", "package", "pypi", "requirements.txt", "pyproject.toml", "poetry", "pipfile", "pipenv"],
+			"labels": [
+				"python",
+				"package",
+				"pypi",
+				"requirements.txt",
+				"pyproject.toml",
+				"poetry",
+				"pipfile",
+				"pipenv"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3124",
@@ -2789,7 +3299,15 @@
 		{
 			"name": "PyQt5 Completions",
 			"details": "https://github.com/tushortz/PyQt5-Completions",
-			"labels": ["python","completions", "auto-complete", "completion", "autocomplete", "snippet", "Completion"],
+			"labels": [
+				"python",
+				"completions",
+				"auto-complete",
+				"completion",
+				"autocomplete",
+				"snippet",
+				"Completion"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2810,7 +3328,9 @@
 		{
 			"name": "PyroCMS Snippets",
 			"details": "https://github.com/Dixens/sublime-text-pyrocms-snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2841,7 +3361,11 @@
 		{
 			"name": "PyTest",
 			"details": "https://github.com/kaste/PyTest",
-			"labels": ["python", "pytest", "testing"],
+			"labels": [
+				"python",
+				"pytest",
+				"testing"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2852,7 +3376,9 @@
 		{
 			"name": "Pytest Snippets",
 			"details": "https://github.com/sloria/sublime-pytest-snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2863,8 +3389,12 @@
 		{
 			"name": "Python 3",
 			"details": "https://github.com/petervaro/python",
-			"labels": ["language syntax"],
-			"previous_names": ["Modern Python"],
+			"labels": [
+				"language syntax"
+			],
+			"previous_names": [
+				"Modern Python"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2895,7 +3425,9 @@
 		{
 			"name": "Python Checker",
 			"details": "https://github.com/patrys/PythonChecker",
-			"labels": ["linting"],
+			"labels": [
+				"linting"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2905,9 +3437,14 @@
 		},
 		{
 			"name": "Python Completions",
-			"previous_names": ["Python Auto-Complete"],
+			"previous_names": [
+				"Python Auto-Complete"
+			],
 			"details": "https://github.com/eliquious/Python-Auto-Complete",
-			"labels": ["python", "completions"],
+			"labels": [
+				"python",
+				"completions"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2948,7 +3485,9 @@
 		{
 			"name": "Python Flake8 Lint",
 			"details": "https://github.com/dreadatour/Flake8Lint",
-			"labels": ["linting"],
+			"labels": [
+				"linting"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2979,7 +3518,9 @@
 		{
 			"name": "Python Improved",
 			"details": "https://github.com/MattDMo/PythonImproved",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2990,7 +3531,9 @@
 		{
 			"name": "Python Nose Testing Snippets",
 			"details": "https://github.com/sloria/sublime-nose-snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3021,7 +3564,9 @@
 		{
 			"name": "Python Path to Clipboard",
 			"details": "https://github.com/Mimino666/SublimeText2-python-package-to-clipboard",
-			"previous_names": ["Python Package to Clipboard"],
+			"previous_names": [
+				"Python Package to Clipboard"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -3042,7 +3587,9 @@
 		{
 			"name": "Python Pep8 Lint",
 			"details": "https://github.com/dreadatour/Pep8Lint",
-			"labels": ["linting"],
+			"labels": [
+				"linting"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -3071,6 +3618,19 @@
 			]
 		},
 		{
+			"name": "python-black",
+			"details": "https://github.com/thep0y/python-black",
+			"labels": [
+				"formatter"
+			],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Python2UnicodeFixer",
 			"details": "https://github.com/allieus/Python2UnicodeFixer",
 			"releases": [
@@ -3083,7 +3643,13 @@
 		{
 			"name": "PythonNiceToHaveFeatures",
 			"details": "https://github.com/monobot/PythonNiceToHaveFeatures",
-			"labels": ["python", "refactor", "relative path", "package path", "path"],
+			"labels": [
+				"python",
+				"refactor",
+				"relative path",
+				"package path",
+				"path"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3133,7 +3699,9 @@
 		{
 			"name": "PythonTraceback",
 			"details": "https://github.com/kedder/sublime-python-traceback",
-			"labels": ["file navigation"],
+			"labels": [
+				"file navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3143,12 +3711,19 @@
 		},
 		{
 			"name": "PythonVoiceCodingPlugin",
-			"details":"https://github.com/mpourmpoulis/PythonVoiceCodingPlugin",
-			"labels":["voice coding","accessibility","syntax tree","python","grammar","high level"],
-			"releases":[
+			"details": "https://github.com/mpourmpoulis/PythonVoiceCodingPlugin",
+			"labels": [
+				"voice coding",
+				"accessibility",
+				"syntax tree",
+				"python",
+				"grammar",
+				"high level"
+			],
+			"releases": [
 				{
-					"sublime_text":">=3000",
-					"tags":true
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
@@ -3175,7 +3750,10 @@
 		{
 			"name": "PyYapf Python Formatter",
 			"details": "https://github.com/jason-kane/PyYapf",
-			"labels": ["python", "formatting"],
+			"labels": [
+				"python",
+				"formatting"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
A `black`-based package with only one formatting function may be more elegant than other formatting packages.
There is an additional function: use the command to generate a black configuration file.