### PR TITLE
Add plugin: BootstrapAutocomplete

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -1176,6 +1176,18 @@
 			]
 		},
 		{
+			"name": "BootstrapAutocomplete",
+			"details": "https://github.com/jfcherng-sublime/ST-BootstrapAutocomplete",
+			"author": ["jfcherng"],
+			"labels": ["auto-complete"],
+			"releases": [
+				{
+					"sublime_text": ">=4105",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://bitbucket.org/Tumbo/bootstrap-jade",
 			"releases": [
 				{

--- a/repository/b.json
+++ b/repository/b.json
@@ -1176,6 +1176,15 @@
 			]
 		},
 		{
+			"details": "https://bitbucket.org/Tumbo/bootstrap-jade",
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "BootstrapAutocomplete",
 			"details": "https://github.com/jfcherng-sublime/ST-BootstrapAutocomplete",
 			"author": ["jfcherng"],
@@ -1184,15 +1193,6 @@
 				{
 					"sublime_text": ">=4105",
 					"tags": true
-				}
-			]
-		},
-		{
-			"details": "https://bitbucket.org/Tumbo/bootstrap-jade",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"branch": "master"
 				}
 			]
 		},


### PR DESCRIPTION
# Why

I know there are many bootstrap autocompletion plugins already.

- [Bootstrap 3 Autocomplete](https://packagecontrol.io/packages/Bootstrap%203%20Autocomplete)
- [Bootstrap 4 Autocomplete](https://packagecontrol.io/packages/Bootstrap%204%20Autocomplete)
- [Bootstrap 4x Autocomplete](https://packagecontrol.io/packages/Bootstrap%204x%20Autocomplete)
- Maybe more implicit ones... I don't know.

So here are problems:

- There is no Bootstrap 5 autocompletion plugin, yet.
- What if I code with Bootstrap 3 & 4 & 5 in different projects?
  Say, project 1 uses Bootstrap 4 but project 2 uses Bootstrap 5.
  Maybe I can install all 3 plugins, but they will all work in a single project and providing unwanted completions.
- ~~Configurable project settings?~~ Code quality? Maintainer still on Github? Utilize ST 4 features?

Hence, this plugin.

# Notes

This plugin means to target on ST 4 to use Python 3.8 and `sublime.CompletionItem`.

# Repo

https://github.com/jfcherng-sublime/ST-BootstrapAutocomplete