### PR TITLE
Adding ric-script syntax highlighter

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1584,7 +1584,7 @@
 		},
 		{
 			"name": "ricscript",
-			"details": "https://github.com/Ricardicus/ric-script",
+			"details": "https://github.com/Ricardicus/ric-script-syntax",
 			"labels": ["language syntax"],
 			"releases": [
 				{

--- a/repository/r.json
+++ b/repository/r.json
@@ -1583,7 +1583,7 @@
 			]
 		},
 		{
-			"name": "ric-script",
+			"name": "ricscript",
 			"details": "https://github.com/Ricardicus/ric-script",
 			"labels": ["language syntax"],
 			"releases": [

--- a/repository/r.json
+++ b/repository/r.json
@@ -1583,6 +1583,17 @@
 			]
 		},
 		{
+			"name": "ric-script",
+			"details": "https://github.com/Ricardicus/ric-script",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">3099",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ride",
 			"details": "https://github.com/frankaemika/ride-sublime",
 			"labels": ["lf", "Lingua Franka", "language syntax"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->

I have a programming language under development that I am very proud of called [ric-script](https://github.com/Ricardicus/ric-script).

I am also a huge fan of Sublime Text and use it everyday. 

The link that i added to the file leads to this repo: [https://github.com/Ricardicus/ric-script-syntax](https://github.com/Ricardicus/ric-script-syntax)

I have added a .sublime-syntax file at the root of a github repo, it can be viewed at https://github.com/Ricardicus/ric-script-syntax/blob/master/ricscript.sublime-syntax .
It should be used for syntax highlighting only.



