### PR TITLE
Add StyleLint-Formatter, tailwindcss Class Sorter

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3990,6 +3990,18 @@
 			]
 		},
 		{
+			"name": "StyleLint-Formatter",
+			"details": "https://github.com/LetsZiggy/StyleLint-Formatter",
+			"issues": "https://github.com/LetsZiggy/StyleLint-Formatter/issues",
+			"labels": ["css", "formatting", "stylelint"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "StyleSorter",
 			"details": "https://github.com/AndreasBackx/StyleSorter",
 			"releases": [

--- a/repository/t.json
+++ b/repository/t.json
@@ -321,6 +321,18 @@
 			]
 		},
 		{
+			"name": "tailwindcss Class Sorter",
+			"details": "https://github.com/LetsZiggy/tailwindcss-class-sorter",
+			"issues": "https://github.com/LetsZiggy/tailwindcss-class-sorter/issues",
+			"labels": ["text manipulation", "formatting"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "TailwindCSSAutocomplete",
 			"details": "https://github.com/bradlc/sublime-tailwindcss",
 			"labels": ["tailwind", "auto-complete"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->

I'm sorry for the joint commits. I intended for a separate pull request but absentmindedly pushed a new commit while this pull request is open.

**StyleLint-Formatter**
- Uses stylelint / stylelint_d to format stylesheets
- Forked from and inspired by [ESLint-Formatter](https://github.com/TheSavior/ESLint-Formatter)

**tailwindcss Class Sorter**
- Sorts tailwindcss classes according to selected sorting type (eg: recess)
- Sorts each class variants according to recommended variant order in [tailwindcss doc](https://tailwindcss.com/docs/configuring-variants#ordering-custom-variants)
- Sorts similar functioning classes according breakpoints