### PR TITLE
Changed the position of ST2 & ST4, to fix the logic issue

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2839,16 +2839,16 @@
 			"labels": ["sort", "sorting"],
 			"releases": [
 				{
-					"sublime_text": ">=4000",
-					"tags": "st4-"
+					"sublime_text": "<3000",
+					"tags": "st2-"
 				},
 				{
 					"sublime_text": "<4000",
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": "<3000",
-					"tags": "st2-"
+					"sublime_text": ">=4000",
+					"tags": "st4-"
 				}
 			]
 		},

--- a/repository/s.json
+++ b/repository/s.json
@@ -2831,7 +2831,7 @@
 					"tags": "st2-"
 				},
 				{
-					"sublime_text": "<4000",
+					"sublime_text": "3000 - 3999",
 					"tags": "st3-"
 				},
 				{


### PR DESCRIPTION
Hello,

I just changed the order of ST2 & ST4 to prevent ST2 user of receiving the latest version of my plugin (since `<3000` and `<4000` are conflicting).

I wanted to have 3 tags, should I use only ST2 & ST4 ?

Thanks!