### PR TITLE
Add package HSX Syntax Highlighting

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -986,6 +986,17 @@
 			]
 		},
 		{
+			"name": "HSX Syntax Highlighting",
+			"details": "https://github.com/jpe90/Sublime-HSX",
+			"labels": ["syntax", "html", "haskell", "highlighting"],
+			"releases": [
+				{
+					"sublime_text": ">=4075",
+					"tags":true
+				}
+			]
+		},
+		{
 			"name": "HTML (C#)",
 			"details": "https://github.com/michaelblyons/SublimeSyntax-HTML-CSharp",
 			"labels": ["language syntax", "completions"],


### PR DESCRIPTION
This package enables HTML syntax embedded inside [HSX quasiquotes](https://ihp.digitallyinduced.com/Guide/hsx.html) in Haskell source code to be highlighted. All HTML is currently highlighted as a string.

Before:
![2021-07-15-112133_1920x1080_scrot](https://user-images.githubusercontent.com/9307830/126015251-0d0c5afd-b2e4-4827-8bd9-ab3c746f34e3.png)
After:
![2021-07-15-111738_1920x1080_scrot](https://user-images.githubusercontent.com/9307830/126015304-77383175-2040-452e-8164-1fadc7e643db.png)

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->
