### PR TITLE
Add Thread Dump Analyser plugin

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2234,6 +2234,20 @@
 			]
 		},
 		{
+			"name": "Thread Dump Analyser",
+			"author": "Vasu",
+			"details": "https://github.com/vasugr/Thread-Dump-Analyser",
+			"readme": "https://raw.githubusercontent.com/vasugr/Thread-Dump-Analyser/main/README.md",
+			"issues": "https://github.com/vasugr/Thread-Dump-Analyser/issues",
+			"labels": ["text manipulation", "formatting","Thread dump"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ThreatConnect Exchange Snippets",
 			"details": "https://github.com/fhightower/tcex-snippets",
 			"labels": ["snippets"],

--- a/repository/t.json
+++ b/repository/t.json
@@ -2254,10 +2254,7 @@
 		},
 		{
 			"name": "Thread Dump Analyser",
-			"author": "Vasu",
 			"details": "https://github.com/vasugr/Thread-Dump-Analyser",
-			"readme": "https://raw.githubusercontent.com/vasugr/Thread-Dump-Analyser/main/README.md",
-			"issues": "https://github.com/vasugr/Thread-Dump-Analyser/issues",
 			"labels": ["text manipulation", "formatting","Thread dump"],
 			"releases": [
 				{


### PR DESCRIPTION
This is a thread dump analyser plugin, which takes a thread dump text file as an input and produces analytic data. I have made similar plugin for VScode as well , you can find it [here](https://marketplace.visualstudio.com/items?itemName=Vasu.tda)