### PR TITLE
Add Cottle Syntax

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3706,6 +3706,17 @@
 			]
 		},
 		{
+			"name": "Cottle",
+			"details": "https://github.com/SublimeText/Cottle",
+			"labels": ["completions", "syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3143",
+					"tags": "3143-"
+				}
+			]
+		},
+		{
 			"name": "CoverMe",
 			"details": "https://github.com/shauryachats/CoverMe",
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -3708,7 +3708,7 @@
 		{
 			"name": "Cottle",
 			"details": "https://github.com/SublimeText/Cottle",
-			"labels": ["completions", "syntax"],
+			"labels": ["completions", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3143",


### PR DESCRIPTION
This commit adds Cottle a text-to-speach scripting language for Elite:Dangerous.

The syntax was developed as result of a request at

- https://stackoverflow.com/questions/67027410/sublime-text-3-custom-syntax-for-cottle-hard-to-start
- https://forum.sublimetext.com/t/problem-developing-syntax-highlight-for-cottle/57051