### PR TITLE
Add SurfaceSyntax

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -5171,6 +5171,16 @@
 			]
 		},
 		{
+			"name": "SurfaceSyntax",
+			"details": "https://github.com/cschmatzler/sublime-surface-syntax",
+			"releases": [
+				{
+					"sublime_text": ">=4075",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Suricate",
 			"details": "https://github.com/nsubiron/SublimeSuricate",
 			"labels": [


### PR DESCRIPTION
Adds basic syntax highlighting for [Surface](https://surface-ui.org/), the component library for Elixir's Phoenix web framework.
