### PR TITLE
Update MarkdownEditing

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -622,8 +622,8 @@
 			"labels": ["markdown", "github markdown", "gfm", "multimarkdown", "color scheme"],
 			"releases": [
 				{
-					"sublime_text": "<3176",
-					"tags": true
+					"sublime_text": "2000 - 3175",
+					"tags": "st2-"
 				},
 				{
 					"sublime_text": "3176 - 4106",


### PR DESCRIPTION
Appears Package Control has issues with previous version checks.

ST3176 doesn't see any tags but only branches, which makes it impossible for users on it to opt-in to alpha releases.

Hence a `st2-2.2.10` tag was added to the most recent commit which is compatible with ST prior to ST3176.

This commit registers `st2-` prefix for all ST builds from 2000 to 3175.

Hope, ST3176 sees tags then.

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->
