### PR TITLE
Add "Toggle Dark Mode"

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2624,6 +2624,16 @@
 			]
 		},
 		{
+			"name": "Toggle Dark Mode",
+			"details": "https://github.com/ElMassimo/sublime-toggle-dark-mode",
+			"releases": [
+				{
+					"sublime_text": ">=4096",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Toggle Delphi File",
 			"details": "https://github.com/alefragnani/toggle-delphi-file",
 			"releases": [

--- a/repository/t.json
+++ b/repository/t.json
@@ -2626,6 +2626,9 @@
 		{
 			"name": "Toggle Dark Mode",
 			"details": "https://github.com/ElMassimo/sublime-toggle-dark-mode",
+			"author": "Maximo Mussini (elmassimo)",
+			"donate": "https://paypal.me/maximomussini",
+			"labels": ["toggle", "color scheme", "dark mode", "utilities"],
 			"releases": [
 				{
 					"sublime_text": ">=4096",


### PR DESCRIPTION
This pull request adds [_Toggle Dark Mode_](https://github.com/ElMassimo/sublime-toggle-dark-mode), a plugin that provides a command to toggle dark mode within Sublime.

It leverages Sublime Text 4's `auto` setting for `theme` and `color_scheme`, as well as the new `ui_info` API to detect OS dark mode preference, making it compatible with all platforms.