### PR TITLE
Add ryanolsonx/sublimetext-syntax-off-theme

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -5773,6 +5773,17 @@
 			]
 		},
 		{
+			"name": "Syntax Off Color Scheme",
+			"details": "https://github.com/ryanolsonx/sublimetext-syntax-off-theme",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Syntax ProtoList",
 			"details": "https://github.com/lvzixun/sublime-protolist-syntax",
 			"releases": [


### PR DESCRIPTION
I've created a color scheme that turns off syntax highlighting. This is something that I wasn't able to find in packagecontrol already. So I created my own.

I didn't add .gitattributes because I've kept this repository small and only have two small screenshots.


<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->
