### PR TITLE
Allow `osx-arm64` platform

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -516,7 +516,7 @@ class TestContainer(object):
                     v = [v]
                 for plat in v:
                     self.assertRegex(plat,
-                                     r"^(\*|(osx|linux|windows)(-x(32|64))?)$")
+                                     r"^(\*|(osx|linux|windows)(-x(32|64))?|osx-arm64)$")
 
                 self.assertCountEqual(v, list(set(v)),
                                       "Specifying the same platform multiple times is redundant")


### PR DESCRIPTION
The Apple M1 machine is `osx-arm64`.

References:

- https://github.com/sublimelsp/st-schema-reviewer-action/pull/1
- https://github.com/sublimelsp/repository/pull/52
