### PR TITLE
Added Architect language syntax

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1577,6 +1577,17 @@
 			]
 		},
 		{
+			"name": "Architect",
+			"details": "https://github.com/architect/sublime-package",
+			"labels": ["language syntax", "architect"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ArcticTypescript",
 			"details": "https://github.com/Phaiax/ArcticTypescript",
 			"releases": [


### PR DESCRIPTION
### Checklist 

- [x] Local tests passed
- [x] Used `tags: true`
- [x] Have a `readme.md`
- [x] No other similar packages exist

### About

Hey there! I'm one of the maintainers of [OpenJS Architect](https://arc.codes) ([GitHub @architect](https://github.com/architect), [npm @architect](https://www.npmjs.com/package/@architect/architect)), a framework for building powerful full-stack serverless web apps on AWS.

In addition JSON and YAML manifests, Architect also features its own lightweight, minimal syntax for declaratively deploying infrastructure-as-code. [A little bit more about the format here.](https://arc.codes/docs/en/guides/get-started/project-layout)

I wish I'd written this Sublime Text syntax definition a long time ago! Unfortunately it wasn't until the last couple of weeks that I was able to abstract all that regex and make everything reasonably maintainable for the rest of the Architect community.

Anyway, thanks!

<img src="https://user-images.githubusercontent.com/200964/132933109-e928a1f0-16e8-4a75-a446-e06e4bec20d6.png" width=500>