### PR TITLE
Add missing readme and issues link for jq gitlab package

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -762,7 +762,9 @@
 		{
 			"name": "Jq",
 			"details": "https://gitlab.com/jiehong/sublime_jq",
-			"labels": ["interactive", "jq"],
+			"readme": "https://gitlab.com/jiehong/sublime_jq/-/raw/master/README.md",
+			"issues": "https://gitlab.com/jiehong/sublime_jq/-/issues",
+			"labels": ["interactive", "jq", "json"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",


### PR DESCRIPTION
This package correctly appears on packagecontrol.io, but its readme and issues link is not automatically determined (see https://packagecontrol.io/packages/Jq).

This fixes that.
