### PR TITLE
Transfer WolframLanguage package to WolframResearch

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -668,7 +668,7 @@
 		},
 		{
 			"name": "WolframLanguage",
-			"details": "https://github.com/ViktorQvarfordt/Sublime-WolframLanguage",
+			"details": "https://github.com/WolframResearch/Sublime-WolframLanguage",
 			"labels": ["language syntax"],
 			"releases": [
 				{


### PR DESCRIPTION
Hi, I work for Wolfram Research and I am the developer for our official Sublime package.

I would like to transfer the WolframLanguage package from https://github.com/ViktorQvarfordt/Sublime-WolframLanguage to https://github.com/WolframResearch/Sublime-WolframLanguage, so I am opening this PR. 

Here is a message I sent to will@wbond.net and CCed viktor.qvarfordt@gmail.com on August 31, but I have not yet heard a reply.


> Hello,
> 
> 
> I am the developer of the official Wolfram Language package for Sublime Text:
> 
> https://github.com/WolframResearch/Sublime-WolframLanguage
> 
> 
> We (Wolfram Research) are interested in taking over the WolframLanguage package in Package Control:
> 
> https://packagecontrol.io/packages/WolframLanguage
> 
> and I'm not sure what the process is to achieve this. (or indeed if this is even possible!)
> 
> 
> 
> This is a fork of the original package from Viktor Qvarfordt:
> 
> https://github.com/ViktorQvarfordt/Sublime-WolframLanguage
> 
> 
> 
> You can see that there has not been any development for a couple of years.
> 
> Wolfram Research is interested in taking over ownership of this package and providing ongoing development and support.
> 
> We have been in communication with Viktor and he has agreed to transfer ownership to Wolfram Research.
> 
> 
> Has Package Control dealt with kind of thing before?
> 
> What should be the next step?
> 
> 
> Brenton



Maybe transferring can be as easy as merging this PR?


