### PR TITLE
Add clean-css

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1340,6 +1340,17 @@
 			]
 		},
 		{
+			"name": "clean-css",
+			"details": "https://github.com/1000ch/Sublime-clean-css",
+			"labels": ["css", "formatting"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CleanCSS",
 			"details": "https://github.com/stolksdorf/CleanCSS",
 			"releases": [


### PR DESCRIPTION
Add [clean-css](https://github.com/1000ch/Sublime-clean-css) that provide [`cleab-css/clean-css`](https://github.com/clean-css/clean-css) functionality on Sublime Text.