### PR TITLE
Added Chez Scheme, Renamed CodeCounter to CodeLines.

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -859,6 +859,17 @@
 			]
 		},
 		{
+			"name": "Chez Scheme",
+			"details": "https://github.com/absop/Scheme",
+			"labels": ["language syntax", "Formatter", "build system"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Chick",
 			"details": "https://github.com/Satoh-D/Chick",
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -2026,13 +2026,14 @@
 			]
 		},
 		{
-			"name": "CodeCounter",
-			"details": "https://github.com/absop/CodeCounter",
+			"name": "CodeLines",
+			"details": "https://github.com/absop/ST-CodeLines",
 			"labels": ["analytics", "statistics", "status bar", "utilities"],
 			"author": "absop",
+			"previous_names": ["CodeCounter"],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=4000",
 					"platforms": ["linux", "windows"],
 					"tags": true
 				}

--- a/repository/c.json
+++ b/repository/c.json
@@ -849,22 +849,22 @@
 			]
 		},
 		{
-			"name": "chester-atom",
-			"details": "https://github.com/gborges0727/chester-atom-sublime",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Chez Scheme",
 			"details": "https://github.com/absop/Scheme",
 			"labels": ["language syntax", "Formatter", "build system"],
 			"releases": [
 				{
 					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "chester-atom",
+			"details": "https://github.com/gborges0727/chester-atom-sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
**Scheme** (Chez Scheme) syntax highlighting, build system and code formatter for Sublime Text 4.