### PR TITLE
add xonsh package

### DIFF
--- a/repository/x.json
+++ b/repository/x.json
@@ -148,6 +148,17 @@
 			]
 		},
 		{
+			"name": "xonsh",
+			"details": "https://github.com/eugenesvk/sublime-xonsh",
+			"labels": ["xonsh", "python", "language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4075",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "xpath",
 			"details": "https://github.com/rosshadden/sublime-xpath",
 			"labels": ["xml", "xpath", "xquery", "clipboard", "preview"],


### PR DESCRIPTION
This package adds support for the Python-powered shell [xonsh](https://xon.sh) (for files with `.xsh` and `.xonshrc` extensions) by extending the syntax definitions from the default Python package with the following xonsh-specific contexts:

- Variables: `$variableA`, including the environment `${...}`
- Subprocess operators: `$()` `$[]` `${}` `@()` `@$()` (and `!()` `![]`)
- Search functions: `` @functionB`search_string` ``
- Builtin functions: `abbrevs()` `aliases()` `compilex()` `execx()` `evalx()` `events()` `print_color()` `exit()` `printx()`

... and copying all the other relevant elements (Snippets, Comments, Completion Rules, Indentation Rules, Symbol List, and the Default keymap) & re-scoping them to work in the `xonsh` syntax