### PR TITLE
Add QuickFileSwitcher

### DIFF
--- a/repository/q.json
+++ b/repository/q.json
@@ -419,6 +419,18 @@
 					"branch": "master"
 				}
 			]
+		},
+		{
+			"name": "QuickFileSwitcher",
+			"details": "https://github.com/magnusdahlstrand/SublimeQuickFileSwitcher",
+			"readme": "https://github.com/magnusdahlstrand/SublimeQuickFileSwitcher/blob/main/README.md",
+			"labels": ["switch", "toggle", "quick", "utility"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
I tried out a few different packages that seemed to do the same thing as this plugin does, but a few I couldn't get to work at all and a couple of others required confusing configurations to work. This plugin lacks configuration and works across all file extensions automatically.