### PR TITLE
Add Astro package

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1932,6 +1932,17 @@
 			]
 		},
 		{
+			"name": "Astro",
+			"details": "https://github.com/Destiner/sublime-astro",
+			"labels": ["language syntax", "astro"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Async Mindset Snippets",
 			"details": "https://github.com/punkave/sublime-async-mindset",
 			"labels": ["snippets"],


### PR DESCRIPTION
The package provides syntax highlighting for [Astro](https://astro.build), which is a frontend framework for static sites.

Syntax grammar is based on the official [syntax file](https://github.com/snowpackjs/astro-language-tools/blob/main/packages/vscode/syntaxes/astro.tmLanguage.json) for VSCode.