### PR TITLE
Add Clojure Sublimed

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1480,6 +1480,18 @@
 			]
 		},
 		{
+			"name": "Clojure Sublimed",
+			"details": "https://github.com/tonsky/Clojure-Sublimed",
+			"labels": ["clojure", "repl", "nrepl"],
+			"donate": "https://www.patreon.com/tonsky",
+			"releases": [
+				{
+					"sublime_text": ">=4075",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ClojureDocSearch",
 			"details": "https://github.com/Foxboron/ClojureDoc-Search",
 			"releases": [


### PR DESCRIPTION
### Checklist

- [x] Local tests passed
- [x] Used `tags: true`
- [x] Have a README.md
- [x] Similar packages: see below

### About

Sublime Clojure is nREPL client and syntax definition for Clojure. Latter is required for REPL to operate: detect form boundaries, find namespace symbol. nREPL is the most popular REPL server in Clojure ecosystem.

The main features of this plugin are inline evaluation (via annotations and phantoms) and convenience (parallel evaluation, formatted stacktraces, execution time)

<img width="797" alt="Screenshot 2021-10-25 at 01 37 11" src="https://user-images.githubusercontent.com/285292/138617429-57875830-70d7-4af0-a872-0683d0fe301b.png">

### Similar packages

[Sublime REPL](https://packagecontrol.io/packages/SublimeREPL):
 
- not specific to Clojure, but can run Clojure
- requires local lein project
- manages process for you
- no remote REPL

[Tutkain](https://packagecontrol.io/packages/Tutkain):

- Uses streaming Socket Server REPL
- Requires an extra REPL panel to operate
- Can’t keeps multiple eval results on a screen simultaneously
- Can’t show stack traces inline in editor
- Can’t eval several forms in parallel
- Can’t eval non well-formed forms (e.g. `(+ 1 2`)
- Can’t eval infinite sequences
- Can’t redirect `*out*`/`*err*` to `System.out`/`System.err`

Thanks!