### PR TITLE
Renamed "Xcode Strings" to "Strings Resource File"

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3926,6 +3926,18 @@
 			]
 		},
 		{
+			"name": "Strings Resource File",
+			"previous_names": ["Xcode Strings"],
+			"details": "https://github.com/peterthomashorn/strings-resource-file-language-for-sublime-text",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "StringUtilities",
 			"details": "https://github.com/akalongman/sublimetext-stringutilities",
 			"labels": ["utilities"],

--- a/repository/x.json
+++ b/repository/x.json
@@ -78,17 +78,6 @@
 			]
 		},
 		{
-			"name": "Xcode Strings",
-			"details": "https://github.com/peterthomashorn/xcode-strings-language-for-sublime-text",
-			"labels": ["language syntax"],
-			"releases": [
-				{
-					"sublime_text": ">3092",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Xdebug",
 			"details": "https://github.com/Kindari/SublimeXdebug",
 			"releases": [


### PR DESCRIPTION
After feedback from review and an issue report suggesting to merge my three Xcode syntax definitions into one package I found out that the "Xcode Strings" package is named misleadingly. It is not restricted to Xcode but used on the Apple platforms often but not just in relation to Xcode. See [the official documentation by Apple](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/LoadingResources/Strings/Strings.html).

I also expanded the syntax definition and added tests for it.