### PR TITLE
Add `CommandsBrowser` package.

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2980,6 +2980,17 @@
 			]
 		},
 		{
+			"name": "CommandsBrowser",
+			"details": "https://github.com/Sublime-Instincts/CommandsBrowser",
+			"labels": ["commands", "plugin/package commands", "browser"],
+			"releases": [
+				{
+					"sublime_text": ">=4121",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/ajayexpert/comment-snippet",
 			"labels": ["snippets"],
 			"releases": [


### PR DESCRIPTION
This PR adds the `CommandsBrowser` package to Package Control.

`CommandsBrowser` is a Sublime Text package that allows a user to view all the available core/plugin commands for Sublime Text and Sublime Merge, along with their documentation/source.

Useful if you are into plugin/package development.