### PR TITLE
Updates to the `Twig` repository JSON entry.

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -3452,7 +3452,11 @@
 					"branch": "master"
 				},
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": "<4107",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4107",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This PR is to update the `Twig` repository JSON entry to update to ST4 releases.

1. Any version less than 4107 (the first stable), will pull changes from any `st3-` prefixed tag releases.
2. Any version equal to or after 4107, will pull changes from regular tag releases.

The `BetterTwig` repo has already released a `st3-v1.0.7` so changes would be seen in versions before 4107 once this PR is merged. Note that `st3-v1.0.7` has no new changes (It's just a release to cut off one final version for ST3 & ST4 < 4107), so in theory, once the PC crawler has finished crawling for changes, all downloaded packages should update to `st3-v1.0.7` with nothing being changed.