### PR TITLE
Add `BetterJinja` (Part 2)

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -685,7 +685,7 @@
 				{
 					"base": "https://github.com/kudago/jinja2-tmbundle",
 					"sublime_text": "<4107",
-					"branch": "master"
+					"tags": true
 				},
 				{
 					"sublime_text": ">=4107",

--- a/repository/j.json
+++ b/repository/j.json
@@ -680,10 +680,15 @@
 		},
 		{
 			"name": "Jinja2",
-			"details": "https://github.com/kudago/jinja2-tmbundle",
+			"details": "https://github.com/Sublime-Instincts/BetterJinja",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"base": "https://github.com/kudago/jinja2-tmbundle",
+					"sublime_text": "<3092",
+					"branch": "master"
+				},
+				{
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]

--- a/repository/j.json
+++ b/repository/j.json
@@ -684,11 +684,11 @@
 			"releases": [
 				{
 					"base": "https://github.com/kudago/jinja2-tmbundle",
-					"sublime_text": "<3092",
+					"sublime_text": "<4107",
 					"branch": "master"
 				},
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=4107",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Sorry that it took so long. Around the time when I first submitted `BetterJinja`, I just got into my job, so there was a bit of flux and challenge with looking into OSS.

The original PR was https://github.com/wbond/package_control_channel/pull/8013
And based of it, I got the permission to collaborate on the repo, but I will continue with the same suggestions that was offered when `BetterTwig` was reviewed.

1. For ST2 and ST3<3092, point the URL to the old `Jinja2` package https://github.com/kudago/jinja2-tmbundle
2. For ST3 > 3092, use `BetterJinja`

I am choosing this path because its the easiest & hassle free IMHO. 