### PR TITLE
Add plugin Paste As Column

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -449,9 +449,7 @@
 		},
 		{
 			"name": "Paste As Column",
-			"description": "Paste clipboard content in block mode (like emacs rectangle mode)",
 			"details": "https://github.com/TheClams/PasteAsColumn",
-			"issues": "https://github.com/TheClams/PasteAsColumn/issues",
 			"labels": ["text manipulation", "clipboard", "paste"],
 			"releases": [
 				{

--- a/repository/p.json
+++ b/repository/p.json
@@ -448,6 +448,19 @@
 			]
 		},
 		{
+			"name": "Paste As Column",
+			"description": "Paste clipboard content in block mode (like emacs rectangle mode)",
+			"details": "https://github.com/TheClams/PasteAsColumn",
+			"issues": "https://github.com/TheClams/PasteAsColumn/issues",
+			"labels": ["text manipulation", "clipboard", "paste"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Paste as One Line",
 			"details": "https://github.com/joshdavenport/PasteAsOneLine",
 			"releases": [


### PR DESCRIPTION
This plugin is just a slight change of the default sublime behavior where in case of multiple line paste it will automatically add space to ensure the block of text is kept aligned, and it also does not require having as many line selected as line in the clipboard.

It was an old plugin hosted on bitbucket, removed last year when bitbucket stopped supporting mercurial repo and some users reached out to get it back.

<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->
