### PR TITLE
Fix .gitattributes for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 text eol=lf
+* -crlf


### PR DESCRIPTION
Add to `.gitattributes` the `* -crlf` rule to disable CRLF behaviour on Windows machines where Git is set to `core.autocrlf`, otherwise users won't be able to submit commits with LF EOLs, due to current `.gitattributes` and `.editorconfig` settings.