### PR TITLE
SphinxRefmate package added : Changes Made

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3149,6 +3149,17 @@
 			]
 		},
 		{
+			"name": "SphinxRefmate",
+			"details": "https://github.com/phughes3866/SphinxRefmate",
+			"labels": ["sphinx"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SPICE Circuit Simulator",
 			"details": "https://github.com/leoheck/sublime-spice",
 			"labels": ["circuit simulator"],


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->

SphinxRefmate is a cross-referencing manager/aggregator for use within Sphinx Documentation projects that use the standard restructuredText in their source files. 

SphinxRefmate can gather, on demand, five types of references from the Sphinx Doc's source and configuration files, and then present these to the user in a Sublime Text quick-panel for selection/insertion. More details in the package's README.md file.

A similarly named package 'Sphinx Ref Helper' is already available on packagecontrol.io, but this is limited to aggregating references of one type from one Sphinx Doc project, through trawling all the source files. SphinxRefmate is operationally different in that it aggregates references from Sphinx Docs config files (conf.py) and build time inventories (objects.inv). SphinxRefmate is much faster and expansible through this approach. SphinxRefmate can gather more types of references than Sphinx Ref Helper, and from multiple Sphinx Doc projects at once (piggy-backing off the intersphinx_mapping variable associated with the standard Sphinx Intersphinx extension).

SphinxRefmate is never going to be needed in the same degree as food, clothes and shelter. It is however, likely to be a popular plugin for Sublime Text editors of Sphinx Doc projects.

Thank you for your considerations.

Paul Hughes