### PR TITLE
feat: add QuickTemplate (Go) package

### DIFF
--- a/repository/q.json
+++ b/repository/q.json
@@ -366,7 +366,7 @@
 			"labels": ["template", "go", "qtpl", "syntax", "auto-complete", "build-system"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]

--- a/repository/q.json
+++ b/repository/q.json
@@ -360,6 +360,18 @@
 			]
 		},
 		{
+			"name": "QuickTemplate (Go)",
+			"details": "https://github.com/SharanSharathi/sublime_qtpl",
+			"issues": "https://github.com/SharanSharathi/sublime_qtpl/issues",
+			"labels": ["template", "go", "qtpl", "syntax", "auto-complete", "build-system"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/chrislongo/QuickThemes",
 			"releases": [
 				{

--- a/repository/q.json
+++ b/repository/q.json
@@ -362,7 +362,6 @@
 		{
 			"name": "QuickTemplate (Go)",
 			"details": "https://github.com/SharanSharathi/sublime_qtpl",
-			"issues": "https://github.com/SharanSharathi/sublime_qtpl/issues",
 			"labels": ["template", "go", "qtpl", "syntax", "auto-complete", "build-system"],
 			"releases": [
 				{


### PR DESCRIPTION
This package adds source.qtpl syntax highlighting, code completion &
build system for sublime.

Contributing for this template-engine:
https://github.com/valyala/quicktemplate

<!--
Your pull request will be reviewed automatically and by a human.

In general, make sure you:

 0. Read the docs: https://packagecontrol.io/docs/submitting_a_package
 1. Used `"tags": true` and not `"branch": "master"`
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.
    Preferably also use the GitHub repo description.
 3. Have tagged a valid semver release (e.g. 1.0.0).
 4. Don't ship with keybindings or context menu entries unless you
    really really need to. These are scarce resources!
 5. Don't ship a color scheme with our syntax. We have hundreds of
    color schemes for a reason, and plenty of scopes to make your
    syntax work.
 6. Tell us what your package is about and why it should be added.
    
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->
