### PR TITLE
Added Algo2-TADs package

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -582,7 +582,7 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]

--- a/repository/a.json
+++ b/repository/a.json
@@ -577,6 +577,17 @@
 			]
 		},
 		{
+			"name": "Algo2-TADs",
+			"details": "https://github.com/Sponja-/Algo2-Sintaxis-TAD-st3",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Align Arguments",
 			"details": "https://github.com/denniskempin/align-arguments",
 			"labels": ["formatting"],


### PR DESCRIPTION
Adds support for a spanish dialect of [Abstract Data Type](https://en.wikipedia.org/wiki/Abstract_data_type) specification, used by students of the COMP930004 class in the University of Buenos Aires. This includes syntax highlighting and some snippets, as seen in the [GitHub repository](https://github.com/Sponja-/Algo2-Sintaxis-TAD-st3).

I'm not sure if non-english packages can be submitted to the default channel. If this isn't the case, I'd appreciate any recommendations on other distribution methods.