### PR TITLE
Add Dictionary

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -808,6 +808,17 @@
 			]
 		},
 		{
+			"name": "Dictionary",
+			"details": "https://github.com/futureprogrammer360/Dictionary",
+			"labels": ["dictionary"],
+			"releases": [
+				{
+					"sublime_text": ">=3080",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/Zinggi/DictionaryAutoComplete",
 			"releases": [
 				{


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is [Dictionary][4], a plugin that shows definitions of words in popups.

My package is similar to [MacDictionary][5]. However, it should still be added because [Dictionary][4] is not OS-dependent and is not limited to just macOS.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
[4]: https://github.com/futureprogrammer360/Dictionary
[5]: https://packagecontrol.io/packages/MacDictionary