### PR TITLE
Add Toit syntax highlight

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2785,7 +2785,7 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=4000",
 					"branch": "master"
 				}
 			]

--- a/repository/t.json
+++ b/repository/t.json
@@ -2779,6 +2779,18 @@
 			]
 		},
 		{
+			"name": "Toit Syntax Highlighting",
+			"details": "https://github.com/snxx-lppxx/toit-sublime",
+			"author": "snxx",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Toks",
 			"details": "https://github.com/thomasthorsen/SublimeToks",
 			"labels": ["C", "C++", "Source Navigation"],

--- a/repository/t.json
+++ b/repository/t.json
@@ -2779,7 +2779,7 @@
 			]
 		},
 		{
-			"name": "Toit Syntax Highlighting",
+			"name": "Toit",
 			"details": "https://github.com/snxx-lppxx/toit-sublime",
 			"author": "snxx",
 			"labels": ["language syntax"],

--- a/repository/t.json
+++ b/repository/t.json
@@ -2786,7 +2786,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=4000",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

Added syntax highlighting for the Toit programming language.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
