### PR TITLE
Replace Sublime-Gitignore with updated fork (again)

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -767,11 +767,11 @@
 		},
 		{
 			"name": "Gitignore",
-			"details": "https://github.com/kevinxucs/Sublime-Gitignore",
+			"details": "https://github.com/vilhelmen/Sublime-Gitignore",
 			"releases": [
 				{
-					"sublime_text": "*",
-					"branch": "master"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

This is a gentle takeover of @kevinxucs's Gitignore package (if they don't mind, hi :wave:), which hasn't been updated in four years. See #1433 for their takeover of the original.

This update drops ST2 support, removes sublime-package support (overrides didn't work anyway), and (should) now automatically compile and push updates from github/gitignore quarterly via Actions. It packages the root gitignores (templates in common use) as well as the global gitignores (templates for various editors, tools, and operating systems).

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
