### PR TITLE
PureBasic raised requirement to Sublime Text Build 4107.

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2714,7 +2714,7 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": ">3092",
+					"sublime_text": ">4107",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
[As a contributor to the package pointed out](https://github.com/peterthomashorn/purebasic-language-for-sublime-text/issues/40) there are some large differences in the support of Sublime Text 3 and 4. Since the time budget on maintaining this package is tiny (I guess this is the norm for all packages) its target is the most recent (major) Sublime Text release only. There is no time or large enough incentive to test and support previous releases.