### PR TITLE
Add Competitive Programming Lite

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3142,6 +3142,17 @@
 			]
 		},
 		{
+			"name": "Competitive Programming Lite",
+			"details": "https://github.com/JameelKaisar/Competitive-Programming-Lite",
+			"labels": ["competitive programming", "competitive coding"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Compile Jasper Template",
 			"details": "https://github.com/MettleUp/CompileJasperTemplate",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. `See Context Menu Below`
- [ ] My package doesn't add key bindings. `See Key Bindings Below`
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.


About:
A simple, easy-to-use Sublime Text plugin to assist in Competitive Programming.

Repository:
https://github.com/JameelKaisar/Competitive-Programming-Lite


Context Menu:
The plugin has no entries in context menu in default mode. However in Competitive Programming mode, the plugin has two context menu entries: CP Test and CP Run. When user exits the Competitive Programming Mode, the menu entries are no longer available.

Key Bindings:
The plugin has four key bindings and these are necessary for creating and navigating through questions (files) efficiently. Competitive Programming usually has tight time constraints and having key bindings for most used functions is a reasonable thing to have. The key bindings are listed in the menu and the command palette and open in split view.


[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

