### PR TITLE
Add Auto Close Panel

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2108,6 +2108,17 @@
 			]
 		},
 		{
+			"name": "Auto Close Panel",
+			"details": "https://github.com/aerobounce/Sublime-AutoClosePanel",
+			"labels": ["auto", "close", "panel"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Auto Encoding for Ruby",
 			"details": "https://github.com/elomarns/auto-encoding-for-ruby",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.

This package automatically hides output panel when its content matches regex.
Useful for panels such as Sublime-LSP's diagnosis (https://github.com/sublimelsp/LSP/issues/1904) and Build output panel.

There is no packages in Package Control which contain the same functionality.