### PR TITLE
Split up "Xcode Build Configuration and Project Syntax Definitions"

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -268,6 +268,17 @@
 			]
 		},
 		{
+			"name": "Old-Style ASCII Property Lists",
+			"details": "https://github.com/peterthomashorn/ascii-property-lists-for-sublime-text",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "OLED Color Scheme",
 			"details": "https://github.com/pavelrevak/OLED-color-scheme",
 			"labels": ["color scheme"],

--- a/repository/x.json
+++ b/repository/x.json
@@ -45,24 +45,24 @@
 			]
 		},
 		{
-			"name": "Xcode Build Configuration and Project Syntax Definitions",
-			"previous_names": ["Xcode Build Configuration", "Xcode Project"],
-			"details": "https://github.com/peterthomashorn/xcode-languages-for-sublime-text",
-			"labels": ["language syntax"],
-			"releases": [
-				{
-					"sublime_text": ">3092",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Xcode Colors",
 			"details": "https://github.com/braver/XcodeColors",
 			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": ">3174",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "Xcode Configuration Settings",
+			"previous_names": ["Xcode Build Configuration", "Xcode Build Configuration and Project Syntax Definitions", "Xcode Project"],
+			"details": "https://github.com/peterthomashorn/xcode-build-configuration-language-for-sublime-text",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">4107",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- Renamed "Xcode Build Configuration and Project Syntax Definitions" to "Xcode Configuration Settings"
- Add "Old-Style ASCII Property Lists"

A little more than two weeks ago I merged two packages [as suggested during initial pull request what originally were three packages](https://github.com/wbond/package_control_channel/pull/8391#issuecomment-956533976) and because of [an issue suggesting that](https://github.com/peterthomashorn/strings-resource-file-language-for-sublime-text/issues/1).

In the end it turned out it was initially right to keep all three in dedicated packages because only one (Xcode Configuration Settings) is directly related to Xcode and the other two are completely independent from each other and more broadly used.

So meanwhile I learned that "Xcode Strings" actually are string resource files (a package rename which was already accepted earlier) and that the Xcode project file actually is an ancient syntax of property lists not that common nowadays anymore. It also does not have anything in common with the existing "plist", "Plist Binary" or "BinaryPlist" packages except the abstract concept and idea of property lists which is a difference like JSON and YAML. The old ASCII syntax is completely different than the binary or XML-based syntax.