### PR TITLE
add JWT Decode

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -1429,6 +1429,16 @@
 			]
 		},
 		{
+			"name": "JWT Decode",
+			"details" : "https://github.com/Xiangjiaox/jwt-sublime-text",
+			"releases": [
+				{
+				"sublime_text": "*",
+				"tags": true
+				}
+			]
+		},
+		{
 			"name": "JXA Build System",
 			"details": "https://github.com/eppfel/JXASublimeText",
 			"labels": ["build system", "editor emulation", "javascript", "open scripting architecture"],


### PR DESCRIPTION
- [ ] I'm the package's author and/or maintainer.
- [ ] I have have read the docs.
- [ ] I have tagged a release with a semver version number.
- [ ] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. 
- [ ] My package doesn't add key bindings. 
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use .gitattributes to exclude files from the package: images, test files, sublime-project/workspace.

This PR adds the JWT Decode package, a simple plugin for decoding JWTs, like jwt.io, in Sublime Text.

There are no packages like it in Package Control.