### PR TITLE
Add Meson Build package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1350,7 +1350,7 @@
 			]
 		},
 		{
-			"name": "Meson Build",
+			"name": "Meson",
 			"details": "https://github.com/colinkiama/sublime-meson",
 			"labels": ["build system", "language_syntax"],
 			"releases": [

--- a/repository/m.json
+++ b/repository/m.json
@@ -1352,6 +1352,7 @@
 		{
 			"name": "Meson Build",
 			"details": "https://github.com/colinkiama/sublime-meson",
+			"labels": ["build system", "language_syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=4050",

--- a/repository/m.json
+++ b/repository/m.json
@@ -1350,6 +1350,16 @@
 			]
 		},
 		{
+			"name": "Meson Build",
+			"details": "https://github.com/colinkiama/sublime-meson",
+			"releases": [
+				{
+					"sublime_text": ">=4050",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Messages",
 			"details": "https://github.com/kristoformaynard/SublimeMessages",
 			"labels": ["linting", "tool execution"],


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] If my package is a syntax it doesn't also add a color scheme. ***

My package is Meson Build. It adds Meson build system commands to Sublime Text and adds syntax highlighting to Meson configuration files.

My package is similar to Meson (the package) however it should still be added because the Meson package repo is missing and it was only concerned with the configuration files. The goal of the Meson Build package to both enhance the configuration file experience and allow users to interact with Meson through Sublime Text. 
