### PR TITLE
add quarto syntax highlighting

### DIFF
--- a/repository/q.json
+++ b/repository/q.json
@@ -133,6 +133,17 @@
 			]
 		},
 		{
+			"name": "Quarto",
+			"details": "https://github.com/quarto-dev/quarto-sublime",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Quartz-Syntax",
 			"details": "https://github.com/contradictioned/quartz-syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***

My package is a syntax highlighting mode for the Quarto scientific and technical markdown publishing system (https://quarto.org).

There are no packages like it in Package Control.
