### PR TITLE
Limit Microsoft Typescript package to ST2 and ST3

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -3567,7 +3567,7 @@
 			"labels": ["auto-complete", "code navigation", "formatting", "language syntax", "snippets", "typescript", "javascript"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<4000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This package is unmaintained and outdated.

A better syntax definition is already shipped with ST4.
Intellisense features are provided by LSP and LSP-typescript.

So lets limit the package's availability to ST2 and ST3.