### PR TITLE
Limit Typescript Syntax package to ST2 and ST3

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -3587,7 +3587,7 @@
 			"details": "https://github.com/braver/TypeScriptSyntax",
 			"releases": [
 				{
-					"sublime_text": ">3000",
+					"sublime_text": "3000 - 4107",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
ST4 provides a far better syntax definition out of the box.

To avoid confusion we should probably deprecate this package.
