### PR TITLE
Add FormatX

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1569,6 +1569,17 @@
 			]
 		},
 		{
+			"name": "FormatX",
+			"details": "https://github.com/cj1128/sublime-formatx",
+			"labels": ["format", "prettier", "goimports", "clang-format"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Forth",
 			"details": "https://github.com/mitranim/sublime-forth",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

There are no packages like it in Package Control.
