### PR TITLE
Restrict TypeScriptSyntax to old ST4 builds

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -3587,7 +3587,7 @@
 			"details": "https://github.com/braver/TypeScriptSyntax",
 			"releases": [
 				{
-					"sublime_text": ">3000",
+					"sublime_text": "<4100",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Because ST4 has an excellent built in syntax for TypeScript already.

<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.