### PR TITLE
SSH-Panel Package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3524,6 +3524,21 @@
 			]
 		},
 		{
+			"name": "SSH-Panel",
+			"details": "https://github.com/Haiquan-27/SSH-Panel",
+			"author": "Haiquan",
+			"issues": "https://github.com/Haiquan-27/SSH-Panel/issues",
+			"readme": "https://raw.githubusercontent.com/Haiquan-27/SSH-Panel/main/README.md",
+			"labels": ["file navigation", "file creation", "remote"],
+			"releases": [
+				{
+					"sublime_text": ">=3211",
+					"platforms": ["windows", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/bmc/ST2SyntaxFromFileName",
 			"releases": [
 				{

--- a/repository/s.json
+++ b/repository/s.json
@@ -3527,8 +3527,6 @@
 			"name": "SSH-Panel",
 			"details": "https://github.com/Haiquan-27/SSH-Panel",
 			"author": "Haiquan",
-			"issues": "https://github.com/Haiquan-27/SSH-Panel/issues",
-			"readme": "https://raw.githubusercontent.com/Haiquan-27/SSH-Panel/main/README.md",
 			"labels": ["file navigation", "file creation", "remote"],
 			"releases": [
 				{


### PR DESCRIPTION
add SSH-Panel

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package Package functions:

1. View, Add, Edit files on remote SSH host
2. View remote file detailed properties
3. Browse with HTML panel like sidebar
4. Verify remote host fingerprint
5. Support password and public-private key pair authentication methods

The function is similar to the *RemoteTree*

difference:
* support on the Linux and Windows
* support all available openssh server operating systems
* the details of the server can be displayed