### PR TITLE
add Markdown Format (autoformatter for markdown .md files)

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -502,6 +502,17 @@
 			]
 		},
 		{
+			"name": "Markdown Format",
+			"details": "https://github.com/jasjuang/sublime_mdformat",
+			"labels": ["markdown", "Format", "Beautifier", "Formatter"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Markdown HTML Preview",
 			"details": "https://github.com/zeyon/MarkdownHtmlPreview",
 			"labels": ["markdown", "preview", "build", "html"],


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] Any commands are available via the command palette.
- [X] My package doesn't add key bindings. **

Surprisingly, there isn't a sublime plugin that can allow us to auto apply [mdformat](https://github.com/executablebooks/mdformat) on save yet. This package solves the problem.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
