### PR TITLE
Changing Fennel package branch

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -411,7 +411,8 @@
 			"releases": [
 				{
 					"sublime_text": ">=3092",
-					"tags": true
+					"tags": true,
+					"branch": "main"
 				}
 			]
 		},


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

I'm just changing the default branch for the `Fennel` package from `master` to `main`.