### PR TITLE
Add st4- version tag for Fish

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -996,8 +996,12 @@
 					"tags": "st2-"
 				},
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "3000 - 3999",
 					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
+					"tags": "st4-"
 				}
 			]
 		},


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.

I am adjusting my existing https://github.com/Phidica/sublime-fish package, adding an `st4-` tag prefix to support dedicated ST4 releases in the future (one such tagged release exists currently but it's just pointing at a forward-compatible ST3 version).


[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org