### PR TITLE
Add dprint

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -1564,6 +1564,16 @@
 			]
 		},
 		{
+			"name": "dprint",
+			"details": "https://github.com/dprint/dprint-sublime",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Dracula Color Scheme",
 			"details": "https://github.com/dracula/sublime",
 			"labels": ["color scheme"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is for [dprint](https://dprint.dev)

There are no packages like it in Package Control.