### PR TITLE
Add Butane package.

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -1709,11 +1709,9 @@
 			"details": "https://github.com/jdoss/sublime-butane",
 			"labels": ["language syntax", "snippets", "syntax highlighting", "syntax", "yaml"],
 			"author": ["Joe Doss (jdoss)"],
-			"readme": "https://raw.githubusercontent.com/jdoss/sublime-butane/main/README.md",
 			"releases": [
 				{
 					"sublime_text": ">=4075",
-					"platforms": ["*"],
 					"tags": true
 				}
 			]

--- a/repository/b.json
+++ b/repository/b.json
@@ -1705,6 +1705,20 @@
 			]
 		},
 		{
+			"name": "Butane",
+			"details": "https://github.com/jdoss/sublime-butane",
+			"labels": ["language syntax", "snippets", "syntax highlighting", "syntax", "yaml"],
+			"author": ["Joe Doss (jdoss)"],
+			"readme": "https://raw.githubusercontent.com/jdoss/sublime-butane/main/README.md",
+			"releases": [
+				{
+					"sublime_text": ">=4075",
+					"platforms": ["*"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "BYOND",
 			"details": "https://github.com/Wirewraith/sublime-byond",
 			"labels": ["language syntax", "build system", "Dream Maker", "Dream Seeker", "Dream Daemon"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***

My package is Butane. It adds syntax support for YAML like `.bu` files that are consumed by https://coreos.github.io/butane/

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
