### PR TITLE
Add TYPO3 Fluid Snippets

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -3627,6 +3627,18 @@
 			]
 		},
 		{
+			"name": "TYPO3 Fluid Snippets",
+			"details": "https://github.com/kitzberger/SublimeTypo3FluidSnippets",
+			"author": ["Daniel Siepmann", "Philipp Kitzberger"],
+			"labels": ["snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "TypoFixr",
 			"details": "https://github.com/sylzys/TypoFixr",
 			"releases": [


### PR DESCRIPTION
<!--
Your pull request will be reviewed automatically and by a human.

The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
If you haven't received a comment on your pull request
and it wasn't merged either,
it just hasn't been reviewed yet.

---

Please ensure the automated reviews pass.
Follow the instructions provided, if necessary.
You can speed up the process
by [running some tests locally](https://packagecontrol.io/docs/submitting_a_package#Step_7).

You can request a review from @packagecontrol-bot
to manually trigger an automated review
if you don't need to push a new commit.
Do **NOT** open a new pull request!

In general, make sure you:

 1. Used `"tags": true` and not `"branch": "master"`
    (versioning docs: <https://packagecontrol.io/docs/submitting_a_package#Step_4>)
 2. Added a README to your repository so that users (and reviewers) 
    can understand what your package provides.

You should proceed with a short description of what the package does
and, in case one or multiple similar package already exists,
why you believe it is different and needed
below this line. -->

It's a fork of the formerly removed package of the same name. I've spoken to Daniel Siepmann (the author of the removed package) and came to the conclusion that I'm uploading the repo onto github and should replace him as the maintainer.

Even though the repo was removed (see https://github.com/wbond/package_control_channel/commit/ee4939071d56e5fb09c93684fa712df983e3399b#diff-79c085e3ad3c3b65c0705209bc6adf95f41d41812cbbc981312718233da11899L3593) it's still listed here: https://packagecontrol.io/packages/TYPO3%20Fluid%20Snippets

Will this be automatically replaced by merging this PR here?