### PR TITLE
Add package `xit!`

### DIFF
--- a/repository/x.json
+++ b/repository/x.json
@@ -100,6 +100,16 @@
 			]
 		},
 		{
+			"name": "xit!",
+			"details": "https://github.com/jotaen/xit-sublime",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Xkcd",
 			"details": "https://github.com/EivindArvesen/xkcd",
 			"releases": [


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is for working with [`[x]it!` files, which is a format for todos and check lists](https://xit.jotaen.net/).

It provides:

- Syntax highlighting
- Commands for toggling the status of a todo item (when the cursor is placed in the item scope)
  - The command auto-saves the file by default, but that can be turned off via the `xit_auto_save` setting.
- “Smart” completions for due dates, where typing e.g. `3d` completes to `-> 2022-04-04`, i.e. the date 3 days from now
- Some sensible default settings that are specific for the `.xit` file format

I’d love for the package name to be `[x]it!` rather than `xit!`, but I suppose that’s not possible, is it?

There are no packages like it in Package Control.