### PR TITLE
Add Haskell HSX Package

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -294,9 +294,9 @@
 			]
 		},
 		{
-			"name": "Haskell NSIS",
-			"details": "https://github.com/idleberg/sublime-haskell-nsis",
-			"labels": ["snippets", "auto-complete", "nsis"],
+			"name": "Haskell HSX",
+			"details": "https://github.com/s0kil/sublime-text-hsx",
+			"labels": ["haskell", "hsx", "ihp"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -305,9 +305,9 @@
 			]
 		},
 		{
-			"name": "Haskell HSX",
-			"details": "https://github.com/s0kil/sublime-text-hsx",
-			"labels": ["haskell", "hsx", "ihp"],
+			"name": "Haskell NSIS",
+			"details": "https://github.com/idleberg/sublime-haskell-nsis",
+			"labels": ["snippets", "auto-complete", "nsis"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/h.json
+++ b/repository/h.json
@@ -295,7 +295,7 @@
 		},
 		{
 			"name": "Haskell HSX",
-			"details": "https://github.com/s0kil/sublime-text-hsx",
+			"details": "https://github.com/digitallyinduced/sublime-text-hsx",
 			"labels": ["haskell", "hsx", "ihp"],
 			"releases": [
 				{

--- a/repository/h.json
+++ b/repository/h.json
@@ -305,6 +305,17 @@
 			]
 		},
 		{
+			"name": "Haskell HSX",
+			"details": "https://github.com/s0kil/sublime-text-hsx",
+			"labels": ["haskell", "hsx", "ihp"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Haxe",
 			"details": "https://github.com/clemos/haxe-sublime-bundle",
 			"previous_names": ["HaXe"],


### PR DESCRIPTION
Add syntax highlighting for Haskell HSX

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] If my package is a syntax it doesn't also add a color scheme. ***