### PR TITLE
Add Hyperscript Syntax Highlighting

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -1546,7 +1546,7 @@
 			"description": "Syntax highlighting for Hyperscript (companion of HTMX)",
 			"releases": [
 				{
-					"sublime_text": ">=4075",
+					"sublime_text": ">=4121",
 					"tags": true
 				}
 			]

--- a/repository/h.json
+++ b/repository/h.json
@@ -1539,6 +1539,19 @@
 			]
 		},
 		{
+			"name": "Hyperscript",
+			"details": "https://github.com/gnat/hyperscript-sublime",
+			"labels": ["language syntax", "syntax", "html", "script", "highlighting", "htmx"],
+			"author": "gnat",
+			"description": "Syntax highlighting for Hyperscript (companion of HTMX)",
+			"releases": [
+				{
+					"sublime_text": ">=4075",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Hypertext Typographer",
 			"details": "https://github.com/ticky/HypertextTypographer",
 			"releases": [

--- a/repository/h.json
+++ b/repository/h.json
@@ -1541,9 +1541,7 @@
 		{
 			"name": "Hyperscript",
 			"details": "https://github.com/gnat/hyperscript-sublime",
-			"labels": ["language syntax", "syntax", "html", "script", "highlighting", "htmx"],
-			"author": "gnat",
-			"description": "Syntax highlighting for Hyperscript (companion of HTMX)",
+			"labels": ["language syntax", "syntax", "html", "script", "highlighting", "htmx", "javascript"],
 			"releases": [
 				{
 					"sublime_text": ">=4121",


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

# [Github Repo](https://github.com/gnat/hyperscript-sublime)


# [Hyperscript](https://hyperscript.org) for Sublime Text

Provides syntax highlighting for the Hyperscript (`_hyperscript`) language, both embedded in HTML and in a standalone file.

**Inspired by the VS Code Plugin, but now for Sublime Text!**

[Hyperscript](https://hyperscript.org) is the companion project of [HTMX](https://htmx.org). A recommended alternative to Stimulus, Alpine.js, jQuery.

<a href="https://github.com/gnat/hyperscript-sublime/tags">
    <img src="https://img.shields.io/github/v/tag/gnat/hyperscript-sublime?label=release&style=for-the-badge&color=%230288D1" /></a>


### What is Hyperscript?

* Event-oriented language.
* [Locality of Behaviour](https://htmx.org/essays/locality-of-behaviour) instead of verbose javascript modules, similar to [Tailwind.css](https://tailwindcss.com/)
* Async transparency.
* No long event chains / christmas trees.
* Null safe.
* Self-documenting natural syntax inspired by [Hypertalk](https://en.wikipedia.org/wiki/HyperTalk) and [AppleScript](https://en.wikipedia.org/wiki/AppleScript).
* Saves a ton of code in components.

See: [A First Look at Hyperscript](https://putyourlightson.com/articles/a-first-look-at-hyperscript)

[![What is hyperscript / HTMX ?](http://img.youtube.com/vi/u2rjnLJ1M98/0.jpg)](http://www.youtube.com/watch?v=u2rjnLJ1M98 "What is hyperscript / HTMX ?")

### Sample Highlighting

![image](https://user-images.githubusercontent.com/24665/174639996-2daf319b-2d4c-4be7-93ac-4b3540908c2c.png)
(Color scheme: [Invader Zim](https://github.com/gnat/sublime-invader-zim))


* [Plugin for VSCode](https://marketplace.visualstudio.com/items?itemName=dz4k.vscode-hyperscript-org)
* [Hyperscript Cheatsheet](https://thisweek.htmx.org/assets/2021-12-19/hyperscript-cheatsheet.pdf)
* [Hyperscript Website](https://hyperscript.org/)
* [HTMX Website](https://htmx.org)
* [Community Discord](https://htmx.org/discord)
* https://github.com/gnat/hyperscript-sublime (This plugin)

There are no packages like it in Package Control.


<!-- 
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 

For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

For updates to existing packages:
If your package isn't using tag based releases,
please switch to tags now.
 -->

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
