### PR TITLE
Add Whiley Package

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -354,6 +354,16 @@
 			]
 		},
 		{
+			"name": "Whiley",
+			"details": "https://github.com/Whiley/WhileySyntaxBundle",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "White Night Color Scheme",
 			"details": "https://github.com/strongliang/WhiteNight.tmTheme",
 			"labels": ["color scheme"],

--- a/repository/w.json
+++ b/repository/w.json
@@ -358,7 +358,7 @@
 			"details": "https://github.com/Whiley/WhileySyntaxBundle",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This provides simple syntax for the [Whiley programming language](http://whiley.org).  Whiley is an experimental programming language, and there is no other syntax for it.

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is ...

There are no packages like it in Package Control.

