### PR TITLE
Add Status Bar JsonPath

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3715,8 +3715,6 @@
 		{
 			"name": "Status Bar File Size",
 			"details": "https://github.com/SublimeText/StatusBarFileSize",
-			"author": "Alex Kirk",
-			"labels": ["status bar", "json", "jsonpath"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3727,6 +3725,8 @@
 		{
 			"name": "Status Bar JsonPath",
 			"details": "https://github.com/akirk/StatusBarJsonPath",
+			"author": "Alex Kirk",
+			"labels": ["status bar", "json", "jsonpath"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/s.json
+++ b/repository/s.json
@@ -3727,8 +3727,6 @@
 			"details": "https://github.com/akirk/StatusBarJsonPath",
 			"author": "Alex Kirk",
 			"labels": ["status bar", "json", "jsonpath"],
-			"readme": "https://gitlab.com/akirk/StatusBarJsonPath/-/raw/master/README.md",
-			"issues": "https://gitlab.com/akirk/StatusBarJsonPath/-/issues",
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/s.json
+++ b/repository/s.json
@@ -3727,6 +3727,8 @@
 			"details": "https://github.com/akirk/StatusBarJsonPath",
 			"author": "Alex Kirk",
 			"labels": ["status bar", "json", "jsonpath"],
+			"readme": "https://gitlab.com/akirk/StatusBarJsonPath/-/raw/master/README.md",
+			"issues": "https://gitlab.com/akirk/StatusBarJsonPath/-/issues",
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/s.json
+++ b/repository/s.json
@@ -3723,6 +3723,16 @@
 			]
 		},
 		{
+			"name": "Status Bar JsonPath",
+			"details": "https://github.com/akirk/StatusBarJsonPath",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Status Bar Time",
 			"details": "https://github.com/lowliet/sublimetext-StatusBarTime",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -3715,6 +3715,8 @@
 		{
 			"name": "Status Bar File Size",
 			"details": "https://github.com/SublimeText/StatusBarFileSize",
+			"author": "Alex Kirk",
+			"labels": ["status bar", "json", "jsonpath"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.
- [x] This is a follow-up to the closed #8372, I have updated the tag to 1.0.0.

My package is a Sublime Text plugin to get the JSONPath (a notation to access the item) under the cursor in a JSON.

There are no packages like it in Package Control.

The plugin also includes a command _JSONPath: Copy_ to copy the displayed path to the clipboard.

## Example

Given the following JSON object:
```
{
	"name": "Hello World",
	"tags": [
		"example"
	],
	"metadata": {
		"author": "Alex Kirk"
	}
}
```
In this scenario the plugin will display/copy the following JSONPaths:

- Cursor inside "name": `name`
- Cursor inside "Hello World": `name`
- Cursor inside "tags": `tags`
- Cursor inside "example": `tags[0]`
- Cursor inside "metadata": `metadata`
- Cursor inside "author": `metadata.author`

## Demo
![screen recording](https://raw.githubusercontent.com/akirk/StatusBarJsonPath/main/statusbarjsonpath.gif)

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore