### PR TITLE
Open URL plugin: move st3 support onto st3 branch, st4 version released with tags

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -649,12 +649,16 @@
 			"labels": ["open folders", "open files", "shortcut", "power user", "web search", "url"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
-					"tags": true
-				},
-				{
 					"sublime_text": "<3000",
 					"branch": "st2"
+				},
+				{
+					"sublime_text": "<4050",
+					"branch": "st3"
+				},
+				{
+					"sublime_text": ">=4050",
+					"tags": true
 				}
 			]
 		},

--- a/repository/o.json
+++ b/repository/o.json
@@ -650,11 +650,11 @@
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"branch": "st2"
+					"tags": "st2-"
 				},
 				{
-					"sublime_text": "<4050",
-					"branch": "st3"
+					"sublime_text": "3000 - 4049",
+					"tags": "st3-"
 				},
 				{
 					"sublime_text": ">=4050",


### PR DESCRIPTION
This package, https://github.com/noahcoad/open-url, already exists. I'm just changing the `releases` dict to move code for the ST3 version of the plugin onto the `st3` branch. The Sublime Text 4 version of the plugin is now the one with `"tags": true`

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
