### PR TITLE
Added package PEPEasm

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -755,6 +755,16 @@
 			]
 		},
 		{
+			"name": "PEPEasm",
+			"details": "https://github.com/Jonyleo/SublimePEPEAsm",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Perfect Code",
 			"details": "https://github.com/chaserogers/PerfectCodeColorScheme",
 			"releases": [

--- a/repository/p.json
+++ b/repository/p.json
@@ -745,18 +745,8 @@
 		},
 		{
 			"name": "PEPE Assembly",
-			"details": "https://github.com/patriq/Sublime-PEPE-Assembly",
-			"labels": ["language syntax", "snippets"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "PEPEasm",
-			"details": "https://github.com/Jonyleo/SublimePEPEAsm",
+			"details": "https://github.com/Jonyleo/PEPEAsm",
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] If my package is a syntax it doesn't also add a color scheme. ***

My package is syntax highlighting for the PEPE assembly programming language, used in a introduction to computer architecture class in IST at university of Lisbon.

My package is very similar to [PEPE Assembly](https://github.com/patriq/Sublime-PEPE-Assembly), however it should still be added because the original package has fallen behind of the new features of the language.

I've tried getting in contact with the maintainer, via github issues and e-mail, but I have not gotten a response.

I would try to get the original package replaced with mine, however I can't find a way to request that.

For this reason I decided to make my own package that addresses this issue. 

I would also like to add that I work on the official compiler for this language, if that adds any weight to my application!

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
