### PR TITLE
st3 versions prefixed with st3-, st4 with regular semver tags

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1317,7 +1317,11 @@
 			"author": "kylebebak",
 			"releases": [
 				{
-					"sublime_text": ">=3084",
+					"sublime_text": "3084 - 4106",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4107",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This package, https://github.com/kylebebak/Requester, already exists. I'm just changing the `releases` dict to move support for ST3 version of the plugin behind tags prefixed with `st3-`. The Sublime Text 4 versions of the plugin are tagged with normal semver tags

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
