### PR TITLE
Add SpaceDuck Color Scheme

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3081,6 +3081,17 @@
 			]
 		},
 		{
+			"name": "SpaceDuck Color Scheme",
+			"details": "https://github.com/ZhongXiLu/SpaceDuck-SublimeText",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SpaceSnippets",
 			"details": "https://github.com/shagabutdinov/sublime-space-snippets",
 			"donate": "https://github.com/shagabutdinov/sublime-enhanced/blob/master/readme-donations.md",


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have have read the docs.
- [X] I have tagged a release with a semver version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.

My package is a yet another color scheme that follows the [SpaceDuck](https://github.com/pineapplegiant/spaceduck) theme. I didn't find any existing ones for Sublime Text, so I made one myself (using a tool).