### PR TITLE
Add backwards compatibility for Atomic Soft Tab Nav package

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2026,7 +2026,7 @@
 			"details": "https://github.com/ruiokada/sublime-text-atomic-soft-tab-nav",
 			"releases": [
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

This pull request is not to add a new package but to introduce backwards compatibility to an existing package. For the initial release of my package, I only tested on Sublime Text 4 but I have now confirmed that it works on Sublime Text 3 as well.
