### PR TITLE
re-add AlgoLang package now that is has been moved to github

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -588,6 +588,18 @@
 			]
 		},
 		{
+			"name": "AlgoLang",
+			"details": "https://github.com/qraynaud/algo-lang-sublime",
+			"labels": ["language syntax"],
+			"issues": "https://heptapod.lsystems.fr/fa/algo-lang-sublime/-/issues",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Align Arguments",
 			"details": "https://github.com/denniskempin/align-arguments",
 			"labels": ["formatting"],
@@ -663,7 +675,7 @@
 					"branch": "master"
 				}
 			]
-		},	
+		},
 		{
 			"name": "Alrighty Snippets",
 			"details": "https://github.com/alrighty/alrighty-snippets-sublime",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is added to support syntax for an algorithmic language.

There are no packages like it in Package Control.