### PR TITLE
Add MarLant

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -800,6 +800,18 @@
 			]
 		},
 		{
+			"name": "MarLant",
+			"details": "https://github.com/retifrav/marlant",
+			"labels": ["subrip", "srt", "subtitles", "language syntax"],
+			"author": "retif",
+			"releases": [
+				{
+					"sublime_text": ">=4099",
+					"tags": "v"
+				}
+			]
+		},
+		{
 			"name": "Marshal Command Code",
 			"previous_names": ["MinecraftCommandCode"],
 			"description": "Syntax highlighting for Minecraft Commands",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer
- [x] I have have read [the docs][1]
- [x] I have tagged a release with a [SemVer][2] version number
- [x] My package repository has a description and a README describing what it's for and how to use it
- [ ] My package doesn't add context menu entries
- [x] My package doesn't add key bindings
- [x] Any commands are available via the command palette
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view
- [x] If my package is a syntax it doesn't also add a color scheme
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace

My package is a plugin for working with SubRip/SRT subtitles. It provides commands for inserting new titles, splitting and joining existing ones, renumbering titles ordinals, shifting all the titles timings and subtitles validation. It also provides a SubRip/SRT language syntax.

There are no packages like it in Package Control. I found these two: [SRT](https://packagecontrol.io/packages/SRT) and [SubVal](https://packagecontrol.io/packages/SubVal), but they provide a single functionality/feature each.

My package does add context menus:

- in tab context menu: 2 items for file-based operations
- in text area menu: 1 item which is a group for several nested items

If you'd prefer it didn't add context menus, that is not a problem, I can delete them from sources and add instructions for users in README.

I know that `author` property should not be provided for a GitHub-hosted package, but my GitHub username isn't quite what I wanted, and so I've set it.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
