### PR TITLE
Move AdvancedNewFile pointer to SublimeText organization.

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -407,7 +407,7 @@
 		},
 		{
 			"name": "AdvancedNewFile",
-			"details": "https://github.com/SublimeText/Sublime-AdvancedNewFile",
+			"details": "https://github.com/SublimeText/AdvancedNewFile",
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/a.json
+++ b/repository/a.json
@@ -407,7 +407,7 @@
 		},
 		{
 			"name": "AdvancedNewFile",
-			"details": "https://github.com/skuroda/Sublime-AdvancedNewFile",
+			"details": "https://github.com/SublimeText/Sublime-AdvancedNewFile",
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
Move the AdvancedNewFile plugin from it's current location (in my [space](https://github.com/skuroda/Sublime-AdvancedNewFile)) to the SublimeText organization.

Note at the time of filing this the project has not been moved to allow for coordination and minimize disruption to end users.