### PR TITLE
Updates repository name for ULSS sublime plugin

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -111,7 +111,7 @@
 		},
 		{
 			"name": "Ulysses Style Sheets",
-			"details": "https://github.com/soulmen/ulss-sublime-plugin",
+			"details": "https://github.com/ulyssesapp/ulss-sublime-plugin",
 			"labels": ["auto-complete", "language syntax"],
 			"releases": [
 				{


### PR DESCRIPTION
This pull request updates the URL of the github repository of the Ulysses Style Sheet syntax highlighting package. Our company moved its github account to a github organization, which resulted in a new URL.