### PR TITLE
Add PyScript

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -3004,6 +3004,17 @@
 			]
 		},
 		{
+			"name": "PyScript",
+			"details": "https://github.com/Sublime-Instincts/PyScript",
+			"labels": ["syntax highlight", "python", "pyscript", "language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4126",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "PySide",
 			"details": "https://github.com/DamnWidget/SublimePySide",
 			"releases": [


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is [PyScript](https://github.com/Sublime-Instincts/PyScript) which provides syntax highlighting for [PyScript](https://pyscript.net/)

There are no packages like it in Package Control.