### PR TITLE
Added Highlight Custom Chars Unicode repo

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -1568,6 +1568,16 @@
 					"tags": true
 				}
 			]
+		},
+		{
+			"name": "Highlight Custom Chars Unicode",
+			"details": "https://github.com/Hootrix/highlight-custom-chars-unicode",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is similar to "Highlight Dodgy Chars" However it should still be added because 

1. Customize the highlight color
2. Customize the highlight text
3. The highlighted characters are modified to unicode encoding, similar to the effect in vim
4. Easy selection of special characters at the beginning of the line
