### PR TITLE
Add NativeScript Core XML Syntax

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -112,6 +112,16 @@
 			]
 		},
 		{
+			"name": "NativeScript Core XML Syntax",
+			"details": "https://github.com/CatchABus/sublime-nativescript-xml-syntax",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "NativeScript Snippets",
 			"details": "https://github.com/tsvetan-ganev/nativescript-sublime-snippets",
 			"labels": ["auto-complete", "snippets"],

--- a/repository/n.json
+++ b/repository/n.json
@@ -116,7 +116,7 @@
 			"details": "https://github.com/CatchABus/sublime-nativescript-xml-syntax",
 			"releases": [
 				{
-					"sublime_text": "">=3092",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]

--- a/repository/n.json
+++ b/repository/n.json
@@ -116,7 +116,7 @@
 			"details": "https://github.com/CatchABus/sublime-nativescript-xml-syntax",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "">=3092",
 					"tags": true
 				}
 			]

--- a/repository/n.json
+++ b/repository/n.json
@@ -114,6 +114,7 @@
 		{
 			"name": "NativeScript Core XML Syntax",
 			"details": "https://github.com/CatchABus/sublime-nativescript-xml-syntax",
+			"labels": ["nativescript", "syntax", "highlight"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add key bindings. **
- [x] If my package is a syntax it doesn't also add a color scheme. ***

My package is [NativeScript Core XML Syntax](https://github.com/CatchABus/sublime-nativescript-xml-syntax).
There are no packages like it in Package Control.

This package adds syntax highlighting for [NativeScript Core](https://docs.nativescript.org/tutorial/plain.html#getting-started-with-nativescript) XML files.

Syntax is identical to the default one for XML with the addition of highlighting view model bindings.
The highlight color is the one used for CDATA tags.