### PR TITLE
(chore) rename Tint => Tint Terminal

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2378,7 +2378,7 @@
 			"name": "Tint Terminal",
 			"previous_names": ["Tint"],
 			"details": "https://github.com/joshgoebel/sublime-tint-terminal",
-			"author": "joshgoebel",
+			"author": "Josh Goebel",
 			"labels": [
 				"terminal",
 				"shell",

--- a/repository/t.json
+++ b/repository/t.json
@@ -2375,19 +2375,23 @@
 			]
 		},
 		{
-			"name": "Tint",
-			"details": "https://github.com/yyyc514/Tint",
-			"author": "jgoebel",
+			"name": "Tint Terminal",
+			"previous_names": ["Tint"],
+			"details": "https://github.com/joshgoebel/sublime-tint-terminal",
+			"author": "joshgoebel",
 			"labels": [
-				"utilities",
 				"terminal",
+				"shell",
+				"bash",
+				"zsh",
+				"utilities",
 				"console",
 				"command line"
 			],
 			"releases": [
 				{
 					"platforms": ["osx", "linux"],
-					"sublime_text": ">3000",
+					"sublime_text": ">=4126",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package _adds only bindings for scratch views it creates._
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view. _The upcoming update resolves this._
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.




This is just the renaming (and refreshing of a package already in the library).


[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
