### PR TITLE
Add Git filter-repo Syntax package

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -579,6 +579,20 @@
 			]
 		},
 		{
+			"name": "Git filter-repo Syntax",
+			"description": "A git filter-repo --analyze output syntax plugin",
+			"details": "https://github.com/WubiCookie/git-filter-repo-sublime-syntax",
+			"issues": "https://github.com/WubiCookie/git-filter-repo-sublime-syntax/issues",
+			"readme": "https://raw.githubusercontent.com/WubiCookie/git-filter-repo-sublime-syntax/master/README.md",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Git Message Auto Save",
 			"previous_names": ["Git Commit Message Auto Save"],
 			"details": "https://github.com/franciscolourenco/sublime-git-message-auto-save",

--- a/repository/g.json
+++ b/repository/g.json
@@ -579,11 +579,8 @@
 			]
 		},
 		{
-			"name": "Git filter-repo Syntax",
-			"description": "A git filter-repo --analyze output syntax plugin",
+			"name": "Git filter-repo",
 			"details": "https://github.com/WubiCookie/git-filter-repo-sublime-syntax",
-			"issues": "https://github.com/WubiCookie/git-filter-repo-sublime-syntax/issues",
-			"readme": "https://raw.githubusercontent.com/WubiCookie/git-filter-repo-sublime-syntax/master/README.md",
 			"labels": ["language syntax"],
 			"releases": [
 				{


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] If my package is a syntax it doesn't also add a color scheme.

My package is a syntax for the `git filter-repo --analyze` command's output files.

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
