### PR TITLE
add QSSEditor plugin info

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -83,6 +83,7 @@
 		"https://raw.githubusercontent.com/noraesae/ClassHierarchy/master/packages.json",
 		"https://raw.githubusercontent.com/Open-MBEE/MSE/master/sublime-syntax/channels/sublime/package-control.json",
 		"https://raw.githubusercontent.com/phyllisstein/Markboard3/master/packages.json",
+		"https://raw.githubusercontent.com/PyQt5/QSSEditorSublimeText/main/package.json",
 		"https://raw.githubusercontent.com/quarnster/CompleteSharp/master/package.json",
 		"https://raw.githubusercontent.com/quarnster/SublimeClang/master/package.json",
 		"https://raw.githubusercontent.com/quarnster/SublimeJava/master/package.json",

--- a/repository/q.json
+++ b/repository/q.json
@@ -101,6 +101,16 @@
 			]
 		},
 		{
+			"name": "QSSEditor",
+			"details": "https://github.com/PyQt5/QSSEditorSublimeText",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "main"
+				}
+			]
+		},
+		{
 			"name": "QSwitch",
 			"details": "https://github.com/mintyPT/QSwitch",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is QSSEditor

There are no packages like it in Package Control.

