### PR TITLE
Added CompareBuff package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3129,6 +3129,20 @@
 				}
 			]
 		},
+        {
+            "name": "CompareBuff",
+            "details": "https://github.com/nexional/CompareBuff",
+			"readme": "https://github.com/nexional/CompareBuff/blob/master/README.md",
+			"issues": "https://github.com/nexional/CompareBuff/issues",
+            "author": "VK",
+            "labels": ["compare", "comparison", "beyond compare", "diff", "buffer"],
+            "releases": [
+                {
+                    "sublime_text": "*",
+                    "tags": true
+                }
+            ]
+        },
 		{
 			"name": "Compare Side-By-Side",
 			"details": "https://bitbucket.org/dougty/sublime-compare-side-by-side",

--- a/repository/c.json
+++ b/repository/c.json
@@ -3142,10 +3142,7 @@
 			]
 		},
 		{
-			"name": "CompareBuff",
 			"details": "https://github.com/nexional/CompareBuff",
-			"readme": "https://github.com/nexional/CompareBuff/blob/master/README.md",
-			"issues": "https://github.com/nexional/CompareBuff/issues",
 			"author": "VK",
 			"labels": ["compare", "comparison", "beyond compare", "diff", "buffer"],
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -3129,25 +3129,25 @@
 				}
 			]
 		},
-        {
-            "name": "CompareBuff",
-            "details": "https://github.com/nexional/CompareBuff",
-			"readme": "https://github.com/nexional/CompareBuff/blob/master/README.md",
-			"issues": "https://github.com/nexional/CompareBuff/issues",
-            "author": "VK",
-            "labels": ["compare", "comparison", "beyond compare", "diff", "buffer"],
-            "releases": [
-                {
-                    "sublime_text": "*",
-                    "tags": true
-                }
-            ]
-        },
 		{
 			"name": "Compare Side-By-Side",
 			"details": "https://bitbucket.org/dougty/sublime-compare-side-by-side",
 			"author": "Doug Ty",
 			"labels": ["diff", "compare", "comparison"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "CompareBuff",
+			"details": "https://github.com/nexional/CompareBuff",
+			"readme": "https://github.com/nexional/CompareBuff/blob/master/README.md",
+			"issues": "https://github.com/nexional/CompareBuff/issues",
+			"author": "VK",
+			"labels": ["compare", "comparison", "beyond compare", "diff", "buffer"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is CompareBuff - [SublimeText package to compare two buffers using external comparison tool]
Link: https://github.com/nexional/CompareBuff

My package is similar to https://packagecontrol.io/packages/BeyondCompare However it should still be added because -
a. It allows you to chose two files/buffers you want to compare from any window
b. Not limited to Beyond Compare tool. You can configure any external comparison tool in settings
c. Can also work on just the selected area