### PR TITLE
Move Liquid package to SublimeText

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1171,12 +1171,20 @@
 		},
 		{
 			"name": "Liquid",
-			"details": "https://github.com/braver/sublime-liquid",
+			"details": "https://github.com/SublimeText/Liquid",
 			"labels": ["liquid", "shopify", "front matter", "jekyll", "language syntax"],
 			"releases": [
 				{
-					"sublime_text": ">3000",
-					"tags": true
+					"sublime_text": "3176 - 4125",
+					"tags": "3176-"
+				},
+				{
+					"sublime_text": "4126 - 4133",
+					"tags": "4126-"
+				},
+				{
+					"sublime_text": ">=4134",
+					"tags": "4134-"
 				}
 			]
 		},


### PR DESCRIPTION
Liquid 1.3.0 uses `embed`, so limiting it to first stable build (3176) shipping that feature.

The st4126 branch contains a backported Markdown syntax from ST 4134 to provide a most recent version of the package for latest stable build.

As of ST 4134 the package extends ST's default HTML,CSS,JS,Markdown syntaxes.