### PR TITLE
Move Astro package to SublimeText organization

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -663,7 +663,7 @@
 					"branch": "master"
 				}
 			]
-		},	
+		},
 		{
 			"name": "Alrighty Snippets",
 			"details": "https://github.com/alrighty/alrighty-snippets-sublime",
@@ -1957,12 +1957,20 @@
 		},
 		{
 			"name": "Astro",
-			"details": "https://github.com/Destiner/sublime-astro",
+			"details": "https://github.com/SublimeText/Astro",
 			"labels": ["language syntax", "astro"],
 			"releases": [
 				{
-					"sublime_text": "*",
-					"tags": true
+					"sublime_text": "3176 - 4125",
+					"tags": "3176-"
+				},
+				{
+					"sublime_text": "4126 - 4133",
+					"tags": "4126-"
+				},
+				{
+					"sublime_text": ">=4134",
+					"tags": "4134-"
 				}
 			]
 		},


### PR DESCRIPTION
As Liquid, Astro has received some work to be based on Sublime Text's core syntaxes.

The author has been informed about the work and the idea about moving the repo via https://github.com/Destiner/sublime-astro/issues/5 without response so far.

[Astro](https://github.com/SublimeText/Astro) was therefore moved today to prepare release of latest changes/improvements.

We might still wait a bit, maybe we get some response in near future. Not sure.