### PR TITLE
Add Ebitengine Kage syntax highlighting and snippets

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -231,6 +231,18 @@
 			]
 		},
 		{
+			"name": "Ebitengine Kage",
+			"details": "https://github.com/sedyh/ebitengine-kage-sublime",
+			"labels": ["kage", "ebitengine", "syntax highlight", "snippets"],
+			"author": "sedyh",
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Echo Evaluator",
 			"details": "https://github.com/Monnoroch/EchoEvaluator",
 			"releases": [

--- a/repository/e.json
+++ b/repository/e.json
@@ -234,7 +234,6 @@
 			"name": "Ebitengine Kage",
 			"details": "https://github.com/sedyh/ebitengine-kage-sublime",
 			"labels": ["kage", "ebitengine", "syntax highlight", "snippets"],
-			"author": "sedyh",
 			"releases": [
 				{
 					"sublime_text": ">=4107",

--- a/repository/k.json
+++ b/repository/k.json
@@ -24,6 +24,18 @@
 			]
 		},
 		{
+			"name": "Ebitengine Kage",
+			"details": "https://github.com/sedyh/ebitengine-kage-support/tree/main/sublime",
+			"labels": ["kage", "ebitengine", "syntax highlight", "snippets"],
+			"author": "sedyh",
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Kahlan PHP Snippets",
 			"details": "https://github.com/geryguilbon/sublime_kahlan_snippets",
 			"labels": ["kahlan", "snippets", "tests", "tdd", "framework", "php"],

--- a/repository/k.json
+++ b/repository/k.json
@@ -24,18 +24,6 @@
 			]
 		},
 		{
-			"name": "Ebitengine Kage",
-			"details": "https://github.com/sedyh/ebitengine-kage-support/tree/main/sublime",
-			"labels": ["kage", "ebitengine", "syntax highlight", "snippets"],
-			"author": "sedyh",
-			"releases": [
-				{
-					"sublime_text": ">=4107",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Kahlan PHP Snippets",
 			"details": "https://github.com/geryguilbon/sublime_kahlan_snippets",
 			"labels": ["kahlan", "snippets", "tests", "tdd", "framework", "php"],


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace. (I don't have any misc files)

<br>

## <img align="left" width="100px" src="https://user-images.githubusercontent.com/19890545/179967638-6b0e4e7d-7f8c-412a-b87d-47ba8e694477.png" alt="ebitengine-kage-support" /> Ebitengine Kage support for Sublime Text

Basic syntax and snippet support for the Ebitengine Kage shading language. 

<br>

### [Github Repo](https://github.com/sedyh/ebitengine-kage-sublime)

### Other versions

[![](https://img.shields.io/badge/source-555555?style=for-the-badge&logo=vim&logoColor=60b371)](https://github.com/sedyh/ebitengine-kage-vim)[![](https://img.shields.io/badge/download-60b371?style=for-the-badge)](https://www.vim.org/scripts/script.php?script_id=6021)<br>[![](https://img.shields.io/badge/source-555555?style=for-the-badge&logo=visualstudiocode&logoColor=72a9d4)](https://github.com/sedyh/ebitengine-kage-vscode)[![](https://img.shields.io/badge/download-72a9d4?style=for-the-badge)](https://marketplace.visualstudio.com/items?itemName=sedyh.ebitengine-kage)

My package is adding support for the shading language Kage. It has a compatible syntax with Go, but the details are different. Kage has high portability. Kage is used to write shaders with Ebitengine.

There are no packages like it in Package Control.

### Highlighting example

![image](https://user-images.githubusercontent.com/19890545/178752622-96915c70-989b-411f-b5d5-d4605a4dd40e.png)

<!-- 
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 

For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

For updates to existing packages:
If your package isn't using tag based releases,
please switch to tags now.
 -->

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
