### PR TITLE
Added Big Scheme Pack

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -770,6 +770,17 @@
 			]
 		},
 		{
+			"name": "BigSchemePack",
+			"details": "https://github.com/dementive/BigSchemePack",
+			"labels": ["color scheme", "theme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Biml",
 			"details": "https://github.com/sorrell/subiml",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a big pack of color schemes with 27 color schemes that highlight syntax in 7 different ways, it also comes with 1 theme.

My package is similar to other packages that add color schemes and themes. However, it should still be added because it adds lots of new great looking color schemes and a theme that has some unique features that most other themes do not, like being dynamic in its coloring. I also added a command that opens a popup menu so managing all of these new color schemes through the command palette isn't the only option.

