### PR TITLE
Added BigSchemePack

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -770,17 +770,6 @@
 			]
 		},
 		{
-			"name": "BigSchemePack",
-			"details": "https://github.com/dementive/BigSchemePack",
-			"labels": ["color scheme", "theme"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Biml",
 			"details": "https://github.com/sorrell/subiml",
 			"releases": [

--- a/repository/b.json
+++ b/repository/b.json
@@ -770,6 +770,17 @@
 			]
 		},
 		{
+			"name": "BigSchemePack",
+			"details": "https://github.com/dementive/BigSchemePack",
+			"labels": ["color scheme", "theme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Biml",
 			"details": "https://github.com/sorrell/subiml",
 			"releases": [

--- a/repository/b.json
+++ b/repository/b.json
@@ -770,6 +770,17 @@
 			]
 		},
 		{
+			"name": "BigSchemePack",
+			"details": "https://github.com/dementive/BigSchemePack",
+			"labels": ["theme", "color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Biml",
 			"details": "https://github.com/sorrell/subiml",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a big pack of 27 color schemes and 1 custom theme made for Sublime Text 4.

There are no packages like it in Package Control, as far as I know there is no package that adds a lot of color schemes. There is also a very limited number of dynamic themes on package control, and none of them are quite like this one. Most themes have hardcoded colors but this one has dynamic accents that look very nice with all the color schemes in this pack.
