### PR TITLE
Use ST3 specific tag for older version of AdvancedNewFile.

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -410,8 +410,11 @@
 			"details": "https://github.com/SublimeText/AdvancedNewFile",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=4000",
 					"tags": true
+				},{
+					"sublime_text": "<4000",
+					"tags": "st3-"
 				}
 			]
 		},


### PR DESCRIPTION
Add specific tag for AdvancedNewFIle for use by legacy versions. This is to allow further development on the codebase with Sublime Text 4 only features.