### PR TITLE
Try to fix duplicate "Paste as Column" package entry

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -451,6 +451,7 @@
 			"name": "Paste As Column",
 			"details": "https://github.com/TheClams/PasteAsColumn",
 			"labels": ["text manipulation", "clipboard", "paste"],
+			"previous_names": ["Paste as Column"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
packagecontrol.io lists "Package as Column" and "Package As Column". The former one is dead link to bitbucket. It also causes Package Control to fail installing it as it seems to look for old package.

I guess it's caused by a casing issue.

This commit is an attempt to trigger a cleanup. Not sure whether it works now that two packages exist already though.
