### PR TITLE
Add Executor

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -1560,6 +1560,18 @@
 			]
 		},
 		{
+			"name": "Executor",
+			"details": "https://github.com/tonsky/Sublime-Executor",
+			"labels": ["build system"],
+			"releases": [
+			{
+				"sublime_text": ">=4081",
+				"platforms": ["osx", "linux"],
+				"tags": true
+			}
+			]
+		},
+		{
 			"name": "exercism",
 			"previous_names": ["STexercism"],
 			"details": "https://github.com/thosgood/STexercism",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package lets you choose and run any executable from your working dirs inside Sublime Text.

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
