### PR TITLE
fix: remove jvantuyl/sublime_diagram_plugin from channel.json

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -60,7 +60,6 @@
 		"https://raw.githubusercontent.com/joacodeviaje/aftersave/master/packages.json",
 		"https://raw.githubusercontent.com/joomlapro/joomla3-sublime-snippets/master/packages.json",
 		"https://raw.githubusercontent.com/jrappen/sublime-packages/master/package_control_channel.json",
-		"https://raw.githubusercontent.com/jvantuyl/sublime_diagram_plugin/master/packages.json",
 		"https://raw.githubusercontent.com/kairyou/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/Kaizhi/SublimeUpdater/master/packages.json",
 		"https://raw.githubusercontent.com/kallepersson/Sublime-Finder/master/packages.json",


### PR DESCRIPTION
This package has changed to repository hosting: https://github.com/jvantuyl/sublime_diagram_plugin/commit/25b96b13344fefb655312099a212ac13ebad6e9a