### PR TITLE
Tidy up dependencies.json

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -4,153 +4,159 @@
 	"dependencies": [
 		{
 			"name": "anytree",
-			"load_order": "01",
 			"description": "Python Anytree module - https://github.com/c0fec0de/anytree",
 			"author": "c0fec0de",
 			"issues": "https://github.com/c0fec0de/anytree/issues",
+			"load_order": "01",
 			"releases": [
 				{
-					"sublime_text": "*",
 					"base": "https://github.com/nbeversl/anytree_sublime",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "arrow",
-			"load_order": "01",
 			"description": "Python arrow module - https://github.com/crsmithdev/arrow",
 			"author": "douglas-vaz",
 			"issues": "https://github.com/douglas-vaz/arrow/issues",
+			"load_order": "01",
 			"releases": [
 				{
-					"sublime_text": "*",
 					"base": "https://github.com/douglas-vaz/arrow",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "backports_lzma",
-			"author": "dvhh",
-			"load_order": "50",
 			"description": "lzma modules for sublime text 2 and 3",
+			"author": "dvhh",
 			"issues": "https://github.com/dvhh/sublime-backports.lzma/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/dvhh/sublime-backports.lzma",
-					"tags": true,
-					"platforms": ["windows"],
-					"sublime_text": "*"
+					"platforms": [
+						"windows"
+					],
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "backrefs",
-			"author": "facelessuser",
-			"load_order": "50",
 			"description": "Backrefs regular expression wrapper.",
+			"author": "facelessuser",
 			"issues": "https://github.com/facelessuser/sublime-backrefs/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-backrefs",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "better_settings",
-			"load_order": "01",
 			"description": "Easily implement OS, Host and OS/Host-level settings aside the normal user-level settings for any plugin.",
 			"author": "KuttKatrea",
 			"issues": "https://github.com/KuttKatrea/sublime-better-settings/issues",
+			"load_order": "01",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
 					"base": "https://github.com/KuttKatrea/sublime-better-settings",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "boto3",
-			"load_order": "02",
 			"description": "Python boto3 module for Amazon Web Services",
 			"author": "revmischa",
 			"issues": "https://github.com/revmischa/sublime-boto3/issues",
+			"load_order": "02",
 			"releases": [
 				{
-					"sublime_text": "*",
 					"base": "https://github.com/revmischa/sublime-boto3",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "bracex",
-			"load_order": "50",
 			"description": "Bracex creates arbitrary strings via brace expansion much like Bash's.",
 			"author": "facelessuser",
 			"issues": "https://github.com/facelessuser/sublime-bracex/issues",
+			"load_order": "50",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
 					"base": "https://github.com/facelessuser/sublime-bracex",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "bs4",
-			"load_order": "51",
 			"description": "Beautiful Soup is a Python library for pulling data out of HTML and XML files - https://www.crummy.com/software/BeautifulSoup/",
 			"author": "jlegewie",
 			"issues": "https://github.com/jlegewie/sublime-beautifulsoup4/issues",
+			"load_order": "51",
 			"releases": [
 				{
 					"base": "https://github.com/jlegewie/sublime-beautifulsoup4",
+					"platforms": [
+						"*"
+					],
 					"sublime_text": ">=3000",
-					"platforms": ["*"],
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "bson",
-			"load_order": "50",
 			"description": "Independent BSON codec for Python that doesn’t depend on MongoDB - https://github.com/py-bson/bson",
 			"author": "idleberg",
 			"issues": "https://github.com/idleberg/sublime-bson/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/idleberg/sublime-bson",
-					"tags": true,
+					"platforms": [
+						"*"
+					],
 					"sublime_text": "*",
-					"platforms": ["*"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "bz2",
-			"load_order": "02",
 			"description": "Python bz2 module",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/sublime-bz2/issues",
+			"load_order": "02",
 			"releases": [
 				{
-					"sublime_text": "*",
 					"base": "https://github.com/codexns/sublime-bz2",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "channelmanager",
-			"author": "evandrocoan",
-			"load_order": "30",
 			"description": "Manages packages installed as git submodules",
+			"author": "evandrocoan",
 			"issues": "https://github.com/evandrocoan/channelmanager/issues",
+			"load_order": "30",
 			"releases": [
 				{
 					"base": "https://github.com/evandrocoan/channelmanager",
@@ -161,38 +167,38 @@
 		},
 		{
 			"name": "chardet",
-			"load_order": "50",
 			"description": "Universal encoding detector for Python 2 and 3 https://github.com/chardet/chardet",
 			"author": "Umoxfo",
 			"issues": "https://github.com/Umoxfo/sublime-chardet/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/Umoxfo/sublime-chardet",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "coloraide",
-			"author": "facelessuser",
-			"load_order": "50",
 			"description": "A color library.",
+			"author": "facelessuser",
 			"issues": "https://github.com/facelessuser/sublime-coloraide/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-coloraide",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "concurrentloghandler",
-			"author": "evandrocoan",
-			"load_order": "09",
 			"description": "An additional concurrent file log handler for Python's standard logging package",
+			"author": "evandrocoan",
 			"issues": "https://github.com/evandroforks/concurrentloghandler/issues",
+			"load_order": "09",
 			"releases": [
 				{
 					"base": "https://github.com/evandroforks/concurrentloghandler",
@@ -203,84 +209,92 @@
 		},
 		{
 			"name": "coverage",
-			"load_order": "15",
 			"description": "coverage.py - http://coverage.readthedocs.org/en/latest/",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/sublime-coverage/issues",
+			"load_order": "15",
 			"releases": [
 				{
 					"base": "https://github.com/codexns/sublime-coverage",
-					"tags": true,
+					"platforms": [
+						"*"
+					],
 					"sublime_text": "*",
-					"platforms": ["*"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "crypt",
-			"load_order": "02",
 			"description": "Python crypt module",
 			"author": "adnanyaqoobvirk",
 			"issues": "https://github.com/adnanyaqoobvirk/sublime-crypt/issues",
+			"load_order": "02",
 			"releases": [
 				{
-					"sublime_text": "*",
 					"base": "https://github.com/adnanyaqoobvirk/sublime-crypt",
-					"platforms": ["linux"],
+					"platforms": [
+						"linux"
+					],
+					"sublime_text": "*",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "cson",
-			"load_order": "50",
 			"description": "A Coffescript Object Notation (CSON) parser for Python - https://github.com/avakar/pycson",
 			"author": "idleberg",
 			"issues": "https://github.com/idleberg/sublime-cson/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/idleberg/sublime-cson",
-					"tags": true,
+					"platforms": [
+						"*"
+					],
 					"sublime_text": "*",
-					"platforms": ["*"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "ctypes",
-			"load_order": "01",
 			"description": "Python _ctypes module",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/sublime-ctypes/issues",
+			"load_order": "01",
 			"releases": [
 				{
 					"base": "https://github.com/codexns/sublime-ctypes",
-					"tags": true,
+					"platforms": [
+						"linux"
+					],
 					"sublime_text": "<3000",
-					"platforms": ["linux"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "dateutil",
-			"load_order": "50",
 			"description": "The dateutil module provides powerful extensions to the datetime module available in the Python standard library",
 			"author": "vovkkk",
 			"issues": "https://github.com/vovkkk/sublime-dateutil/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/vovkkk/sublime-dateutil",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "debugtools",
-			"author": "evandrocoan",
-			"load_order": "10",
 			"description": "Alternate simplified logging support and general utilities functions",
+			"author": "evandrocoan",
 			"issues": "https://github.com/evandrocoan/debugtools/issues",
+			"load_order": "10",
 			"releases": [
 				{
 					"base": "https://github.com/evandrocoan/debugtools",
@@ -291,24 +305,24 @@
 		},
 		{
 			"name": "dicttoxml",
-			"load_order": "50",
 			"description": "Converts a Python dictionary or other native data type into a valid XML string - https://github.com/idleberg/sublime-dicttoxml",
 			"author": "idleberg",
 			"issues": "https://github.com/idleberg/sublime-dicttoxml/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/idleberg/sublime-dicttoxml",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "diffmatchpatch",
-			"author": "evandrocoan",
-			"load_order": "09",
 			"description": "Autored by Neil Fraser and others, Diff Match Patch is a high-performance library in multiple languages that manipulates plain text",
+			"author": "evandrocoan",
 			"issues": "https://github.com/evandroforks/diffmatchpatch/issues",
+			"load_order": "09",
 			"releases": [
 				{
 					"base": "https://github.com/evandroforks/diffmatchpatch",
@@ -319,356 +333,388 @@
 		},
 		{
 			"name": "emojitations",
-			"load_order": "50",
 			"description": "A library for using Unicode emoji annotations - https://github.com/kcsaff/emojitations",
 			"author": "idleberg",
 			"issues": "https://github.com/idleberg/sublime-emojitations/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/idleberg/sublime-emojitations",
-					"tags": true,
+					"platforms": [
+						"*"
+					],
 					"sublime_text": ">3000",
-					"platforms": ["*"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "enum",
-			"load_order": "50",
 			"description": "Python enum module",
 			"author": "FichteFoll",
 			"issues": "https://github.com/packagecontrol/enum/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/enum",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "fileio",
-			"load_order": "01",
 			"description": "Python _fileio module",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/sublime-fileio/issues",
+			"load_order": "01",
 			"releases": [
 				{
 					"base": "https://github.com/codexns/sublime-fileio",
-					"tags": true,
+					"platforms": [
+						"linux"
+					],
 					"sublime_text": "<3000",
-					"platforms": ["linux"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "gateone-terminal",
-			"load_order": "50",
 			"description": "GateOne terminal",
 			"author": "randy3k",
 			"issues": "https://github.com/packagecontrol/gateone-terminal/issues",
+			"load_order": "50",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
 					"base": "https://github.com/packagecontrol/gateone-terminal",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "gntp",
-			"author": "facelessuser",
-			"load_order": "50",
 			"description": "Growl Notification Transport Protocol library.",
+			"author": "facelessuser",
 			"issues": "https://github.com/facelessuser/sublime-gntp/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-gntp",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "golangconfig",
-			"load_order": "10",
 			"description": "A library for Go environment configuration",
 			"author": "Go Authors",
 			"issues": "https://github.com/golang/sublime-config/issues",
+			"load_order": "10",
 			"releases": [
 				{
 					"base": "https://github.com/golang/sublime-config",
-					"tags": true,
+					"platforms": [
+						"*"
+					],
 					"sublime_text": "*",
-					"platforms": ["*"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "jsonschema",
-			"load_order": "55",
 			"description": "An(other) implementation of JSON Schema for Python",
 			"author": "kylebebak",
 			"issues": "https://github.com/kylebebak/sublime-jsonschema/issues",
+			"load_order": "55",
 			"releases": [
 				{
 					"base": "https://github.com/kylebebak/sublime-jsonschema",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "lxml",
-			"load_order": "10",
 			"description": "lxml",
 			"author": "eerohele",
 			"issues": "https://github.com/eerohele/sublime-lxml/issues",
+			"load_order": "10",
 			"releases": [
 				{
 					"base": "https://github.com/eerohele/sublime-lxml",
-					"tags": true,
+					"platforms": [
+						"osx-x64",
+						"linux",
+						"windows"
+					],
 					"sublime_text": ">=3000",
-					"platforms": ["osx-x64", "linux", "windows"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "lzma",
-			"load_order": "50",
 			"description": "Python lzma module",
 			"author": "ehamiter",
 			"issues": "https://github.com/ehamiter/sublime-lzma/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/ehamiter/sublime-lzma",
-					"tags": true,
+					"platforms": [
+						"osx-x64"
+					],
 					"sublime_text": ">=3000",
-					"platforms": ["osx-x64"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "markupsafe",
-			"load_order": "50",
 			"description": "Python MarkupSafe module",
 			"author": "FichteFoll",
 			"issues": "https://github.com/packagecontrol/MarkupSafe/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/MarkupSafe",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "mdpopups",
-			"author": "facelessuser",
-			"load_order": "55",
 			"description": "Markdown Popups for Sublime",
+			"author": "facelessuser",
 			"issues": "https://github.com/facelessuser/sublime-markdown-popups/issues",
+			"load_order": "55",
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-markdown-popups",
-					"tags": true,
-					"sublime_text": ">=3124"
+					"sublime_text": ">=3124",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "multiprocessing",
-			"load_order": "01",
 			"description": "Python _multiprocessing module",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/sublime-multiprocessing/issues",
+			"load_order": "01",
 			"releases": [
 				{
 					"base": "https://github.com/codexns/sublime-multiprocessing",
-					"tags": true,
+					"platforms": [
+						"windows"
+					],
 					"sublime_text": "<3000",
-					"platforms": ["windows"]
+					"tags": true
 				},
 				{
 					"base": "https://github.com/codexns/sublime-multiprocessing",
-					"tags": true,
+					"platforms": [
+						"osx"
+					],
 					"sublime_text": ">=3000",
-					"platforms": ["osx"]
+					"tags": true
 				},
 				{
 					"base": "https://github.com/codexns/sublime-multiprocessing",
-					"tags": true,
+					"platforms": [
+						"linux"
+					],
 					"sublime_text": "*",
-					"platforms": ["linux"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "natsort",
-			"load_order": "50",
 			"description": "Python natsort package",
 			"author": "alimony",
 			"issues": "https://github.com/alimony/sublime-natsort/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/alimony/sublime-natsort",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "newterm",
-			"load_order": "20",
 			"description": "Open a terminal to a specific folder and optionally set environment variables",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/newterm/issues",
+			"load_order": "20",
 			"releases": [
 				{
 					"base": "https://github.com/codexns/newterm",
-					"tags": true,
+					"platforms": [
+						"*"
+					],
 					"sublime_text": "*",
-					"platforms": ["*"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "numpy",
-			"load_order": "01",
 			"description": "Python numpy module",
 			"author": "komsit37",
 			"issues": "https://github.com/komsit37/sublime-numpy/issues",
+			"load_order": "01",
 			"releases": [
 				{
 					"base": "https://github.com/komsit37/sublime-numpy",
-					"tags": true,
+					"platforms": [
+						"windows-x64",
+						"osx-x64",
+						"linux-x64"
+					],
 					"sublime_text": ">=3000",
-					"platforms": ["windows-x64", "osx-x64", "linux-x64"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "oauthlib",
-			"load_order": "50",
 			"description": "Python oauthlib module",
 			"author": "csch0",
 			"issues": "https://github.com/packagecontrol/oauthlib/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/oauthlib",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "ordereddict",
-			"load_order": "50",
 			"description": "Python ordereddict module",
 			"author": "FichteFoll",
 			"issues": "https://github.com/packagecontrol/ordereddict/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/ordereddict",
-					"tags": true,
-					"sublime_text": "<3000"
+					"sublime_text": "<3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "package_events",
-			"load_order": "20",
 			"description": "Allows Sublime Text packages to emit and listen for events",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/package_events/issues",
+			"load_order": "20",
 			"releases": [
 				{
 					"base": "https://github.com/codexns/package_events",
-					"tags": true,
+					"platforms": [
+						"*"
+					],
 					"sublime_text": "*",
-					"platforms": ["*"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "package_setting_context",
-			"load_order": "01",
 			"description": "Allow final user to disable key bindings with very few changes needed from the dev",
 			"author": "math2001",
 			"issues": "https://github.com/math2001/package_setting_context/issues",
+			"load_order": "01",
 			"releases": [
 				{
 					"base": "https://github.com/math2001/package_setting_context",
+					"platforms": [
+						"*"
+					],
 					"sublime_text": "*",
-					"platforms": ["*"],
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "paramiko",
-			"load_order": "51",
 			"description": "Python implementation of the SSHv2 protocol - http://paramiko-www.readthedocs.org/en/latest/index.html",
 			"author": "jlegewie",
 			"issues": "https://github.com/jlegewie/sublime-paramiko/issues",
+			"load_order": "51",
 			"releases": [
 				{
 					"base": "https://github.com/jlegewie/sublime-paramiko",
+					"platforms": [
+						"osx"
+					],
 					"sublime_text": ">=3000",
-					"platforms": ["osx"],
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "pathlib",
-			"load_order": "50",
 			"description": "Python pathlib module",
 			"author": "FichteFoll",
 			"issues": "https://github.com/packagecontrol/pathlib/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pathlib",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "pathtools",
-			"load_order": "10",
 			"description": "Path utilities for Python https://pypi.python.org/pypi/pathtools",
 			"author": "vovkkk",
 			"issues": "https://github.com/vovkkk/sublime-pathtools/issues",
+			"load_order": "10",
 			"releases": [
 				{
 					"base": "https://github.com/vovkkk/sublime-pathtools",
+					"platforms": [
+						"*"
+					],
 					"sublime_text": "*",
-					"platforms": ["*"],
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "pexpect",
-			"load_order": "10",
 			"description": "Python pexpect module",
 			"author": "varp",
 			"issues": "https://github.com/varp/sublime-pexpect/issues",
+			"load_order": "10",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
 					"base": "https://github.com/varp/sublime-pexpect",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "plantumlconnection",
-			"author": "evandrocoan",
-			"load_order": "50",
 			"description": "Python interface to a plantuml web service instead of having to run Java locally",
+			"author": "evandrocoan",
 			"issues": "https://github.com/evandrocoan/plantumlconnection/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/evandrocoan/plantumlconnection",
@@ -679,10 +725,10 @@
 		},
 		{
 			"name": "portalockerfile",
-			"author": "evandrocoan",
-			"load_order": "08",
 			"description": "An extended version of portalocker to lock files in Python using the with statement",
+			"author": "evandrocoan",
 			"issues": "https://github.com/evandroforks/portalockerfile/issues",
+			"load_order": "08",
 			"releases": [
 				{
 					"base": "https://github.com/evandroforks/portalockerfile",
@@ -693,39 +739,43 @@
 		},
 		{
 			"name": "psutil",
-			"load_order": "10",
 			"description": "Python psutil module",
 			"author": "randy3k",
 			"issues": "https://github.com/packagecontrol/psutil/issues",
+			"load_order": "10",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
 					"base": "https://github.com/packagecontrol/psutil",
-					"platforms": ["osx-x64", "windows", "linux"],
+					"platforms": [
+						"osx-x64",
+						"windows",
+						"linux"
+					],
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "ptyprocess",
-			"load_order": "40",
 			"description": "Python ptyprocess module",
 			"author": "randy3k",
 			"issues": "https://github.com/packagecontrol/ptyprocess/issues",
+			"load_order": "40",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
 					"base": "https://github.com/packagecontrol/ptyprocess",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "pushdownparser",
-			"author": "evandrocoan",
-			"load_order": "09",
 			"description": "A modern parsing library for Python, implementing Earley & LALR(1) and an easy interface",
+			"author": "evandrocoan",
 			"issues": "https://github.com/evandrocoan/pushdownparser/issues",
+			"load_order": "09",
 			"releases": [
 				{
 					"base": "https://github.com/evandrocoan/pushdownparser",
@@ -736,623 +786,650 @@
 		},
 		{
 			"name": "PyCrypto",
-			"load_order": "50",
 			"description": "Python Cryptography Toolkit - https://www.dlitz.net/software/pycrypto/",
 			"author": "jlegewie",
 			"issues": "https://github.com/jlegewie/sublime-PyCrypto/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/jlegewie/sublime-PyCrypto",
+					"platforms": [
+						"osx-x64"
+					],
 					"sublime_text": ">=3000",
-					"platforms": ["osx-x64"],
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "pyfispip",
-			"load_order": "50",
 			"description": " Python FIS MTM/PIP SQL/RPC Interface",
 			"author": "fopina",
 			"issues": "https://github.com/fopina/sublime-pyfispip/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/fopina/sublime-pyfispip",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "pygments",
-			"load_order": "01",
 			"description": "Python pygments module",
 			"author": "AndreasBackx",
 			"issues": "https://github.com/packagecontrol/pygments/issues",
+			"load_order": "01",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pygments",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "pymdownx",
-			"author": "facelessuser",
-			"load_order": "50",
 			"description": "PyMdown Extensions for Python Markdown",
+			"author": "facelessuser",
 			"issues": "https://github.com/facelessuser/sublime-pymdownx/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-pymdownx",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "pyte",
-			"author": "randy3k",
-			"load_order": "50",
 			"description": "Python pyte module",
+			"author": "randy3k",
 			"issues": "https://github.com/packagecontrol/pyte/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pyte",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "python-docx",
-			"load_order": "20",
 			"description": "Python DOCX Module",
 			"author": "WriteML",
 			"issues": "https://github.com/writeml/sublime-docx/issues",
+			"load_order": "20",
 			"releases": [
 				{
 					"base": "https://github.com/writeml/sublime-docx",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "python-jinja2",
-			"load_order": "51",
 			"description": "Python Jinja2 module",
 			"author": "FichteFoll",
 			"issues": "https://github.com/packagecontrol/jinja2/issues",
+			"load_order": "51",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/jinja2",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "python-markdown",
-			"author": "facelessuser",
-			"load_order": "50",
 			"description": "Python Markdown module",
+			"author": "facelessuser",
 			"issues": "https://github.com/facelessuser/sublime-markdown/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-markdown",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "python-pywin32",
-			"author": "randy3k",
-			"load_order": "50",
 			"description": "Pywin32 module",
+			"author": "randy3k",
 			"issues": "https://github.com/packagecontrol/pywin32/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pywin32",
-					"platforms": ["windows"],
-					"tags": true,
-					"sublime_text": ">=3000"
+					"platforms": [
+						"windows"
+					],
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "python-six",
-			"load_order": "01",
 			"description": "Python six library https://github.com/benjaminp/six",
 			"author": "jcoc611",
 			"issues": "https://github.com/packagecontrol/sublime-six/issues",
+			"load_order": "01",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/sublime-six",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "python-toml",
-			"load_order": "01",
 			"description": "Python lib for TOML",
 			"author": "Jimmy Girardet",
 			"issues": "https://github.com/jgirardet/sublime-toml/issues",
+			"load_order": "01",
 			"releases": [
 				{
 					"base": "https://github.com/jgirardet/sublime-toml",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "pytz",
-			"load_order": "50",
 			"description": "Python pytz module",
 			"author": "FichteFoll",
 			"issues": "https://github.com/packagecontrol/pytz/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pytz",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "pywinpty",
-			"author": "randy3k",
-			"load_order": "40",
 			"description": "Python winpty module",
+			"author": "randy3k",
 			"issues": "https://github.com/packagecontrol/pywinpty/issues",
+			"load_order": "40",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pywinpty",
-					"platforms": ["windows"],
-					"tags": true,
-					"sublime_text": ">=3000"
+					"platforms": [
+						"windows"
+					],
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "pyyaml",
-			"load_order": "50",
 			"description": "Python PyYAML module",
 			"author": "FichteFoll",
 			"issues": "https://github.com/packagecontrol/pyyaml/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pyyaml",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "pyzmq",
-			"load_order": "50",
 			"description": "Python ZMQ module",
 			"author": "randy3k",
 			"issues": "https://github.com/packagecontrol/pyzmq/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pyzmq",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "regex",
-			"author": "facelessuser",
-			"load_order": "50",
 			"description": "Regex Module",
+			"author": "facelessuser",
 			"issues": "https://github.com/facelessuser/sublime-regex/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-regex",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "requests",
-			"load_order": "50",
 			"description": "Python requests module",
 			"author": "FichteFoll",
 			"issues": "https://github.com/packagecontrol/requests/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/requests",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "requests-oauthlib",
-			"load_order": "51",
 			"description": "Python requests-oauthlib module",
 			"author": "csch0",
 			"issues": "https://github.com/packagecontrol/requests-oauthlib/issues",
+			"load_order": "51",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/requests-oauthlib",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "resumeback",
-			"load_order": "50",
 			"description": "Python resumeback module",
 			"author": "FichteFoll",
 			"issues": "https://github.com/packagecontrol/resumeback/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/resumeback",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "ruamel-yaml",
-			"load_order": "01",
 			"description": "Python ruamel.yaml module",
 			"author": "Thomas Smith",
 			"issues": "https://github.com/Thom1729/sublime-ruamel/issues",
+			"load_order": "01",
 			"releases": [
 				{
 					"base": "https://github.com/Thom1729/sublime-ruamel",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "rx",
-			"load_order": "01",
 			"description": "Reactive extensions for Python",
 			"author": "guillermooo",
 			"issues": "https://github.com/guillermooo/rxpyst/issues",
+			"load_order": "01",
 			"releases": [
 				{
 					"base": "https://github.com/guillermooo/rxpyst",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "sassc",
-			"load_order": "50",
 			"description": "Sassc binaries",
 			"author": "blitzrk",
 			"issues": "https://github.com/blitzrk/sublime_sassc/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/blitzrk/sublime_sassc",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "screeninfo",
-			"load_order": "99",
 			"description": "Fetch location and size of physical screens - https://github.com/rr-/screeninfo",
 			"author": "ggets",
 			"issues": "https://github.com/ggets/sublime-screeninfo/issues",
+			"load_order": "99",
 			"releases": [
 				{
 					"base": "https://github.com/ggets/sublime-screeninfo",
-					"tags": true,
+					"platforms": [
+						"*"
+					],
 					"sublime_text": "*",
-					"platforms": ["*"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "select-windows",
-			"load_order": "02",
 			"description": "Python select module for Sublime Text 2 on Windows",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/sublime-select-windows/issues",
+			"load_order": "02",
 			"releases": [
 				{
-					"sublime_text": "*",
 					"base": "https://github.com/codexns/sublime-select-windows",
+					"sublime_text": "*",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "serial",
-			"author": "pyserial",
-			"load_order": "50",
 			"description": "Python serial port access library",
+			"author": "pyserial",
 			"issues": "https://github.com/bisguzar/sublime-serial/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/bisguzar/sublime-serial",
-					"tags": true,
+					"platforms": [
+						"*"
+					],
 					"sublime_text": ">=3000",
-					"platforms": ["*"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "shellenv",
-			"load_order": "10",
 			"description": "Access a user's environmental variables as defined in their shell",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/shellenv/issues",
+			"load_order": "10",
 			"releases": [
 				{
 					"base": "https://github.com/codexns/shellenv",
-					"tags": true,
+					"platforms": [
+						"*"
+					],
 					"sublime_text": "*",
-					"platforms": ["*"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "speg",
-			"load_order": "50",
 			"description": "A PEG-based parser interpreter with memoization - https://github.com/avakar/speg",
 			"author": "idleberg",
 			"issues": "https://github.com/idleberg/sublime-speg/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/idleberg/sublime-speg",
-					"tags": true,
+					"platforms": [
+						"*"
+					],
 					"sublime_text": "*",
-					"platforms": ["*"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "sqlite3",
-			"load_order": "01",
 			"description": "Python _sqlite3 module",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/sublime-sqlite3/issues",
+			"load_order": "01",
 			"releases": [
 				{
 					"base": "https://github.com/codexns/sublime-sqlite3",
-					"tags": true,
+					"platforms": [
+						"windows",
+						"linux"
+					],
 					"sublime_text": "*",
-					"platforms": ["windows", "linux"]
+					"tags": true
 				},
 				{
 					"base": "https://github.com/codexns/sublime-sqlite3",
-					"tags": true,
+					"platforms": [
+						"osx"
+					],
 					"sublime_text": ">=3000",
-					"platforms": ["osx"]
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "ssl-linux",
-			"load_order": "01",
 			"description": "Python _ssl module for Linux",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/sublime-ssl-linux/issues",
+			"load_order": "01",
 			"releases": [
 				{
+					"platforms": [
+						"linux"
+					],
+					"sha256": "23f35f64458a0a14c99b1bb1bbc3cb04794c7361c4940e0a638d40f038acd377",
 					"sublime_text": "*",
-					"platforms": ["linux"],
-					"version": "1.0.2",
 					"url": "http://packagecontrol.io/ssl/1.0.2/ssl-linux.sublime-package",
-					"sha256": "23f35f64458a0a14c99b1bb1bbc3cb04794c7361c4940e0a638d40f038acd377"
+					"version": "1.0.2"
 				}
 			]
 		},
 		{
 			"name": "ssl-windows",
-			"load_order": "01",
 			"description": "Python _ssl module for Sublime Text 2 on Windows",
 			"author": "wbond",
 			"issues": "https://github.com/codexns/sublime-ssl-windows/issues",
+			"load_order": "01",
 			"releases": [
 				{
+					"platforms": [
+						"windows"
+					],
+					"sha256": "efe25e3bdf2e8f791d86327978aabe093c9597a6ceb8c2fb5438c1d810e02bea",
 					"sublime_text": "<3000",
-					"platforms": ["windows"],
-					"version": "1.0.0",
 					"url": "http://packagecontrol.io/ssl/1.0.0/ssl-windows.sublime-package",
-					"sha256": "efe25e3bdf2e8f791d86327978aabe093c9597a6ceb8c2fb5438c1d810e02bea"
+					"version": "1.0.0"
 				}
 			]
 		},
 		{
 			"name": "StyledPopup",
-			"load_order": "50",
 			"description": "Pyton module for Sublime Text to automatically style popups based on active color scheme.",
 			"author": "huot25",
 			"issues": "https://github.com/huot25/StyledPopup/issues",
+			"load_order": "50",
 			"releases": [
 				{
-					"sublime_text": ">=3070",
 					"base": "https://github.com/huot25/StyledPopup",
+					"sublime_text": ">=3070",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "sublime_lib",
-			"load_order": "01",
 			"description": "Utility library for frequently used functionality in Sublime Text library and convenience functions or classes",
 			"author": "Thomas Smith",
 			"issues": "https://github.com/SublimeText/sublime_lib/issues",
+			"load_order": "01",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
 					"base": "https://github.com/SublimeText/sublime_lib",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]
 		},
 		{
 			"name": "SublimeP4Python",
-			"load_order": "51",
 			"description": "Python module for the Perforce API, extracted from https://pypi.python.org/pypi/P4Python.",
 			"author": "mrelusive",
 			"issues": "https://github.com/claytonlemons/SublimeP4Python/issues",
+			"load_order": "51",
 			"releases": [
 				{
+					"base": "https://github.com/claytonlemons/SublimeP4Python",
+					"platforms": [
+						"windows"
+					],
 					"sublime_text": "*",
-					"platforms": ["windows"],
-					"tags": true,
-					"base": "https://github.com/claytonlemons/SublimeP4Python"
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "tabulate",
-			"load_order": "01",
 			"description": "Python tabulate module",
 			"author": "csch0",
 			"issues": "https://github.com/packagecontrol/tabulate/issues",
+			"load_order": "01",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/tabulate",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "TM1py",
-			"load_order": "99",
 			"description": "Python module for interfacing with IBM TM1 Planning Analytics",
 			"author": "MariusWirtz",
 			"issues": "https://github.com/ajmyers/TM1py/issues",
+			"load_order": "99",
 			"releases": [
 				{
 					"base": "https://github.com/ajmyers/TM1py",
-					"tags": true,
-					"sublime_text": ">3092"
+					"sublime_text": ">3092",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "typing",
-			"load_order": "50",
 			"description": "Python typing module",
 			"author": "FichteFoll",
 			"issues": "https://github.com/packagecontrol/typing/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/typing",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "watchdog",
-			"load_order": "20",
 			"description": "Python library to monitor filesystem events http://packages.python.org/watchdog/",
 			"author": "vovkkk",
 			"issues": "https://github.com/vovkkk/sublime-watchdog/issues",
+			"load_order": "20",
 			"releases": [
 				{
 					"base": "https://github.com/vovkkk/sublime-watchdog",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "wcmatch",
-			"author": "facelessuser",
-			"load_order": "55",
 			"description": "Python wcmatch module which provides enhanced file globbing and matching",
+			"author": "facelessuser",
 			"issues": "https://github.com/facelessuser/sublime-wcmatch/issues",
+			"load_order": "55",
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-wcmatch",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "wcwidth",
-			"author": "randy3k",
-			"load_order": "10",
 			"description": "Python wcwidth module",
+			"author": "randy3k",
 			"issues": "https://github.com/packagecontrol/wcwidth/issues",
+			"load_order": "10",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/wcwidth",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "websocket-client",
-			"load_order": "10",
 			"description": "Python websocket client library https://github.com/websocket-client/websocket-client",
 			"author": "jcoc611",
 			"issues": "https://github.com/packagecontrol/sublime-websocket-client/issues",
+			"load_order": "10",
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/sublime-websocket-client",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "xdotool",
-			"load_order": "50",
 			"description": "Automation tool on Linux",
 			"author": "randy3k",
 			"issues": "https://github.com/randy3k/sublime-xdotool/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/randy3k/sublime-xdotool",
-					"platforms": ["linux"],
-					"tags": true,
-					"sublime_text": "*"
+					"platforms": [
+						"linux"
+					],
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "xmltodict",
-			"load_order": "50",
 			"description": "Makes working with XML feel like you are working with JSON - https://github.com/martinblech/xmltodict",
 			"author": "idleberg",
 			"issues": "https://github.com/idleberg/sublime-xmltodict/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/idleberg/sublime-xmltodict",
-					"tags": true,
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},
 		{
 			"name": "yaml_macros_engine",
-			"load_order": "50",
 			"description": "Engine for YAML Macros",
 			"author": "Thomas Smith",
 			"issues": "https://github.com/Thom1729/yaml-macros-engine/issues",
+			"load_order": "50",
 			"releases": [
 				{
 					"base": "https://github.com/Thom1729/yaml-macros-engine",
-					"tags": true,
-					"sublime_text": ">=3000"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		}

--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -11,6 +11,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/nbeversl/anytree_sublime",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -25,6 +26,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/douglas-vaz/arrow",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -39,9 +41,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/dvhh/sublime-backports.lzma",
-					"platforms": [
-						"windows"
-					],
+					"platforms": ["windows"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -56,6 +56,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-backrefs",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -70,6 +71,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/KuttKatrea/sublime-better-settings",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -84,6 +86,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/revmischa/sublime-boto3",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -98,6 +101,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-bracex",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -112,9 +116,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/jlegewie/sublime-beautifulsoup4",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -129,9 +131,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/idleberg/sublime-bson",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -146,6 +146,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/codexns/sublime-bz2",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -160,6 +161,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/evandrocoan/channelmanager",
+					"platforms": ["*"],
 					"sublime_text": ">=3114",
 					"tags": true
 				}
@@ -174,6 +176,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/Umoxfo/sublime-chardet",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -188,6 +191,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-coloraide",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -202,6 +206,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/evandroforks/concurrentloghandler",
+					"platforms": ["*"],
 					"sublime_text": ">=3114",
 					"tags": true
 				}
@@ -216,9 +221,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/codexns/sublime-coverage",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -233,9 +236,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/adnanyaqoobvirk/sublime-crypt",
-					"platforms": [
-						"linux"
-					],
+					"platforms": ["linux"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -250,9 +251,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/idleberg/sublime-cson",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -267,9 +266,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/codexns/sublime-ctypes",
-					"platforms": [
-						"linux"
-					],
+					"platforms": ["linux"],
 					"sublime_text": "<3000",
 					"tags": true
 				}
@@ -284,6 +281,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/vovkkk/sublime-dateutil",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -298,6 +296,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/evandrocoan/debugtools",
+					"platforms": ["*"],
 					"sublime_text": ">=3114",
 					"tags": true
 				}
@@ -312,6 +311,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/idleberg/sublime-dicttoxml",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -326,6 +326,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/evandroforks/diffmatchpatch",
+					"platforms": ["*"],
 					"sublime_text": ">=3114",
 					"tags": true
 				}
@@ -340,9 +341,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/idleberg/sublime-emojitations",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": ">3000",
 					"tags": true
 				}
@@ -357,6 +356,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/enum",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -371,9 +371,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/codexns/sublime-fileio",
-					"platforms": [
-						"linux"
-					],
+					"platforms": ["linux"],
 					"sublime_text": "<3000",
 					"tags": true
 				}
@@ -388,6 +386,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/gateone-terminal",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -402,6 +401,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-gntp",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -416,9 +416,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/golang/sublime-config",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -433,6 +431,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/kylebebak/sublime-jsonschema",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -447,11 +446,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/eerohele/sublime-lxml",
-					"platforms": [
-						"osx-x64",
-						"linux",
-						"windows"
-					],
+					"platforms": ["osx-x64","linux","windows"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -466,9 +461,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/ehamiter/sublime-lzma",
-					"platforms": [
-						"osx-x64"
-					],
+					"platforms": ["osx-x64"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -483,6 +476,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/MarkupSafe",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -497,6 +491,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-markdown-popups",
+					"platforms": ["*"],
 					"sublime_text": ">=3124",
 					"tags": true
 				}
@@ -511,25 +506,19 @@
 			"releases": [
 				{
 					"base": "https://github.com/codexns/sublime-multiprocessing",
-					"platforms": [
-						"windows"
-					],
+					"platforms": ["windows"],
 					"sublime_text": "<3000",
 					"tags": true
 				},
 				{
 					"base": "https://github.com/codexns/sublime-multiprocessing",
-					"platforms": [
-						"osx"
-					],
+					"platforms": ["osx"],
 					"sublime_text": ">=3000",
 					"tags": true
 				},
 				{
 					"base": "https://github.com/codexns/sublime-multiprocessing",
-					"platforms": [
-						"linux"
-					],
+					"platforms": ["linux"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -544,6 +533,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/alimony/sublime-natsort",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -558,9 +548,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/codexns/newterm",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -575,11 +563,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/komsit37/sublime-numpy",
-					"platforms": [
-						"windows-x64",
-						"osx-x64",
-						"linux-x64"
-					],
+					"platforms": ["windows-x64","osx-x64","linux-x64"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -594,6 +578,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/oauthlib",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -608,6 +593,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/ordereddict",
+					"platforms": ["*"],
 					"sublime_text": "<3000",
 					"tags": true
 				}
@@ -622,9 +608,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/codexns/package_events",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -639,9 +623,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/math2001/package_setting_context",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -656,9 +638,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/jlegewie/sublime-paramiko",
-					"platforms": [
-						"osx"
-					],
+					"platforms": ["osx"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -673,6 +653,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pathlib",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -687,9 +668,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/vovkkk/sublime-pathtools",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -704,6 +683,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/varp/sublime-pexpect",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -718,6 +698,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/evandrocoan/plantumlconnection",
+					"platforms": ["*"],
 					"sublime_text": ">=3114",
 					"tags": true
 				}
@@ -732,6 +713,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/evandroforks/portalockerfile",
+					"platforms": ["*"],
 					"sublime_text": ">=3114",
 					"tags": true
 				}
@@ -746,11 +728,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/psutil",
-					"platforms": [
-						"osx-x64",
-						"windows",
-						"linux"
-					],
+					"platforms": ["osx-x64","windows","linux"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -765,6 +743,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/ptyprocess",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -779,6 +758,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/evandrocoan/pushdownparser",
+					"platforms": ["*"],
 					"sublime_text": ">=3114",
 					"tags": true
 				}
@@ -793,9 +773,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/jlegewie/sublime-PyCrypto",
-					"platforms": [
-						"osx-x64"
-					],
+					"platforms": ["osx-x64"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -810,6 +788,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/fopina/sublime-pyfispip",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -824,6 +803,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pygments",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -838,6 +818,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-pymdownx",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -852,6 +833,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pyte",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -866,6 +848,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/writeml/sublime-docx",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -880,6 +863,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/jinja2",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -894,6 +878,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-markdown",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -908,9 +893,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pywin32",
-					"platforms": [
-						"windows"
-					],
+					"platforms": ["windows"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -925,6 +908,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/sublime-six",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -939,6 +923,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/jgirardet/sublime-toml",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -953,6 +938,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pytz",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -967,9 +953,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pywinpty",
-					"platforms": [
-						"windows"
-					],
+					"platforms": ["windows"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -984,6 +968,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pyyaml",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -998,6 +983,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/pyzmq",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -1012,6 +998,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-regex",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -1026,6 +1013,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/requests",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1040,6 +1028,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/requests-oauthlib",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1054,6 +1043,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/resumeback",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1068,6 +1058,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/Thom1729/sublime-ruamel",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -1082,6 +1073,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/guillermooo/rxpyst",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -1096,6 +1088,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/blitzrk/sublime_sassc",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1110,9 +1103,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/ggets/sublime-screeninfo",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1127,6 +1118,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/codexns/sublime-select-windows",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1141,9 +1133,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/bisguzar/sublime-serial",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -1158,9 +1148,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/codexns/shellenv",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1175,9 +1163,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/idleberg/sublime-speg",
-					"platforms": [
-						"*"
-					],
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1192,18 +1178,13 @@
 			"releases": [
 				{
 					"base": "https://github.com/codexns/sublime-sqlite3",
-					"platforms": [
-						"windows",
-						"linux"
-					],
+					"platforms": ["windows","linux"],
 					"sublime_text": "*",
 					"tags": true
 				},
 				{
 					"base": "https://github.com/codexns/sublime-sqlite3",
-					"platforms": [
-						"osx"
-					],
+					"platforms": ["osx"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -1217,12 +1198,10 @@
 			"load_order": "01",
 			"releases": [
 				{
-					"platforms": [
-						"linux"
-					],
-					"sha256": "23f35f64458a0a14c99b1bb1bbc3cb04794c7361c4940e0a638d40f038acd377",
-					"sublime_text": "*",
 					"url": "http://packagecontrol.io/ssl/1.0.2/ssl-linux.sublime-package",
+					"sha256": "23f35f64458a0a14c99b1bb1bbc3cb04794c7361c4940e0a638d40f038acd377",
+					"platforms": ["linux"],
+					"sublime_text": "*",
 					"version": "1.0.2"
 				}
 			]
@@ -1235,12 +1214,10 @@
 			"load_order": "01",
 			"releases": [
 				{
-					"platforms": [
-						"windows"
-					],
-					"sha256": "efe25e3bdf2e8f791d86327978aabe093c9597a6ceb8c2fb5438c1d810e02bea",
-					"sublime_text": "<3000",
 					"url": "http://packagecontrol.io/ssl/1.0.0/ssl-windows.sublime-package",
+					"sha256": "efe25e3bdf2e8f791d86327978aabe093c9597a6ceb8c2fb5438c1d810e02bea",
+					"platforms": ["windows"],
+					"sublime_text": "<3000",
 					"version": "1.0.0"
 				}
 			]
@@ -1254,6 +1231,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/huot25/StyledPopup",
+					"platforms": ["*"],
 					"sublime_text": ">=3070",
 					"tags": true
 				}
@@ -1268,6 +1246,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/SublimeText/sublime_lib",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -1282,9 +1261,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/claytonlemons/SublimeP4Python",
-					"platforms": [
-						"windows"
-					],
+					"platforms": ["windows"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1299,6 +1276,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/tabulate",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1313,6 +1291,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/ajmyers/TM1py",
+					"platforms": ["*"],
 					"sublime_text": ">3092",
 					"tags": true
 				}
@@ -1327,6 +1306,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/typing",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1341,6 +1321,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/vovkkk/sublime-watchdog",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1355,6 +1336,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-wcmatch",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -1369,6 +1351,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/wcwidth",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -1383,6 +1366,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/packagecontrol/sublime-websocket-client",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1397,9 +1381,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/randy3k/sublime-xdotool",
-					"platforms": [
-						"linux"
-					],
+					"platforms": ["linux"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1414,6 +1396,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/idleberg/sublime-xmltodict",
+					"platforms": ["*"],
 					"sublime_text": "*",
 					"tags": true
 				}
@@ -1428,6 +1411,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/Thom1729/yaml-macros-engine",
+					"platforms": ["*"],
 					"sublime_text": ">=3000",
 					"tags": true
 				}


### PR DESCRIPTION
Tidy up dependencies.json

This PR introduces a common key sort order for all dependency entries to make transition to scheme 4.0.0 easier.

libraries: name, description, author, issues, load_oarder, releases

releases: base, platforms, sublime_text, tags

It doesn't change content.