### PR TITLE
Adjust SuperSettings readme URL

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -5280,6 +5280,7 @@
 		{
 			"name": "SuperSettings",
 			"details": "https://github.com/TobyGiacometti/SublimeSuperSettings",
+			"readme": "https://raw.githubusercontent.com/TobyGiacometti/SublimeSuperSettings/main/README.md",
 			"previous_names": ["Directory Settings"],
 			"releases": [
 				{


### PR DESCRIPTION
I have recently switched to using a `main` branch instead of a `master` branch. Since Package Control takes the readme from the `master` branch by default, I am now explicitly providing the readme URL.