### PR TITLE
Added the package WordingStatus

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -750,18 +750,6 @@
 			]
 		},
 		{
-			"name": "WordCount",
-			"details": "https://github.com/philipbelesky/WordCount",
-			"homepage": "https://github.com/titoBouzout/WordCount",
-			"author": "titoBouzout",
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"details": "https://github.com/SublimeText/WordHighlight",
 			"releases": [
 				{

--- a/repository/w.json
+++ b/repository/w.json
@@ -761,7 +761,8 @@
 		{
 			"name": "WordingStatus",
 			"details": "https://github.com/evandrocoan/WordingStatus",
-			"author": "evandrocoan",
+			"previous_names": ["WordCount"],
+			"author": ["titoBouzout", "evandrocoan"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/w.json
+++ b/repository/w.json
@@ -773,7 +773,6 @@
 		{
 			"name": "WordingStatus",
 			"details": "https://github.com/evandrocoan/WordingStatus",
-			"homepage": "https://github.com/evandrocoan/WordingStatus",
 			"author": "evandrocoan",
 			"releases": [
 				{

--- a/repository/w.json
+++ b/repository/w.json
@@ -771,6 +771,18 @@
 			]
 		},
 		{
+			"name": "WordingStatus",
+			"details": "https://github.com/evandrocoan/WordingStatus",
+			"homepage": "https://github.com/evandrocoan/WordingStatus",
+			"author": "evandrocoan",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Wordless",
 			"details": "https://github.com/welaika/Sublime-Text-Wordless",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a rewrite of WordCount (https://github.com/wbond/package_control_channel/issues/6907).

Fixes https://github.com/evandrocoan/WordingStatus/issues/5

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore