### PR TITLE
Add kdesrc-build

### DIFF
--- a/repository/k.json
+++ b/repository/k.json
@@ -90,6 +90,17 @@
 			]
 		},
 		{
+			"name": "kdesrc-build",
+			"details": "https://github.com/ratijas/kdesrc-build-sublime",
+			"labels": ["language syntax", "snippets", "completions", "kde"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Keep Lines With Word",
 			"details": "https://github.com/qianhk/KeepLinesWithWord",
 			"labels": ["text manipulation"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette. (None)
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view. (There are none)
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is LSP-like support for kdesrc-build tool's configuration files and build output syntax.

- https://github.com/ratijas/kdesrc-build-sublime
- https://invent.kde.org/sdk/kdesrc-build

There are no packages like it in Package Control.