### PR TITLE
Add Advanced Ansible Snippets

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -373,6 +373,17 @@
 			]
 		},
 		{
+			"name": "Advanced Ansible Snippets",
+			"details": "https://github.com/memoryleak/AdvancedAnsibleSnippets",
+			"labels": ["auto-complete", "snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Advanced Aria Templates snippets pack",
 			"details": "https://github.com/dpreussner/advanced-at-snippets-pack",
 			"labels": ["snippets"],


### PR DESCRIPTION
- [ x] I'm the package's author and/or maintainer.
- [ x] I have have read [the docs][1].
- [ x] I have tagged a release with a [semver][2] version number.
- [ x] My package repo has a description and a README describing what it's for and how to use it.
- [ x] My package doesn't add context menu entries. *
- [ x] My package doesn't add key bindings. **

My package is similar to AnsibleSnippets. However it should still be added because it has a more complete list of snippets and is up to date with the new Ansible syntax.
