### PR TITLE
Add Cataracted Dark

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -405,6 +405,17 @@
 			]
 		},
 		{
+			"name": "Cataracted Dark",
+			"details": "https://github.com/betraying/cataracted-dark-sublime-text",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Catkin Builder",
 			"details": "https://github.com/ZacharyTaylor/Catkin-Builder",
 			"labels": ["build system"],

--- a/repository/c.json
+++ b/repository/c.json
@@ -405,7 +405,7 @@
 			]
 		},
 		{
-			"name": "Cataracted Dark",
+			"name": "Cataracted Dark Color Scheme",
 			"details": "https://github.com/betraying/cataracted-dark-sublime-text",
 			"labels": ["color scheme"],
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is [Cataracted Dark Color Scheme](https://github.com/betraying/cataracted-dark-sublime-text).
There are no packages like it in Package Control.
