### PR TITLE
Remove "Material Theme"

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -923,17 +923,6 @@
 			]
 		},
 		{
-			"name": "Material Theme",
-			"details": "https://github.com/equinusocio/material-theme",
-			"labels": ["theme", "color scheme", "material"],
-			"releases": [
-				{
-					"sublime_text": ">=3103",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Material Theme - Appbar",
 			"details": "https://github.com/equinusocio/material-theme-appbar",
 			"labels": ["theme", "material design", "material theme"],


### PR DESCRIPTION
> It redirects to a vsc theme now, breaking the package for all existing users.

> Now it points to the one for VSCode: https://packagecontrol.io/packages/Material%20Theme
> Thus breaks ST people's setup: https://github.com/material-theme/vsc-material-theme/issues/1256
> And the dev team unlikely will restore that: https://twitter.com/materialtheme/status/1598567199756656640 

Noticed by @jfcherng 

We should aim to replace it with a fork that still works, but for now removing it from the index to prevent it from breaking more setups is the best course of action.