### PR TITLE
Re-add "Material Theme" with a fork

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -923,6 +923,17 @@
 			]
 		},
 		{
+			"name": "Material Theme",
+			"details": "https://github.com/SublimeText/material-theme",
+			"labels": ["theme", "color scheme", "material"],
+			"releases": [
+				{
+					"sublime_text": ">=3103",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Material Theme - Appbar",
 			"details": "https://github.com/equinusocio/material-theme-appbar",
 			"labels": ["theme", "material design", "material theme"],


### PR DESCRIPTION
Skipping the template because I know what I'm doing.

Re-add the package that has been removed in #8646, this time pointing to a fork in the SublimeText org.

This is a manually created repository that I pushed the contents of an older fork to and then modified. Using an actual fork here (via GitHub) would not have benefitted anyone because the original repository has been force-pushed to and does not maintain any of its original git history, fracturing the entire fork network at once.