### PR TITLE
Adding Unity Unit Tests for C Completions

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -372,20 +372,20 @@
 			]
 		},
 		{
-            		"name": "Unity Unit Testing for C Completions",
-            		"details": "https://github.com/pajacobson/unity-test-c",
-            		"labels": ["auto-complete", "snippets", "testing"],
-            		"releases": [
-                		{
-                    			"sublime_text": "<4000",
-                    			"tags": "st3-"
-                		},
-                		{
-                    			"sublime_text": ">=4000",
-                    			"tags": true
-                		}
-            		]
-        	},	
+			"name": "Unity Unit Testing for C Completions",
+			"details": "https://github.com/pajacobson/unity-test-c",
+			"labels": ["auto-complete", "snippets", "testing"],
+			"releases": [
+				{
+					"sublime_text": "<4000",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
 		{
 			"details": "https://github.com/UnicornForest/Unity3D",
 			"releases": [

--- a/repository/u.json
+++ b/repository/u.json
@@ -372,6 +372,21 @@
 			]
 		},
 		{
+            		"name": "Unity Unit Testing for C Completions",
+            		"details": "https://github.com/pajacobson/unity-test-c",
+            		"labels": ["auto-complete", "snippets", "testing"],
+            		"releases": [
+                		{
+                    			"sublime_text": "<4000",
+                    			"tags": "st3-"
+                		},
+                		{
+                    			"sublime_text": ">=4000",
+                    			"tags": true
+                		}
+            		]
+        	},	
+		{
 			"details": "https://github.com/UnicornForest/Unity3D",
 			"releases": [
 				{

--- a/repository/u.json
+++ b/repository/u.json
@@ -372,8 +372,8 @@
 			]
 		},
 		{
-			"name": "Unity Unit Testing for C Completions",
-			"details": "https://github.com/pajacobson/unity-test-c",
+			"name": "Unity Test Completions",
+			"details": "https://github.com/pajacobson/unity_test_completions",
 			"labels": ["auto-complete", "snippets", "testing"],
 			"releases": [
 				{


### PR DESCRIPTION
New package with completions for ThrowTheSwitch.org Unity Unit Testing framework

<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***

My package provides completions for ThrowTheSwitch.org's Unity C test framework.
There are no packages like it in Package Control.


<!-- 
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 

For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

For updates to existing packages:
If your package isn't using tag based releases,
please switch to tags now.
 -->

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
