### PR TITLE
Combine Unity Test Completion releases into single ST3+

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -377,11 +377,7 @@
 			"labels": ["auto-complete", "snippets", "testing"],
 			"releases": [
 				{
-					"sublime_text": "<4000",
-					"tags": "st3-"
-				},
-				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.

"Unity Test Completions" is already on Package Control. 
The PR removes seperate releases for ST3 and ST4 and replaces with a single ST3+ release.

There are no packages like it in Package Control.
