### PR TITLE
Add WSL Build package

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -1119,6 +1119,19 @@
 			]
 		},
 		{
+			"name": "WSL Build",
+			"details": "https://github.com/existentialmutt/wsl_build",
+			"description": "Create custom build systems for projects running in WSL2",
+			"labels": ["build system"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true,
+					"platforms": ["windows"]
+				}
+			]
+		},
+		{
 			"name": "Wux Weapp Snippets",
 			"description": "Wux Weapp Snippets Plugin for Sublime Text 2/3.",
 			"details": "https://github.com/wux-weapp/wux-weapp-sublime-snippets",


### PR DESCRIPTION


- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries.
- [X] My package doesn't add key bindings.

My package is WSL Build, an ExexCommand for creating build systems for projects running in WSL2

There are no packages like it in Package Control.

This is my first published Sublime Package so feedback is appreciated :)

Thank you!
