### PR TITLE
Adding Hog to the list of repositories

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -818,6 +818,16 @@
 			]
 		},
 		{
+			"name" : "Hog",
+			"details" : "https://github.com/Hog-CERN/HogSublime",
+			"releases" : [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Hogan Build",
 			"details": "https://github.com/individuo7/Hogan-Build",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a syntax highlighter for the list files of [Hog (HDL-on-git)](https://cern.ch/Hog), a tool to handle HDL code on git. Hog uses special files, called Hog list files, to list the source file required to generate the firmware project. This sublime package provides syntax support for these special files. 