### PR TITLE
Adding Pyisort to the list of repositories

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2947,13 +2947,10 @@
 		{
 			"name": "Pyisort",
 			"details": "https://github.com/returnchung/pyisort",
-			"issues": "https://github.com/returnchung/pyisort/issues",
-			"author": ["returnchung"],
 			"labels": ["formatting"],
 			"releases": [
 				{
 					"sublime_text": ">=4000",
-					"platforms": "*",
 					"tags": true
 				}
 			]

--- a/repository/p.json
+++ b/repository/p.json
@@ -2945,6 +2945,20 @@
 			]
 		},
 		{
+			"name": "Pyisort",
+			"details": "https://github.com/returnchung/pyisort",
+			"issues": "https://github.com/returnchung/pyisort/issues",
+			"author": ["returnchung"],
+			"labels": ["formatting"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"platforms": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/biermeester/Pylinter",
 			"labels": ["linting"],
 			"releases": [

--- a/repository/p.json
+++ b/repository/p.json
@@ -2950,7 +2950,7 @@
 			"labels": ["formatting"],
 			"releases": [
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs](https://packagecontrol.io/docs/submitting_a_package).
- [x] I have tagged a release with a [semver](https://semver.org/) version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes](https://www.git-scm.com/docs/gitattributes#_export_ignore) to exclude files from the package: images, test files, sublime-project/workspace.

My package is Python [isort](https://github.com/PyCQA/isort) formatter for Sublime Text.

My package is similar to `isort` and `isorted`. However it should still be added because `isort` is out of date for several years and all of them lack the flexibility for sublime settings or specific project settings. Besides, there are more supported isort command options can be configured and extended in the future.
