### PR TITLE
Update Ruby Slim for Sublime Text 4107+

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -2265,12 +2265,20 @@
 		},
 		{
 			"name": "Ruby Slim",
-			"details": "https://github.com/slim-template/ruby-slim.tmbundle",
+			"details": "https://github.com/SublimeText/Slim",
 			"previous_names": ["ruby-slim.tmbundle", "ruby-slim"],
 			"releases": [
 				{
-					"sublime_text": "*",
-					"branch": "master"
+					"sublime_text": "<4107",
+					"tags": "st2-"
+				},
+				{
+					"sublime_text": "4107 - 4130",
+					"tags": "4107-"
+				},
+				{
+					"sublime_text": ">=4131",
+					"tags": "4131-"
 				}
 			]
 		},


### PR DESCRIPTION
This PR re-targets "Ruby Slim" package to SublimeText organization. The repository is a fork of original ruby-slim.tmbundle to backup its history and provide backward compatible historic data for ST2 and 3.

The main purpose however is to provide a completely rewritten syntax definition for Sublime Text build 4107+, which is in no form compatible with or related with the original package.

As such...
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.
   _Tests and images are not excluded per design so external syntax test runners can download the archive and include tests. The preview image is included to be locally available for "Markown Image" package._

An issue to ask permission for re-targeting the package has been filed at https://github.com/slim-template/ruby-slim.tmbundle/issues/84. As the last commit in that repository dates back to 2018, I don't however expect any response. Would be glad about it though.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
