### PR TITLE
Renamed Cool & Clear for better discoverability

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3607,7 +3607,6 @@
 			"name": "Cool & Clear - Color Scheme",
 			"previous_names": ["Cool & Clear"],
 			"details": "https://github.com/Doodpants/Cool-and-Clear-Color-Scheme",
-			"description": "A tastefully minimal, high contrast, light-mode color scheme",
 			"author": "Karl von Laudermann",
 			"labels": ["color scheme"],
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -3604,6 +3604,18 @@
 			]
 		},
 		{
+			"name": "Cool & Clear",
+			"details": "https://github.com/Doodpants/Cool-and-Clear-Color-Scheme",
+			"author": "Karl von Laudermann",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": ">=3170",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CoolBase64",
 			"details": "https://github.com/coekuss/CoolBase64-sublime",
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -3604,8 +3604,10 @@
 			]
 		},
 		{
-			"name": "Cool & Clear",
+			"name": "Cool & Clear - Color Scheme",
+			"previous_names": ["Cool & Clear"],
 			"details": "https://github.com/Doodpants/Cool-and-Clear-Color-Scheme",
+			"description": "A tastefully minimal, high contrast, light-mode color scheme",
 			"author": "Karl von Laudermann",
 			"labels": ["color scheme"],
 			"releases": [


### PR DESCRIPTION
This change just modifies the entry for the "Cool & Clear" package, to rename it to "Cool & Clear - Color Scheme", so that it shows up in the results when people search for "color scheme" in Package Control. It also shortens the description text a little bit.