### PR TITLE
[Chef] Move chef package to tags

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -864,7 +864,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "main"
+					"tags": true
 				}
 			]
 		},

--- a/repository/c.json
+++ b/repository/c.json
@@ -864,7 +864,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"branch": "main"
 				}
 			]
 		},


### PR DESCRIPTION
SousChefs updated the default branch, so this needs to be updated as it currently shows missing  See https://github.com/sous-chefs/sublimechef/issues/45

I am now a maintainer of this package and have updated it to the current standards including gitattributes and using tags

- [x] I'm the package's maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore