### PR TITLE
Added ChatGPT Package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -766,6 +766,20 @@
 			]
 		},
 		{
+			"name": "ChatGPT",
+			"details": "https://github.com/eusonlito/Sublime-Text-ChatGPT",
+			"description" : "OpenAI ChatGPT connector",
+			"author": "Lito",
+			"labels": ["auto-complete"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true,
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "ChatScript Syntax",
 			"details": "https://github.com/kuzyn/chatscript-tmlanguage",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Related package https://github.com/eusonlito/Sublime-Text-ChatGPT

- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is ...

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
