### PR TITLE
Spin-off GitSavvy ST3 version

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -852,18 +852,13 @@
 		{
 			"name": "GitSavvy",
 			"details": "https://github.com/timbrel/GitSavvy",
-			"labels": [
-				"git",
-				"dashboard",
-				"inline",
-				"stage",
-				"patch"
-			],
-			"readme": "https://raw.githubusercontent.com/timbrel/GitSavvy/master/README.md",
-			"author": "divmain",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "<4000",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
GitSavvy will switch to ST4/py3.8 with the next (or so) release.  The plan is at least to only do patch releases for ST3.  We'll see.


