### PR TITLE
Add Dhall Syntax Highlighting

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -805,6 +805,17 @@
 			]
 		},
 		{
+			"name": "Dhall Syntax Highlighting",
+			"details": "https://github.com/kukimik/dhall-sublime-syntax-highlighting",
+			"labels": ["language syntax", "dhall"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Diagram",
 			"details": "https://github.com/jvantuyl/sublime_diagram_plugin",
 			"labels": ["diagrams", "plantuml"],


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***

My package is Dhall Syntax Highligting (a `.tmLanguage` definition for the [Dhall](https://dhall-lang.org/) language).

My package is similar to https://packagecontrol.io/packages/Dhall. However it should still be added because the Dhall package is no longer available (the github repo was deleted). I have a copy of the `.sublime-syntax` file from some version of the Dhall package (obtained somewhere on github), but I have no information about its licensing, so I think I can't just redestribute it.

This also explains why I do not obey the rule included in the review guidelines:

> Syntax packages should be named after the language, i.e. "LESS", not "LESS syntax" or "LESS highlighting" because syntaxes in ST do much more than just highlighting.

The name "Dhall" is already taken, by a non-existent package (see also https://github.com/wbond/packagecontrol.io/issues/154).

<!-- 
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 

For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

For updates to existing packages:
If your package isn't using tag based releases,
please switch to tags now.
 -->

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
