### PR TITLE
Add ExpandSelectionToComments package

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -1602,6 +1602,19 @@
 			]
 		},
 		{
+			"name": "ExpandSelectionToComments",
+			"details": "https://github.com/timfjord/ExpandSelectionToComments",
+			"labels": [
+				"expand", "selection", "comment"
+			],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Expand Selection by Paragraph",
 			"details": "https://github.com/natew/ExpandSelectionByParagraph",
 			"releases": [

--- a/repository/e.json
+++ b/repository/e.json
@@ -1602,19 +1602,6 @@
 			]
 		},
 		{
-			"name": "ExpandSelectionToComments",
-			"details": "https://github.com/timfjord/ExpandSelectionToComments",
-			"labels": [
-				"expand", "selection", "comment"
-			],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Expand Selection by Paragraph",
 			"details": "https://github.com/natew/ExpandSelectionByParagraph",
 			"releases": [
@@ -1705,6 +1692,19 @@
 			"name": "ExpandRegion",
 			"details": "https://github.com/aronwoost/sublime-expand-region",
 			"labels": ["text selection", "expand selection", "snippets", "code navigation"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "ExpandSelectionToComments",
+			"details": "https://github.com/timfjord/ExpandSelectionToComments",
+			"labels": [
+				"expand", "selection", "comment"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

The package expands the current selection to fully enclose the intersecting comment block

- works with multiple cursors
- supports soft undo
- supports comments divided with empty lines
- works with any language that has syntax highlighting

<!-- 
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 

For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

For updates to existing packages:
If your package isn't using tag based releases,
please switch to tags now.
 -->

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore