### PR TITLE
Add Easy Isort package

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -80,6 +80,18 @@
 			]
 		},
 		{
+			"name": "Easy Isort",
+			"details": "https://github.com/tiyujopite/easy_isort",
+			"labels": ["isort", "python"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true,
+					"dependencies": ["isort"]
+				}
+			]
+		},
+		{
 			"name": "Easy Open",
 			"details": "https://github.com/mjkaufer/Easy-Open",
 			"author": "mjkaufer",


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is [Easy Isort](https://github.com/tiyujopite/easy_isort), this is used to sort python files imports.

My package is similar to [isort](https://github.com/asfaltboy/sublime-text-isort-plugin) or [isorted](https://github.com/rimvaliulin/isorted). However it should still be added because these packages do not work as expected, or have a very complex configuration for the user. (I have decided to make my own package because after much testing I have not been able to get any of the two to work).


[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
