### PR TITLE
Add Python Web Scraping Snippets

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -3336,6 +3336,17 @@
 			]
 		},
 		{
+			"name": "Python Web Scraping Snippets",
+			"details": "https://github.com/futureprogrammer360/Python-Web-Scraping-Snippets",
+			"labels": ["snippets", "python", "web scraping", "auto-complete", "autocomplete", "completions"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "python-black",
 			"details": "https://github.com/thep0y/python-black",
 			"labels": [


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries.
- [X] My package doesn't add key bindings.
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.

My package is Python Web Scraping Snippets, a collection of snippets for Python web scraping.

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org