### PR TITLE
Update/takeover Gleam package

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -951,12 +951,12 @@
 		},
 		{
 			"name": "Gleam",
-			"details": "https://github.com/itsgreggreg/sublime-text-gleam",
+			"details": "https://github.com/digitalcora/sublime-text-gleam",
 			"labels": ["gleam", "language syntax"],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
-					"tags": true
+					"sublime_text": ">=4075",
+					"tags": "v"
 				}
 			]
 		},


### PR DESCRIPTION
- [x] I'm the package's author.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] **(N/A)** Any commands are available via the command palette.
- [x] **(N/A)** Preferences and keybindings are listed in the menu and the command palette, and open in split view.
- [x] My package is a syntax, and it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

### Context

[This package](https://github.com/digitalcora/sublime-text-gleam) supports the [Gleam](https://gleam.run/) programming language.

I'm proposing a takeover of the existing package named "Gleam", owned by @itsgreggreg ([source](https://github.com/itsgreggreg/sublime-text-gleam)), added in #8157. I installed this package as a user and reported a few bugs in it, and the owner responded by archiving the repo without a reply. I'm assuming this means they are no longer interested in maintaining it, and they don't seem to have any public contact info, so I've just tagged them here in case there is any objection.

Versus the original package, this one:

* ...has slightly better syntax support, and recognizes recent additions to the language (`use` expressions). It still doesn't do much "real" parsing, but I'd like to improve on this in the future for better meta scope coverage.

* ...doesn't have the "format on save" behavior (which was slightly broken, as the setting to turn it off didn't work, meaning lots of error pop-ups if it didn't work with your environment). Since Gleam's built-in formatter works with stdin/stdout, I reason this is better done by a tool like [Fmt](https://packagecontrol.io/packages/Fmt), and have included instructions for setting this up. Thanks to @braver in [this comment](https://github.com/wbond/package_control_channel/pull/8681#issuecomment-1410192199) for the pointer to Fmt.

* ...doesn't support Sublime Text 3, as it uses version 2 of the syntax highlighter. I don't think there is _currently_ anything in the syntax that requires this, but I'm wary of running into bugs that are unfixed in version 1, and followed the advice of the [official docs](https://www.sublimetext.com/docs/syntax.html#header) that "New syntaxes should target `2`".

Here are screenshots of the syntax in action, using some examples from the Gleam Language Tour:

* [Breakers](https://user-images.githubusercontent.com/394835/218580347-665bb929-9042-499a-80c5-2de0ed8f9fb7.png) (default light theme)
* [Mariana](https://user-images.githubusercontent.com/394835/218580361-242914a4-f560-47ad-9423-7065c218fbb8.png) (default dark theme)