### PR TITLE
[ghosttext] Update meta of existing package

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -419,7 +419,6 @@
 			"issues": "https://github.com/fregante/GhostText/issues",
 			"donate": "https://github.com/sponsors/fregante",
 			"homepage": "https://ghosttext.fregante.com",
-			"author": "fregante",
 			"previous_names": ["ChromeTextArea"],
 			"labels": [
 				"browser integration"

--- a/repository/g.json
+++ b/repository/g.json
@@ -416,7 +416,14 @@
 		{
 			"name": "GhostText",
 			"details": "https://github.com/GhostText/GhostText-for-SublimeText",
+			"issues": "https://github.com/fregante/GhostText/issues",
+			"donate": "https://github.com/sponsors/fregante",
+			"homepage": "https://ghosttext.fregante.com",
+			"author": "fregante",
 			"previous_names": ["ChromeTextArea"],
+			"labels": [
+				"browser integration"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] Any commands are available via the command palette.

No changes were made in the following or are unrelated:

- [ ] I have tagged a release with a [semver][2] version number.
- [ ] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is https://packagecontrol.io/packages/GhostText

I just added some more fields from https://raw.githubusercontent.com/wbond/package_control/master/example-repository.json



<!-- 
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 

For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

For updates to existing packages:
If your package isn't using tag based releases,
please switch to tags now.
 -->

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
