### PR TITLE
Add phpfmt8 package

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1342,29 +1342,29 @@
 			]
 		},
 		{
-            "name": "phpfmt",
-            "details": "https://github.com/nanch/phpfmt_stable",
-            "labels": ["language syntax", "formatter", "php", "formatting"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "platforms": "*",
-                    "tags": true
-                }
-            ]
-        },
-        {
-            "name": "phpfmt8",
-            "details": "https://github.com/driade/phpfmt8",
-            "labels": ["language syntax", "formatter", "php", "formatting"],
-            "releases": [
-                {
-                    "sublime_text": ">=3000",
-                    "platforms": "*",
-                    "tags": true
-                }
-            ]
-        },
+			"name": "phpfmt",
+			"details": "https://github.com/nanch/phpfmt_stable",
+			"labels": ["language syntax", "formatter", "php", "formatting"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "phpfmt8",
+			"details": "https://github.com/driade/phpfmt8",
+			"labels": ["language syntax", "formatter", "php", "formatting"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": "*",
+					"tags": true
+				}
+			]
+		},
 		{
 			"name": "PHPGrammar",
 			"details": "https://github.com/gerardroche/sublime-php-grammar",

--- a/repository/p.json
+++ b/repository/p.json
@@ -1355,7 +1355,7 @@
         },
         {
             "name": "phpfmt8",
-            "details": "https://github.com/driade/phpfmt-8",
+            "details": "https://github.com/driade/phpfmt8",
             "labels": ["language syntax", "formatter", "php", "formatting"],
             "releases": [
                 {

--- a/repository/p.json
+++ b/repository/p.json
@@ -1342,17 +1342,29 @@
 			]
 		},
 		{
-			"name": "phpfmt",
-			"details": "https://github.com/nanch/phpfmt_stable",
-			"labels": ["language syntax", "formatter", "php", "formatting"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"platforms": "*",
-					"tags": true
-				}
-			]
-		},
+            "name": "phpfmt",
+            "details": "https://github.com/nanch/phpfmt_stable",
+            "labels": ["language syntax", "formatter", "php", "formatting"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "platforms": "*",
+                    "tags": true
+                }
+            ]
+        },
+        {
+            "name": "phpfmt8",
+            "details": "https://github.com/driade/phpfmt-8",
+            "labels": ["language syntax", "formatter", "php", "formatting"],
+            "releases": [
+                {
+                    "sublime_text": ">=3000",
+                    "platforms": "*",
+                    "tags": true
+                }
+            ]
+        },
 		{
 			"name": "PHPGrammar",
 			"details": "https://github.com/gerardroche/sublime-php-grammar",

--- a/repository/p.json
+++ b/repository/p.json
@@ -1343,18 +1343,6 @@
 		},
 		{
 			"name": "phpfmt",
-			"details": "https://github.com/nanch/phpfmt_stable",
-			"labels": ["language syntax", "formatter", "php", "formatting"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"platforms": "*",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "phpfmt8",
 			"details": "https://github.com/driade/phpfmt8",
 			"labels": ["language syntax", "formatter", "php", "formatting"],
 			"releases": [


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [ ] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a clone of phpfmt but with php8 support
