### PR TITLE
Transfer ownership of archived Bats package and add ST4 support

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -261,7 +261,7 @@
 				"syntax",
 				"snippets",
 				"language syntax"
-			],
+			]
 		},
 		{
 			"name": "BazelSyntax",

--- a/repository/b.json
+++ b/repository/b.json
@@ -245,13 +245,23 @@
 		{
 			"name": "Bats",
 			"previous_names": ["Bats (Bash Automated Testing System)"],
-			"details": "https://github.com/sptndc/sublime-bats",
+			"details": "https://github.com/SublimeText/bash-automated-testing-system",
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": "<4000",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
 					"tags": true
 				}
-			]
+			],
+			"labels": [
+				"bash",
+				"syntax",
+				"snippets",
+				"language syntax"
+			],
 		},
 		{
 			"name": "BazelSyntax",


### PR DESCRIPTION
The previous repository was archived, so I forked it to the SublimeText org and added support for ST4.

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] If my package is a syntax it doesn't also add a color scheme. ***
