### PR TITLE
Added MatrixCalculator package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1047,6 +1047,17 @@
 			]
 		},
 		{
+			"name": "MatrixCalculator",
+			"details": "https://github.com/bradybhalla/sublime-matrix-calculator",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/jawb/Matrixify",
 			"releases": [
 				{


### PR DESCRIPTION

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [ ] My package doesn't add key bindings. (see note)
- [x] Any commands are available via the command palette.

My package is a matrix calculator for Sublime Text.  It can do in-text adition, mutliplication, row reduction, and inversion of matrices.  This package also formats matrices in a readable format and allows easy creation of matrices of any size.

There are no packages like it in Package Control.

Note: this package requires one key binding, which only runs when the user types something like `5x5` and then presses `tab`.  This is used to create an empty matrix, and because of the required text before the tab, this won't override any keybinds from other packages.



[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
