### PR TITLE
Re-Add Sublack4 

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -4123,6 +4123,17 @@
 			]
 		},
 		{
+			"name": "sublack4",
+			"details": "https://github.com/munkybutt/sublack",
+			"author": "MunkyButt",
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/yrammos/SubLilyPond",
 			"releases": [
 				{

--- a/repository/s.json
+++ b/repository/s.json
@@ -4125,6 +4125,8 @@
 		{
 			"name": "sublack4",
 			"details": "https://github.com/munkybutt/sublack",
+			"description": "Black formatting for sublime text 4, based on the sublack plugin.",
+			"labels": ["auto-format", "formatter", "black", "python"],
 			"author": "MunkyButt",
 			"releases": [
 				{


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a bridge between pythons black formatter and sublime 4

This is a refactored and updated version of sublack which is no longer actively developed:
https://github.com/wbond/package_control_channel/pull/8348