### PR TITLE
Update CopyRelativePath to tag-based releases

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3768,7 +3768,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries.  (I think it does and that's the whole reason it exists)
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

This switches CopyRelativePath from deprecated branch-based versioning to tag-based versioning as recommended by the docs.

The goal is ultimately for this release to become live in Package Control, as I had a contributor add a fix for python versioning in ST4.
https://github.com/bpicolo/CopyRelativePath/releases/tag/1.0.0
