### PR TITLE
Remove Sk-ST3

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2142,21 +2142,6 @@
 			]
 		},
 		{
-			"name": "Sk-ST3",
-			"description": "Skript Language Modern Syntax Highlighting. Skript is a Minecraft plugin that allows you to write codes with plain english and use it as plugins",
-			"details": "https://github.com/AyhamAl-Ali/sk-st3",
-			"homepage": "https://forums.skunity.com/resources/sk-st3-syntax-highlighting-open-source.710/",
-			"issues": "https://github.com/AyhamAl-Ali/sk-st3/issues",
-			"labels": ["language syntax", "color scheme"],
-			"author": "Ayham Al-Ali",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Skeleton Snippet",
 			"details": "https://github.com/rodrigoiii/skeleton-snippet",
 			"labels": ["auto complete", "snippet"],


### PR DESCRIPTION
The package was reported on Discord to cause all text to be rendered in bold and the reason is quite apparant:

There is not only one but two `Preferences.sublime-settings` file in this package that modifiy application-level settings including `font_options` but also `ignored_packages`, `font_size` and even `color_scheme`.

This level of intrusion from a third-party package is unacceptable by Package Control standards and the package should be either fixed by the author or removed from the index (it may always be added back when these problems are fixed).

https://github.com/AyhamAl-Ali/Sk-ST3/blob/2.6.3/ST3/Sk-ST3/%2B%20Material%20Theme%20(Recommended)/Preferences.sublime-settings https://github.com/AyhamAl-Ali/Sk-ST3/blob/2.6.3/ST3/Sk-ST3/Without%20Material%20Theme%20(Not%20Recommended)/Preferences.sublime-settings

Additionally, it also ships with two `.sublime-package` files that accomplish nothing since they'll end up inside a `.sublime-package` already and all the VSC code inside of the same package is additional dead weight from an ST package PoV.

https://github.com/AyhamAl-Ali/Sk-ST3/blob/2.6.3/ST3/Sk-ST3/%2B%20Material%20Theme%20(Recommended)/Material%20Theme.sublime-package (3.4MB)

cc @AyhamAl-Ali
