### PR TITLE
Added Super Templates

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -5224,6 +5224,17 @@
 			]
 		},
 		{
+			"name": "Super Templates",
+			"details": "https://github.com/WiseLibs/super-templates-syntax",
+			"labels": ["language syntax", "HTML", "template"],
+			"releases": [
+				{
+					"sublime_text": ">=3211",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Super-Awesome Paste",
 			"details": "https://github.com/huntie/super-awesome-paste",
 			"labels": ["text manipulation", "formatting"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

This package is the syntax definition for the HTML/XML templating language [`super-templates`](https://github.com/WiseLibs/super-templates).

There are no packages like it in Package Control.

<!-- 
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 
 -->

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
