### PR TITLE
Add CloseAllNoConfirm package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1585,6 +1585,17 @@
 			]
 		},
 		{
+			"name": "Close All without Confirmation",
+			"details": "https://github.com/ddbln/CloseAllNoConfirm",
+			"labels": ["file navigation", "files", "close files", "file close", "commands", "productivity", "utilities", "refactoring"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Close Oldest File",
 			"details": "https://github.com/jturcotte/SublimeCloseOldestFile",
 			"releases": [
@@ -1601,17 +1612,6 @@
 				{
 					"sublime_text": "<3000",
 					"branch": "master"
-				}
-			]
-		},
-		{
-			"name": "Close All without Confirmation",
-			"details": "https://github.com/ddbln/CloseAllNoConfirm",
-			"labels": ["File Management", "Close Files", "Files", "No Confirm", "Productivity", "Utility", "Refactoring"],
-			"releases": [
-				{
-					"sublime_text": ">=3092",
-					"tags": true
 				}
 			]
 		},

--- a/repository/c.json
+++ b/repository/c.json
@@ -1605,10 +1605,8 @@
 			]
 		},
 		{
-			"name": "CloseAllNoConfirm",
 			"details": "https://github.com/ddbln/CloseAllNoConfirm",
-			"description": "Instantly close all files (saved & unsaved) without confirmations.",
-			"labels": ["close", "files", "no confirm"],
+			"labels": ["File Management", "Close Files", "Files", "No Confirm", "Productivity", "Utility", "Refactoring"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/c.json
+++ b/repository/c.json
@@ -1605,6 +1605,18 @@
 			]
 		},
 		{
+			"name": "CloseAllNoConfirm",
+			"details": "https://github.com/ddbln/CloseAllNoConfirm",
+			"description": "Instantly close all files (saved & unsaved) without confirmations.",
+			"labels": ["close", "files", "no confirm"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CloseCommentTag",
 			"details": "https://github.com/Satoh-D/CloseCommentTag",
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -1605,6 +1605,7 @@
 			]
 		},
 		{
+			"name": "Close All without Confirmation",
 			"details": "https://github.com/ddbln/CloseAllNoConfirm",
 			"labels": ["File Management", "Close Files", "Files", "No Confirm", "Productivity", "Utility", "Refactoring"],
 			"releases": [


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is "CloseAllNoConfirm": Instantly close all unsaved (and saved) files in Sublime Text, ditching all confirmation dialogs. Cautious users can opt for a single prompt, if desired.

My package is similar to some existing packages that close files or windows. However, it should still be added because it specifically focuses on closing all files (saved and unsaved) without confirmation dialogs, providing a more streamlined and efficient user experience. This can be helpful in situations where there are many or huge numbers of files open (for example after a search and replace action in multiple files / a big project folder...) that one does not want to save. Saving all is easy and native in Sublime Text, but closing all (unsaved) files requires the user to confirm a dialogue for each file, hence this plugin. Additionally, it offers an optional single confirmation prompt to make it attractive for users who are more cautious, too.

<!--
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 

For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

--> I have reviewed the guidelines and ensured that my package:
• Has valid semantic version tags.
• Has a README that is understandable for new users and is in English.
• Does not include unnecessary files, such as package-metadata.json and *.pyc files.
• Has all commands discoverable via the Command Palette in a Default.sublime-commands file.
• Does not include unnecessary keybindings.
• Has Python plugins placed in the root folder of the repository.
• Has no dependencies on other packages.
• Does not use the .no-sublime-package file.

I believe my package adheres to the review guidelines and is ready for submission.

For updates to existing packages:
If your package isn't using tag based releases,
please switch to tags now.

<!--
[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
-->