### PR TITLE
add "JS Template String Converter" plugin

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -941,6 +941,7 @@
 		{
 			"name": "JS Template String Converter",
 			"details": "https://github.com/predragnikolic/JS-Template-String-Converter",
+			"labels": ["javascript", "typescript", "jsx", "vue", "svelte"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",

--- a/repository/j.json
+++ b/repository/j.json
@@ -939,6 +939,16 @@
 			]
 		},
 		{
+			"name": "JS Template String Converter",
+			"details": "https://github.com/predragnikolic/JS-Template-String-Converter",
+			"releases": [
+				{
+					"sublime_text": ">=4070",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "JS Var Shortcuts",
 			"details": "https://github.com/twolfson/sublime-js-var-shortcuts",
 			"labels": ["formatting", "text manipulation", "js", "javascript", "var", "variable"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is ... 
a plugin that converts converts regular strings to template strings as soon as the users types `${`
Please see the readme for more info https://github.com/predragnikolic/JS-Template-String-Converter#readme
 
it can be used in JavaScript, TypeScript, Svelte, Vue, JSX, TSX files.

<details>
<summary>I added a keybinding.</summary>


My package does add one keybinding, and that is this:
```

[
	 { "keys": ["{"], "command": "insert_snippet", "args": {"contents": "{$0}"}, "context":
        [
            { "key": "setting.auto_match_enabled" },
            { "key": "selector", "operand": "source.js | source.jsx | source.ts | source.tsx | text.html.ngx | text.html.svelte | text.html.vue" },
            { "key": "selection_empty", "match_all": true },
            { "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\\\$", "match_all": true }
        ]
    },
]
```

I added a lot of context checks to not mess with users defined keybindings.
What this keybinding does it it expands `{` to `{}` if the preceding_text text is `$`. 
I added this keybinding to fix case 1.

Usually ST is good at adding the closing bracket automatically,
but st will not add the closing bracket automatically if there is no space before the quote:
case 1 
```
"hello $|" -> type `{`
"hello ${|" -> no closing bracket because there is no space in front of " 
```
case 2
```
"hello $| " -> type `{`
"hello ${|} " -> a closing bracket because there is a space in front of " 
```

This plugin will make case 1 to behave like case 2:
```
"hello $|" -> type `{`
"hello ${|}" -> because of the keybinding from this plugin
```

</details>

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
