### PR TITLE
Update Wallaby packages.json location

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -116,6 +116,7 @@
 		"https://raw.githubusercontent.com/timonwong/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",
 		"https://raw.githubusercontent.com/vkocubinsky/sublime_packages/master/packages.json",
+		"https://raw.githubusercontent.com/wallabyjs/sublime-text-releases/main/packages.json",
 		"https://raw.githubusercontent.com/wallysalami/QuickLook/master/packages.json",
 		"https://raw.githubusercontent.com/weslly/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/wuub/requirementstxt/master/packages.json",
@@ -123,7 +124,6 @@
 		"https://raw.githubusercontent.com/x3ns/x3-alpha-theme/master/packages.json",
 		"https://raw.githubusercontent.com/xgenvn/InputHelper/master/packages.json",
 		"https://raw.githubusercontent.com/zfkun/sublime-kissy-snippets/master/packages.json",
-		"https://raw.githubusercontent.com/wallabyjs/sublime-text-releases/main/packages.json",
 		"https://sublimerge.com/packages.json",
 		"https://tinkerwell.app/plugins/sublime/packages.json"
 	]

--- a/channel.json
+++ b/channel.json
@@ -123,7 +123,7 @@
 		"https://raw.githubusercontent.com/x3ns/x3-alpha-theme/master/packages.json",
 		"https://raw.githubusercontent.com/xgenvn/InputHelper/master/packages.json",
 		"https://raw.githubusercontent.com/zfkun/sublime-kissy-snippets/master/packages.json",
-		"https://s3.amazonaws.com/wallaby-downloads/sublime/packages.json",
+		"https://raw.githubusercontent.com/wallabyjs/sublime-text-releases/main/packages.json",
 		"https://sublimerge.com/packages.json",
 		"https://tinkerwell.app/plugins/sublime/packages.json"
 	]


### PR DESCRIPTION
Update Wallaby packages.json to reside on github instead of s3 to fix s3 removing support for TLS 1.0

- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].

My packages are ...

Wallaby and Quokka (existing packages, just updated the manifest location):
* https://packagecontrol.io/packages/Wallaby
* https://packagecontrol.io/packages/Quokka