### PR TITLE
Added Ember & Glimmer Syntax

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -781,6 +781,17 @@
 			]
 		},
 		{
+			"name": "Ember & Glimmer Syntax",
+			"details": "https://github.com/robclancy/sublime-ember-syntax",
+			"labels": ["language syntax", "ember.js", "glimmer", "handlebars"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Ember CLI Snippets",
 			"details": "https://github.com/terminalvelocity/ember-cli-sublime-snippets",
 			"labels": ["snippets", "ember", "cli", "seeds"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is syntax highlighting for Ember/Glimmer templates. https://github.com/robclancy/sublime-ember-syntax

My package is similar to Ember Syntax and Handlebars syntax however it should still be added because the Handlebars one is for an older syntax and Ember Syntax is abandoned (even the repository is gone).