### PR TITLE
Added ImperatorTools and Victoria3Tools

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -358,6 +358,17 @@
 			]
 		},
 		{
+			"name": "ImperatorTools",
+			"details": "https://github.com/dementive/ImperatorTools",
+			"labels": ["language syntax", "auto-complete", "snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Import Cost",
 			"details": "https://github.com/julianburr/sublime-import-cost",
 			"labels": ["js", "npm", "webpack", "import-cost"],

--- a/repository/i.json
+++ b/repository/i.json
@@ -363,7 +363,7 @@
 			"labels": ["language syntax", "auto-complete", "snippets"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]

--- a/repository/v.json
+++ b/repository/v.json
@@ -313,7 +313,7 @@
 			"labels": ["language syntax", "auto-complete", "snippets"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]

--- a/repository/v.json
+++ b/repository/v.json
@@ -308,6 +308,17 @@
 			]
 		},
 		{
+			"name": "Victoria3Tools",
+			"details": "https://github.com/dementive/Victoria3Tools",
+			"labels": ["language syntax", "auto-complete", "snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "View Bookmarks",
 			"details": "https://github.com/adam-zethraeus/SublimeViewBookmarks",
 			"labels": ["bookmarks", "file navigation"],


### PR DESCRIPTION
- [*] I'm the package's author and/or maintainer.
- [*] I have have read [the docs][1].
- [*] I have tagged a release with a [semver][2] version number.
- [*] My package repo has a description and a README describing what it's for and how to use it.
- [*] My package doesn't add context menu entries. *
- [*] My package doesn't add key bindings. **
- [*] Any commands are available via the command palette.
- [*] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [*] If my package is a syntax it doesn't also add a color scheme. ***
- [*] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My packages are...

The only packages that offers any kind of support for Imperator Rome and Victoria 3 Scripting.
