### PR TITLE
Update MDX package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1208,14 +1208,26 @@
 			]
 		},
 		{
-			"name": "MDX Syntax Highlighting",
-			"details": "https://github.com/jonsuh/mdx-sublime",
-			"description": "Syntax highlighting for MDX, JSX in Markdown",
+			"name": "MDX",
+			"details": "https://github.com/SublimeText/MDX",
 			"labels": ["jsx", "language syntax", "markdown", "mdx"],
+			"previous_names": ["MDX Syntax Highlighting"],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
-					"tags": true
+					"sublime_text": "3143 - 3211",
+					"tags": "3143-"
+				},
+				{
+					"sublime_text": "4107 - 4125",
+					"tags": "4107-"
+				},
+				{
+					"sublime_text": "4126 - 4142",
+					"tags": "4126-"
+				},
+				{
+					"sublime_text": ">=4143",
+					"tags": "4143-"
 				}
 			]
 		},


### PR DESCRIPTION
This commit...

1. renames "MDX Syntax Highlighting" package to "MDX"
2. retargets the package to https://github.com/SublimeText/MDX
3. adds release entries for rewritten ST4 syntax definitions

The new repo provides a fully rewritten MDX syntax definition for ST4.

It forkes https://github.com/jonsuh/mdx-sublime only in order to

1. maintain the old (imperfect) syntax for ST3 and early ST4 releases
2. avoid adding another MDX package to packagecontrol.io

Release 1.0.0 and ongoing reguire ST4126+ and have nothing in common with the old syntax/package anymore. Answering the following questions with that in mind.


- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
