### PR TITLE
Update LESS package

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -769,17 +769,21 @@
 		},
 		{
 			"name": "LESS",
-			"details": "https://github.com/danro/LESS-sublime",
+			"details": "https://github.com/SublimeText/LESS",
 			"donate": "https://paypal.me/koenlageveen",
-			"labels": ["language syntax"],
+			"labels": ["language syntax", "auto-complete"],
 			"releases": [
 				{
-					"sublime_text": "<4000",
-					"tags": "st3-"
+					"sublime_text": "3143 - 4106",
+					"tags": "st3143-"
 				},
 				{
-					"sublime_text": ">=4000",
-					"tags": true
+					"sublime_text": "4107 - 4148",
+					"tags": "st4107-"
+				},
+				{
+					"sublime_text": ">=4149",
+					"tags": "st4149-"
 				}
 			]
 		},


### PR DESCRIPTION
This commit retargets LESS package to SublimeText org and adds relevant release entries to maintain current version (2.7.4) for ST3 and ship rewritten 3.0.0 to ST4107+
