### PR TITLE
Rename ToggleNeoVintageous → NeoVintageousToggle

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -291,6 +291,18 @@
 			]
 		},
 		{
+			"name": "NeoVintageousToggle",
+			"previous_names": ["ToggleNeoVintageous"],
+			"details": "https://github.com/NeoVintageous/NeoVintageousToggle",
+			"labels": ["neovintageous", "toggle", "vim", "vi", "vintage", "vintageous", "neovim", "nvim", "emulation", "emulator", "editor emulation"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "NESASM",
 			"details": "https://github.com/klaussilveira/SublimeNESASM",
 			"releases": [

--- a/repository/t.json
+++ b/repository/t.json
@@ -2790,17 +2790,6 @@
 			]
 		},
 		{
-			"name": "ToggleNeoVintageous",
-			"details": "https://github.com/NeoVintageous/ToggleNeoVintageous",
-			"labels": ["toggle", "vim", "vi", "vintage", "vintageous", "neovintageous", "neovim", "nvim", "emulation", "emulator", "editor emulation"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "ToggleQuotes",
 			"details": "https://github.com/spadgos/sublime-ToggleQuotes",
 			"releases": [


### PR DESCRIPTION
https://github.com/NeoVintageous/ToggleNeoVintageous

→

https://github.com/NeoVintageous/NeoVintageousToggle

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is NeoVintageousToggle

https://github.com/NeoVintageous/NeoVintageousToggle

There are no packages like it in Package Control.


[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
