### PR TITLE
Remove polyfill

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1738,17 +1738,6 @@
 			]
 		},
 		{
-			"name": "polyfill",
-			"details": "https://github.com/gerardroche/sublime-polyfill",
-			"labels": ["commands", "ctrlp", "file open", "navigation", "nerdtree", "sidebar", "toggles", "vim"],
-			"releases": [
-				{
-					"sublime_text": ">=3083",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Polygen",
 			"author": "Tristano Ajmone",
 			"details": "https://github.com/tajmone/sublime-polygen",


### PR DESCRIPTION
My package is no longer maintained and has since been replaced by other plugins.

https://github.com/gerardroche/sublime-polyfill

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

