### PR TITLE
Add NeoVintageousFiles

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -291,6 +291,17 @@
 			]
 		},
 		{
+			"name": "NeoVintageousFiles",
+			"details": "https://github.com/gerardroche/NeoVintageousFiles",
+			"labels": ["vim", "neovintageous", "vintageous", "vintage"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "NeoVintageousHighlightLine",
 			"details": "https://github.com/gerardroche/NeoVintageousHighlightLine",
 			"labels": ["neovintageous", "vim", "vi", "vintage", "vintageous", "neovim", "nvim"],


### PR DESCRIPTION


- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is NeoVintageousFiles

https://github.com/gerardroche/NeoVintageousFiles

There are no packages like it in Package Control.

Q: My package has two package dependencies for some functionality to work, SIdeBarTools and Origami. Is it possible to specify these dependencies to have them auto installed? Or some other solution other than instructing the user to install the dependencies?