### PR TITLE
Add ShowAsciiValue

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1591,6 +1591,17 @@
 			]
 		},
 		{
+			"name": "ShowAsciiValue",
+			"details": "https://github.com/gerardroche/sublime-show-ascii-value",
+			"labels": ["status bar"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ShowDefinitionEx",
 			"description": "Visually showing definition",
 			"details": "https://github.com/jk4837/ShowDefinitionEx",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is ShowAsciiValue

There are no packages like it in Package Control.