### PR TITLE
add KDL syntax highlighting package

### DIFF
--- a/repository/k.json
+++ b/repository/k.json
@@ -101,6 +101,17 @@
 			]
 		},
 		{
+			"name": "KDL",
+			"details": "https://github.com/eugenesvk/sublime-KDL",
+			"labels": ["KDL", "language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4075",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Keep Lines With Word",
 			"details": "https://github.com/qianhk/KeepLinesWithWord",
 			"labels": ["text manipulation"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [ ] ± My package doesn't add key bindings. ** 
  It overrides quotes `'`/`"` to add a nicety of autopair after "\b" in KDL strings, so doesn't create any new __key__ bindings
- [x] (no commands) Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
  Don't think quote overrides need to be listed
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a syntax highlighting package for the [KDL cuddly document language](https://kdl.dev)
There are no packages like it in Package Control.

<!-- 
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 

For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition
 -->

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
