### PR TITLE
Make GitDiffView backwards compatible with ST3

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -644,7 +644,12 @@
 			"labels": ["git", "diff"],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": "<4000",
+					"platforms": ["osx", "linux"],
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
 					"platforms": ["osx", "linux"],
 					"tags": true
 				}


### PR DESCRIPTION
Hello, 
I decided to update the GitDiffView plugin and only support Python 3.8 forward,
but I don't want to break ST3 users, so I created this PR.

I created a release tag for ST3 -> https://github.com/predragnikolic/sublime-git-diff-view/releases/tag/st3-0.5.0
I am not sure if I need to do anything else, if you spot something off, please say.