### PR TITLE
Add LaravelTestingCompletions

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -396,6 +396,17 @@
 			]
 		},
 		{
+			"name": "LaravelTestingCompletions",
+			"details": "https://github.com/gerardroche/sublime-laravel-testing-completions",
+			"labels": ["laravel", "completions", "auto-complete"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Lark Grammar Syntax",
 			"details": "https://github.com/lark-parser/lark_syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION
https://github.com/gerardroche/sublime-laravel-testing-completions

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is LaravelTestingCompletions, a completions pack for Laravel Testing.

There are no packages like it in Package Control.