### PR TITLE
Add GotoDefinitionSplit

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1709,6 +1709,17 @@
 			]
 		},
 		{
+			"name": "GotoDefinitionSplit",
+			"details": "https://github.com/gerardroche/sublime-goto-definition-split",
+			"labels": ["file navigation"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/jtdeng/GoToDoc",
 			"previous_names": ["Goto Golang Document"],
 			"releases": [


### PR DESCRIPTION
https://github.com/gerardroche/sublime-goto-definition-split

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. 
  **A context menu item is added to Goto Definition Split**
- [ ] My package doesn't add key bindings.
  **Key bindings are added to override the goto definition keybinding. This is intentional. The point of the plugin is change the Goto Definition in split to split by group instead of by tab.**
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is GotoDefinitionSplit. Change Goto Definition in split to split by group instead of split by tab.

There are no packages like it in Package Control.