### PR TITLE
Update MonokaiFree

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -2364,11 +2364,15 @@
 		{
 			"name": "MonokaiFree",
 			"details": "https://github.com/gerardroche/sublime-monokai-free",
-			"labels": ["color scheme"],
+			"labels": ["monokai", "color scheme"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=4000",
 					"tags": true
+				},
+				{
+					"sublime_text": "<4000",
+					"tags": "st3-"
 				}
 			]
 		},


### PR DESCRIPTION
https://github.com/gerardroche/sublime-monokai-free

The newer versions of MonokaiFree are going to drop support for the tmTheme format of its color scheme.