### PR TITLE
Dissolve old packages.json for "Logs Colorize"

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -111,7 +111,6 @@
 		"https://raw.githubusercontent.com/thecotne/smart_less_build/master/package.json",
 		"https://raw.githubusercontent.com/thecotne/subl-protocol/master/package.json",
 		"https://raw.githubusercontent.com/thinkv/sublime-elfinder/master/packages.json",
-		"https://raw.githubusercontent.com/tiger2wander/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/tillig/SublimeMSBuild/master/packages.json",
 		"https://raw.githubusercontent.com/timonwong/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",

--- a/repository/l.json
+++ b/repository/l.json
@@ -1591,6 +1591,17 @@
 			]
 		},
 		{
+			"name": "Logs Colorize",
+			"author": "Uoc Nguyen",
+			"homepage": "https://github.com/uocnb/SublimeText2-Logs",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Logstash Syntax Highlighting",
 			"details": "https://github.com/nir0s/sublime-logstash-syntax-highlighter",
 			"labels": ["language syntax", "syntax", "highlighting"],


### PR DESCRIPTION
Noticed this randomly while searching for a different package.

- The github username was updated to reflect the rename.
- The package supports all ST version since it only provides tmLanguage syntax definitions.

cc @uocnb 