### PR TITLE
Adding JsonSymbolsAndColorSyntax

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -1267,6 +1267,17 @@
 			]
 		},
 		{
+			"name": "JsonSymbolsAndColorSyntax",
+			"details": "https://github.com/Monox18/JsonSymbolsAndColorSyntax/",
+			"labels": ["json", "code navigation", "formatting", "color scheme", "language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "JsonTree",
 			"details": "https://github.com/Flyclops/JsonTree",
 			"labels": ["json", "tree", "search"],

--- a/repository/j.json
+++ b/repository/j.json
@@ -1139,6 +1139,17 @@
 			]
 		},
 		{
+			"name": "Json Colors And Navigation",
+			"details": "https://github.com/Monox18/JsonColorsAndNavigation/",
+			"labels": ["json", "code navigation", "formatting", "color scheme", "language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "JSON Key-Value",
 			"details": "https://github.com/aurule/json-kv",
 			"labels": ["language syntax", "json"],
@@ -1262,17 +1273,6 @@
 			"releases": [
 				{
 					"sublime_text": ">=3092",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "JsonSymbolsAndColorSyntax",
-			"details": "https://github.com/Monox18/JsonSymbolsAndColorSyntax/",
-			"labels": ["json", "code navigation", "formatting", "color scheme", "language syntax"],
-			"releases": [
-				{
-					"sublime_text": "*",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is ...

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
