### PR TITLE
Update MonokaiFree version constraints

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -2367,11 +2367,11 @@
 			"labels": ["monokai", "color scheme"],
 			"releases": [
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=3211",
 					"tags": true
 				},
 				{
-					"sublime_text": "<4000",
+					"sublime_text": "<3211",
 					"tags": "st3-"
 				}
 			]


### PR DESCRIPTION
In v2.0.0 I dropped support for the old tmTheme color scheme. Originally I thought only ST4 supported the new color schemes, but it seems that the new color scheme works fine since at least build 3211. So I've updated the versions constraints to allow users on >=3211 to be upgraded to the latest version.

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is MonokaiFree
https://github.com/gerardroche/sublime-monokai-free

There are no packages like it in Package Control.
