### PR TITLE
Added ConvertKit Plugin

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3606,6 +3606,16 @@
 			]
 		},
 		{
+			"name": "ConvertKit",
+			"details": "https://github.com/paschembri/convertkit_plugin",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CookLang",
 			"details": "https://github.com/cooklang/CookSublime",
 			"releases": [


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.

My package is a plugin for managing ConvertKit tags

There are no packages like it in Package Control.