### PR TITLE
Add GoTo File package

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1651,6 +1651,16 @@
 			]
 		},
 		{
+			"name": "GoTo File",
+			"details": "https://github.com/ryuukk/goto_file",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Goto Related",
 			"details": "https://github.com/schreifels/sublime-goto-related",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package provides an alternative to GotoAnything

When user only want to switch file, GotoAnything is distracting, because:

- it flickers the screen on each keystrone
- it preview file on each keystroke
- it hides the path you were reading on the file since it previews a different file on each keystroke
- it preview files you don't care about (why preview a.c aa.c aaa.c aaaa.c if i only want file aaaaaaa.c?)

GoTo File lists files from opened folders, caches them to avoid useless I/O and properly categorize them


There are no packages like it in Package Control.

Repo: https://github.com/ryuukk/goto_file