### PR TITLE
Fix Tryton Snippets details.

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -3396,7 +3396,7 @@
 		},
 		{
 			"name": "Tryton Snippets",
-			"details": "https://gitlab.com/datalifeit/sublimetext-tryton-snippets",
+			"details": "https://github.com/datalifeit/sublimetext-tryton-snippets",
 			"labels": ["tryton", "snippets"],
 			"releases": [
 				{


### PR DESCRIPTION
After PR [8753](https://github.com/wbond/package_control_channel/pull/8753), the package is not available for install.
In [packagecontrol.io](https://packagecontrol.io/packages/Tryton%20Snippets) appears the following message
`Package info was unavailable last time crawler ran. Invalid "details" value "https://gitlab.com/datalifeit/sublimetext-tryton-snippets" for one of the packages in the repository /var/www/packagecontrol.io/channel/repository.json.`
I guess it's because it's a gitlab repository, so we've migrated the repository to Github.