### PR TITLE
Add Apex Syntax

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1411,6 +1411,17 @@
 			]
 		},
 		{
+			"name": "Apex",
+			"details": "https://github.com/SublimeText/Apex",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4126",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Apex Intention Actions",
 			"details": "https://github.com/nchursin/ApexIntentionActions",
 			"labels": ["snippets", "apex", "salesforce", "intention", "autocompletion"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a syntax definition package for Salesforce Apex based on ST4126+'s Java syntax.

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
