### PR TITLE
Add NeoVintageous packages Colemak and Dvorak

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -302,6 +302,28 @@
 			]
 		},
 		{
+			"name": "NeoVintageousColemak",
+			"details": "https://github.com/gerardroche/NeoVintageousColemak",
+			"labels": ["vim", "neovintageous", "vintageous", "vintage"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "NeoVintageousDvorak",
+			"details": "https://github.com/gerardroche/NeoVintageousDvorak",
+			"labels": ["vim", "neovintageous", "vintageous", "vintage"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "NeoVintageousFiles",
 			"details": "https://github.com/gerardroche/NeoVintageousFiles",
 			"labels": ["vim", "neovintageous", "vintageous", "vintage"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My packages are [NeoVintageous](https://github.com/NeoVintageous/NeoVintageous) plugins that support alternate keyboard mappings: [NeoVintageousDvorak](https://github.com/gerardroche/NeoVintageousDvorak) and [NeoVintageousColemak](https://github.com/gerardroche/NeoVintageousColemak). 

I made them individual packages so users can contribute to the mappings packages without the burden of having to understand the internals of NeoVintageous. Also, as an example of how to use the source feature.

NeoVintageous v1.32 will be available soon. It eases the setup of both packages by allowing users the ability autoload the mappings packages. 

~I'm marking this as a Draft until I've released v1.32, which should be some time next week. :sparkles: :cake: :rocket:~

There are no packages like it in Package Control.