### PR TITLE
CK3 Tools Package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1269,6 +1269,17 @@
 			]
 		},
 		{
+			"name": "CK3 Tools",
+			"details": "https://github.com/SnowCrystalPDS/CK3-Tools",
+			"labels": ["CK3", "Crusader Kings 3"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Claat Snippets",
 			"details": "https://github.com/ucl-casa-ce/claat-snippets-sublime",
 			"homepage": "https://www.connected-environments.org",


### PR DESCRIPTION
Added a package for Crusader Kings 3 Sublime tools used by the CK3 team, so it can be used by modders if they so wish.

- [X ] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] If my package is a syntax it doesn't also add a color scheme. (It does add a color scheme, but it is only used by the team for very minor specific additions. All the other stuff can be used by all color schemes)
- [X] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").

My package is ...
There are no packages like it in Package Control.
