### PR TITLE
add VS Code Dark Modern Color Scheme

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -597,6 +597,18 @@
 				}
 			]
 		},
+        {
+            "name": "Visual Studio Color Scheme",
+            "details": "https://github.com/rexarvind/visual_studio_code_color_scheme",
+            "issues": "https://github.com/rexarvind/visual_studio_code_color_scheme/issues",
+            "labels": ["color scheme"],
+            "releases":[
+                {
+                    "sublime_text": "*",
+                    "tags": true
+                }
+            ]
+        },
 		{
 			"name": "Visual Studio Dark",
 			"details": "https://github.com/nikeee/visual-studio-dark",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is to have VS Code like Dark Modern Color Scheme in Sublime Text

There are no packages like it in Package Control.