### PR TITLE
Add FabricEngine Package

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -46,9 +46,9 @@
 		{
 			"name": "FabricEngine",
 			"details": "https://github.com/stepcg/SublimeFabricEngineSyntax",
+			"labels": ["FabricEngine", "VOSS", "language syntax"],
 			"releases": [
 				{
-					"labels": ["FabricEngine", "VOSS", "language syntax"],
 					"sublime_text": "*",
 					"tags": true
 				}

--- a/repository/f.json
+++ b/repository/f.json
@@ -46,7 +46,7 @@
 		{
 			"name": "FabricEngine",
 			"details": "https://github.com/stepcg/SublimeFabricEngineSyntax",
-			"labels": ["FabricEngine", "VOSS", "language syntax"],
+			"labels": ["VOSS", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/f.json
+++ b/repository/f.json
@@ -48,6 +48,7 @@
 			"details": "https://github.com/stepcg/SublimeFabricEngineSyntax",
 			"releases": [
 				{
+					"labels": ["FabricEngine", "VOSS", "language syntax"],
 					"sublime_text": "*",
 					"tags": true
 				}

--- a/repository/f.json
+++ b/repository/f.json
@@ -44,6 +44,16 @@
 			]
 		},
 		{
+			"name": "FabricEngine",
+			"details": "https://github.com/stepcg/SublimeFabricEngineSyntax",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Facebook Material Theme",
 			"details": "https://github.com/ridewn/material-theme",
 			"labels": ["theme", "color scheme", "material", "facebook"],


### PR DESCRIPTION
Add FabricEngine package repository definition in f.json

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is similar to some other switch config file syntax highlighting packages for other networking vendors but is unique in that it supports the specific syntax of the Extreme FabricEngine switch platform, which is incompatible with other syntax definitions.

Note: The repo name is more generic but overridden so the package name is set to just "FabricEngine" per the naming guidelines.