### PR TITLE
Add Gitk and Khan

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -830,6 +830,17 @@
 			]
 		},
 		{
+			"name": "Gitk",
+			"details": "https://github.com/gerardroche/sublime-gitk",
+			"labels": ["git"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "GitlabIntegrate",
 			"details": "https://github.com/SnoringFrog/GitlabIntegrate",
 			"labels": ["gitlab", "issues"],

--- a/repository/k.json
+++ b/repository/k.json
@@ -243,6 +243,17 @@
 			]
 		},
 		{
+			"name": "Khan",
+			"details": "https://github.com/gerardroche/sublime-khan",
+			"labels": ["utilities"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Kick Assembler (C64)",
 			"details": "https://github.com/Swoffa/SublimeKickAssemblerC64",
 			"labels": ["language syntax", "build system", "snippets"],


### PR DESCRIPTION
**Gitk**

Launch gitk from within Sublime.

**Khan**

Add, remove, and clear rulers at the current cursor using the command palette.

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My packages are:

- **Gitk**: Launch gitk from within Sublime.
- **Khan**: Add, remove, and clear rulers at the current cursor using the command palette.

My rulers package, Kkan, is similar to others, but it should be added anyways. It is a simple, lightweight, command-palette only, package.