### PR TITLE
add Prettierd Format

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2247,6 +2247,18 @@
 			]
 		},
 		{
+			"name": "Prettierd Format",
+			"details": "https://github.com/smastrom/sublime-prettierd-format",
+			"author": "Simone Mastromattei",
+			"labels": ["prettier", "prettierd", "format"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Pretty EDN",
 			"details": "https://github.com/oakmac/sublime-pretty-edn",
 			"author": "Chris Oakman",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

There are no packages like it in Package Control.

Repo: https://github.com/smastrom/sublime-prettierd-format
