### PR TITLE
Add SBNF

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -14,6 +14,7 @@
 		"https://raw.githubusercontent.com/amazedkoumei/SublimeKnifeSolo/master/packages.json",
 		"https://raw.githubusercontent.com/Andr3as/Sublime-SurroundWith/master/packages.json",
 		"https://raw.githubusercontent.com/apophys/sublime-packages/master/packages.json",
+		"https://raw.githubusercontent.com/BenjaminSchaaf/sbnf/master/package_control/packages.json",
 		"https://raw.githubusercontent.com/blachniet/sublime-mimosa/master/packages.json",
 		"https://raw.githubusercontent.com/blake-regalia/linked-data.syntaxes/master/channels/sublime/package-control.json",
 		"https://raw.githubusercontent.com/blueplanet/sublime-text-2-octopress/master/packages.json",


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is SBNF

I'm not 100% sure if the older tags are a problem. The newest tag and all future ones are on a different orphan branch that includes binaries.

There are no packages like it in Package Control.