### PR TITLE
Add Flexoki Color Scheme

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1182,7 +1182,7 @@
 		{
 			"name": "Flexoki Color Scheme",
 			"details": "https://github.com/kepano/flexoki-sublime",
-			"labels": ["color-scheme"],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/f.json
+++ b/repository/f.json
@@ -1180,6 +1180,17 @@
 			]
 		},
 		{
+			"name": "Flexoki Color Scheme",
+			"details": "https://github.com/kepano/flexoki-sublime",
+			"labels": ["color-scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Flight JS Snippets",
 			"details": "https://github.com/cameronhunter/flight-js-snippets",
 			"labels": ["snippets"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is [Flexoki](https://github.com/kepano/flexoki-sublime)

There are no packages like it in Package Control.