### PR TITLE
Maintanance: Remove duplicate information from package info

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2561,7 +2561,6 @@
 			"details": "https://github.com/wistful/SublimeAutoPEP8",
 			"labels": ["linting", "formatting"],
 			"readme": "https://raw.githubusercontent.com/wistful/SublimeAutoPEP8/master/Readme.md",
-			"issues": "https://github.com/wistful/SublimeAutoPEP8/issues",
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/b.json
+++ b/repository/b.json
@@ -1425,7 +1425,6 @@
 		{
 			"name": "BreakLines",
 			"details": "https://github.com/Moojuiceman/BreakLines",
-			"issues": "https://github.com/Moojuiceman/BreakLines/issues",
 			"labels": ["break", "group", "split", "separate", "lines"],
 			"releases": [
 				{

--- a/repository/c.json
+++ b/repository/c.json
@@ -4318,7 +4318,6 @@
 			"labels": ["linting", "formatting", "code style"],
 			"author": "molee1905",
 			"readme": "https://raw.githubusercontent.com/cslint/sublime-cslint/master/README.md",
-			"issues": "https://github.com/cslint/sublime-cslint/issues",
 			"releases": [
 				{
 					"sublime_text": ">=3124",

--- a/repository/e.json
+++ b/repository/e.json
@@ -372,7 +372,6 @@
 			"name": "EdgeOS",
 			"description": "Syntax highlighting for EdgeMax EdgeOS.",
 			"details": "https://github.com/lojoja/sublime-syntax-edgeos",
-			"issues": "https://github.com/lojoja/sublime-syntax-edgeos/issues",
 			"readme": "https://raw.githubusercontent.com/lojoja/sublime-syntax-edgeos/master/README.md",
 			"author": "lojoja",
 			"labels": ["language syntax"],
@@ -441,7 +440,6 @@
 			"author": "Tony Ennis",
 			"description" : "Send text to the editmode API & insert a snippet in its place.",
 			"details": "https://github.com/tonyennis145/editmode-sublime",
-			"issues": "https://github.com/tonyennis145/editmode-sublime/issues",
 			"labels": ["snippets", "utilities"],
 			"previous_names": ["Chunks"],
 			"releases": [

--- a/repository/h.json
+++ b/repository/h.json
@@ -1390,7 +1390,6 @@
 			"name": "HTTP Headers Reindent",
 			"details": "https://github.com/T0nyX1ang/HttpHeadersReindent",
 			"author": "Tony Xiang",
-			"description": "A tool to reindent http header file from Fiddler to Python dictionary format",
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1447,7 +1446,6 @@
 		{
 			"name": "HttpUnit",
 			"details": "https://github.com/gaohuia/HttpUnit",
-			"issues" : "https://github.com/gaohuia/HttpUnit/issues",
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/j.json
+++ b/repository/j.json
@@ -800,7 +800,6 @@
 			"name": "Jq",
 			"details": "https://gitlab.com/jiehong/sublime_jq",
 			"readme": "https://gitlab.com/jiehong/sublime_jq/-/raw/master/README.md",
-			"issues": "https://gitlab.com/jiehong/sublime_jq/-/issues",
 			"labels": ["interactive", "jq", "json"],
 			"releases": [
 				{

--- a/repository/l.json
+++ b/repository/l.json
@@ -277,7 +277,6 @@
 		{
 			"name": "Laravel Colour Scheme",
 			"details": "https://github.com/michaeldyrynda/Laravel.tmTheme",
-			"issues": "https://github.com/michaeldyrynda/Laravel.tmTheme/issues",
 			"homepage": "https://dyrynda.com.au",
 			"author": "michaeldyrynda",
 			"labels": ["color scheme", "light color scheme", "laravel", "laravel docs", "laravel color scheme"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -86,7 +86,6 @@
 			"name": "SaltUI",
 			"description": "SaltUI Component Snippets for Sublime",
 			"details": "https://github.com/recurrying/salt-snippet-plugin-for-sublime",
-			"issues": "https://github.com/recurrying/salt-snippet-plugin-for-sublime/issues",
 			"labels": ["SaltUI", "snippets"],
 			"releases": [
 				{
@@ -99,7 +98,6 @@
 			"name": "SAMB",
 			"description" : "SAMB (server assembly framework) syntax and snippets",
 			"details": "https://github.com/cheikhshift/samb-sublime",
-			"issues": "https://github.com/cheikhshift/samb-sublime/issues",
 			"labels": ["SAMB syntax highlight", "snippets"],
 			"releases": [
 				{
@@ -1446,7 +1444,6 @@
 			"name": "Sheller",
 			"description": "A brand new package to work with Command Prompt without using Command Prompt.",
 			"details": "https://github.com/bantya/Sheller",
-			"issues": "https://github.com/bantya/Sheller/issues",
 			"labels": ["shell", "cmd", "directory", "files"],
 			"releases": [
 				{
@@ -2480,8 +2477,6 @@
 			"name": "SmartIM",
 			"details": "https://github.com/icymind/SmartIM",
 			"description": "reset input method to us when enter normal_mode, and restore previous input method when you enter insert_mode",
-			"homepage": "https://github.com/icymind/SmartIM",
-			"issues": "https://github.com/icymind/SmartIM/issues",
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2543,8 +2538,6 @@
 		{
 			"name": "Smithy",
 			"description": "Syntax Support for Smithy IDL.",
-			"homepage": "https://github.com/albe-rosado/sublime-smithy",
-			"issues": "https://github.com/albe-rosado/sublime-smithy/issues",
 			"details": "https://github.com/albe-rosado/sublime-smithy",
 			"labels": ["language syntax"],
 			"releases": [
@@ -5710,7 +5703,6 @@
 			"name": "SwitchPanel",
 			"description": "Switch which ouput panel to display",
 			"details": "https://github.com/stoivo/sublime_switch_panel",
-			"issues": "https://github.com/stoivo/sublime_switch_panel/issues",
 			"labels": ["panel"],
 			"releases": [
 				{
@@ -5785,7 +5777,6 @@
 			"name": "Sync Merge Scheme",
 			"description": "Sync UI Schemes between Sublime Text and Sublime Merge",
 			"details": "https://github.com/rafmjr/SyncMergeScheme",
-			"issues": "https://github.com/rafmjr/SyncMergeScheme/issues",
 			"labels": ["color scheme", "merge", "utilities", "diff/merge"],
 			"releases": [
 				{
@@ -5862,7 +5853,6 @@
 			"name": "Syncrow",
 			"description": "Create and Sync Snippets.",
 			"details": "https://github.com/Afzal7/syncrow",
-			"issues": "https://github.com/Afzal7/syncrow/issues",
 			"homepage": "https://syncrow.herokuapp.com",
 			"author": "Afzal7",
 			"labels": ["syncrow", "create", "synchronize", "snippets"],
@@ -5886,7 +5876,6 @@
 		{
 			"name": "Synonymizer",
 			"details": "https://github.com/A5308Y/sublime-synonymizer",
-			"issues": "https://github.com/A5308Y/sublime-synonymizer/issues",
 			"author": "A5308Y",
 			"labels": ["naming"],
 			"releases": [
@@ -6093,7 +6082,6 @@
 			"description": "Syntax Highlighting, smart snippets, autocompletion, code navigation and more for Verilog and SystemVerilog",
 			"details": "https://github.com/TheClams/SystemVerilog",
 			"homepage": "http://sv-doc.readthedocs.org/en/latest",
-			"issues": "https://github.com/TheClams/SystemVerilog/issues",
 			"labels": ["language syntax", "snippets", "completion"],
 			"releases": [
 				{


### PR DESCRIPTION
If "details" field is given, "description", "issues", ... are resolved automatically from "details"'s url, so explicitly defining duplicated information is not needed.
