### PR TITLE
Fix missing "Logs Colorize" details

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1607,7 +1607,7 @@
 		{
 			"name": "Logs Colorize",
 			"author": "Uoc Nguyen",
-			"homepage": "https://github.com/uocnb/SublimeText2-Logs",
+			"details": "https://github.com/uocnb/SublimeText2-Logs",
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
This PR fixes missing `"details"` field in `Logs Colorize` package.

The package is therefore marked "missing" at packagecontrol.io at the moment.