### PR TITLE
Add UL4 syntax highlighting

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -93,7 +93,7 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=4107",
 					"tags": true
 				}
 			]

--- a/repository/u.json
+++ b/repository/u.json
@@ -88,6 +88,17 @@
 			]
 		},
 		{
+			"name": "UL4",
+			"details": "https://github.com/LivingLogic/LivingLogic.SublimeText.UL4",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Ultimate Dark",
 			"details": "https://github.com/rubjo/ultimate-dark",
 			"labels": ["dark", "color scheme"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.
