### PR TITLE
Prevent installation of MagicPython on ST4

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -185,7 +185,7 @@
 			"labels": ["language syntax", "python"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<4000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
There is very little reason to do this when the default syntax definition is much better due to using the `sublime-syntax` format, follows the scope naming standards and is actively maintained, because this package hasn't had a tag pushed in 4 years despite seeing *some* changes, albeit the last one over a year ago.

A pull request asking for clarification of the support status for ST4 has not been answered for 8 months.
https://github.com/MagicStack/MagicPython/pull/255

cc @vpetrovykh (FYI)