### PR TITLE
Add AutoProjects

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2514,6 +2514,17 @@
 			]
 		},
 		{
+			"name": "AutoProjects",
+			"details": "https://github.com/SublimeText/AutoProjects",
+			"labels": ["folder", "project"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/SublimeText/AutoSelect",
 			"releases": [
 				{


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a tiny helper to automatically open folders as projects, to mimic behavior of VS Code's `.vscode` directory.

There are no packages like it in Package Control.

Folder2Project seems to have somewhat a comparable scope, but only opens existing projects for a file already open in ST.

My package however targets workflows where users open folders in ST via context menu but actually want them to be treated as ST project with all its advantages.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
