### PR TITLE
Added ToggleSidebarFocus plugin

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2717,6 +2717,16 @@
 			]
 		},
 		{
+			"name": "Toggle Sidebar Focus",
+			"details": "https://github.com/educbraga/ToggleSidebarFocus",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},	
+		{
 			"name": "Toggle Symbol to String",
 			"details": "https://github.com/zoomix/SublimeToggleSymbol",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs](https://packagecontrol.io/docs/submitting_a_package)
- [x] I have tagged a release with a [semver](https://semver.org/) version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes](https://www.git-scm.com/docs/gitattributes#_export_ignore) to exclude files from the package: images, test files, sublime-project/workspace.

My package is [ToggleSidebarFocus](https://github.com/educbraga/ToggleSidebarFocus)
A plugin for Sublime Text that allows you to open, focus, and close the sidebar using the same keyboard shortcut.

There are no packages like it in Package Control.