### PR TITLE
Add JunLang

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -68,6 +68,7 @@
 		"https://raw.githubusercontent.com/keeganstreet/sublime-specificity/master/packages.json",
 		"https://raw.githubusercontent.com/kik0220/sublimetext_japanize/master/packages.json",
 		"https://raw.githubusercontent.com/kylederkacz/lettuce-farmer/master/packages.json",
+		"https://github.com/Jun-Software/JunLang_package/raw/package/package.json",
 		"https://raw.githubusercontent.com/leporo/SublimeYammy/master/packages.json",
 		"https://raw.githubusercontent.com/lifted-studios/AutoCopyright/master/packages.json",
 		"https://raw.githubusercontent.com/lucifr/CNPunctuationAutopair/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -68,7 +68,7 @@
 		"https://raw.githubusercontent.com/keeganstreet/sublime-specificity/master/packages.json",
 		"https://raw.githubusercontent.com/kik0220/sublimetext_japanize/master/packages.json",
 		"https://raw.githubusercontent.com/kylederkacz/lettuce-farmer/master/packages.json",
-		"https://github.com/Jun-Software/JunLang_package/raw/package/package.json",
+		"https://raw.githubusercontent.com/Jun-Software/JunLang_package/package/package.json",
 		"https://raw.githubusercontent.com/leporo/SublimeYammy/master/packages.json",
 		"https://raw.githubusercontent.com/lifted-studios/AutoCopyright/master/packages.json",
 		"https://raw.githubusercontent.com/lucifr/CNPunctuationAutopair/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -68,7 +68,6 @@
 		"https://raw.githubusercontent.com/keeganstreet/sublime-specificity/master/packages.json",
 		"https://raw.githubusercontent.com/kik0220/sublimetext_japanize/master/packages.json",
 		"https://raw.githubusercontent.com/kylederkacz/lettuce-farmer/master/packages.json",
-		"https://raw.githubusercontent.com/Jun-Software/JunLang_package/package/package.json",
 		"https://raw.githubusercontent.com/leporo/SublimeYammy/master/packages.json",
 		"https://raw.githubusercontent.com/lifted-studios/AutoCopyright/master/packages.json",
 		"https://raw.githubusercontent.com/lucifr/CNPunctuationAutopair/master/packages.json",

--- a/repository/j.json
+++ b/repository/j.json
@@ -1407,7 +1407,7 @@
 		{
 			"name": "JunLang", 
 			"details": "https://github.com/Jun-Software/JunLang_package",
-			"labels": ["JunLang"],
+			"labels": ["JunLang", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/j.json
+++ b/repository/j.json
@@ -1405,6 +1405,17 @@
 			]
 		},
 		{
+			"name": "JunLang", 
+			"details": "https://github.com/Jun-Software/JunLang_package",
+			"labels": ["JunLang"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Junos",
 			"details": "https://github.com/nprintz/junos-sublime-pkg",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is `JunLang`

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
