### PR TITLE
Fix Mermaid Tag Prefix

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1353,7 +1353,7 @@
 				},
 				{
 					"sublime_text": ">=4050",
-					"tags": "st4-"
+					"tags": "st4-v"
 				}
 			]
 		},


### PR DESCRIPTION
This commit renames tag prefix `st4-` to `st4-v` as upstream repository names release tags `st4-v{semver}`.

ST4 specific releases have therefore not yet been shipped to clients.
