### PR TITLE
Add TreeSitter package

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -3296,6 +3296,24 @@
 			]
 		},
 		{
+			"name": "TreeSitter",
+			"details": "https://github.com/sublime-treesitter/TreeSitter",
+			"labels": [
+				"tree-sitter",
+				"navigation",
+				"selection",
+				"symbols",
+				"parsers"
+			],
+			"author": "kylebebak",
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "TreeTop",
 			"details": "https://github.com/royvandewater/Sublime2-TreeTop",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number. **[See 1.0.0 here](https://github.com/sublime-treesitter/TreeSitter/releases/tag/1.0.0)**
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace. **There are no such files in this repo**

This package provides other Sublime Text packages with a performant and flexible interface to [Tree-sitter](https://tree-sitter.github.io/tree-sitter/).

It also provides commands to:

- Get a Tree-sitter `Tree` by its buffer id, or get trees for all tracked buffers
- Subscribe to tree changes in any buffer in real time using `sublime_plugin.EventListener`
- Get a tree from a string of code
- Get a node from a point or selection
- Select ancestor, descendant, sibling, or "cousin" nodes
- Query a tree, walk a tree
- Goto symbols returned by tree queries

There are no packages like it in Package Control. See more in the package README: https://github.com/sublime-treesitter/treesitter
