### PR TITLE
Add the "evscript" package

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -1440,6 +1440,17 @@
 			]
 		},
 		{
+			"name": "evscript",
+			"details": "https://github.com/ISSOtm/sublime-evscript",
+			"labels": ["language syntax", "game boy", "RGBDS"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Exact Quick Find",
 			"details": "https://github.com/aafulei/sublime-exact-quick-find",
 			"author": "Aaron Fu Lei",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette. (None.)
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace. (There are none.)

My package is a new syntax definition, with no accessories for now. (I'll add some goodies in a later release, e.g. "shell config"; but I want to move on for a while.)

There are no packages like it in Package Control. (The language is really niche.)

- [x] For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
