### PR TITLE
Add PRQL syntax highlighting

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2741,6 +2741,17 @@
 			]
 		},
 		{
+			"name": "PRQL",
+			"details": "https://github.com/PRQL/sublime-prql",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Pseudo Block Mode",
 			"details": "https://github.com/guija/pseudo_block_mode",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a syntax highlighter for [PRQL](https://prql-lang.org/).

PRQL is a modern language for transforming data — a simple, powerful, pipelined SQL replacement.

There are no packages like it in Package Control.


[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
