### PR TITLE
Add ERB Formatter

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -1173,6 +1173,16 @@
 			]
 		},
 		{
+			"name": "ERB Formatter",
+			"details": "https://github.com/gobijan/ERBFormatter",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "ERB Snippets",
 			"details": "https://github.com/matthewrobertson/ERB-Sublime-Snippets",
 			"labels": ["snippets"],

--- a/repository/e.json
+++ b/repository/e.json
@@ -1175,7 +1175,7 @@
 		{
 			"name": "ERB Formatter",
 			"details": "https://github.com/gobijan/ERBFormatter",
-			"labels": ["ERB", "formatter"],
+			"labels": ["ERB", "formatter", "Ruby"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/e.json
+++ b/repository/e.json
@@ -1175,7 +1175,7 @@
 		{
 			"name": "ERB Formatter",
 			"details": "https://github.com/gobijan/ERBFormatter",
-			"labels": ["ERB", "formatter", "Ruby"],
+			"labels": ["ERB", "formatter", "Ruby", "Rails"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/e.json
+++ b/repository/e.json
@@ -1175,10 +1175,11 @@
 		{
 			"name": "ERB Formatter",
 			"details": "https://github.com/gobijan/ERBFormatter",
+			"labels": ["ERB", "formatter"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION

- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.


My package is a formatter for ERB files often used in Ruby on Rails applications.
There are no packages like it in Package Control.
