### PR TITLE
Take-over Compare Side-By-Side

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3150,7 +3150,11 @@
 			"labels": ["diff", "compare", "comparison"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<4000",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]

--- a/repository/c.json
+++ b/repository/c.json
@@ -3146,8 +3146,7 @@
 		},
 		{
 			"name": "Compare Side-By-Side",
-			"details": "https://bitbucket.org/dougty/sublime-compare-side-by-side",
-			"author": "Doug Ty",
+			"details": "https://github.com/kaste/Compare-Side-By-Side",
 			"labels": ["diff", "compare", "comparison"],
 			"releases": [
 				{


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].  Yeah, at some point but it's been a while.
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is https://github.com/kaste/Compare-Side-By-Side forked from https://bitbucket.org/dougty/sublime-compare-side-by-side/

The original repo has not been updated to work with ST4.  The PRs were ignored.  There is no interaction at all.  The hosted screenshots (now removed from the README) have been deleted.  

- This is a minimal take-over, just making it work.  The repo history is intact.
+ (Change:) Doesn't add global key bindings, ie. it uses contextualized bindings 🚀 
+ (Change:) Uses the standard `edit_settings` in the main menu for editing the settings in split view fashion
+ (Change:) Runs on py3.8

Actually I'm running this (my) version for years now and it should be on PC.  I just hoped initially someone else would make it.  Now I do.  
