### PR TITLE
Split release channels of MoveTab

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -2537,8 +2537,12 @@
 			"details": "https://github.com/SublimeText/MoveTab",
 			"releases": [
 				{
-					"sublime_text": "*",
-					"branch": "master"
+					"sublime_text": ">=4000",
+					"tags": true
+				},
+				{
+					"sublime_text": "<4000",
+					"tags": "st3-v"
 				}
 			]
 		},


### PR DESCRIPTION
Just splitting into two release channels after breaking compatibility with Python 3.3.