### PR TITLE
Add the "Redo" package

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -863,6 +863,17 @@
 			]
 		},
 		{
+			"name": "Redo",
+			"details": "https://github.com/ISSOtm/sublime-redo",
+			"labels": ["redo", "language syntax", "build system"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Redux Snippets",
 			"details": "https://github.com/reduxframework/snippets_sublime",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette. (It's a build system.)
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package adds support for [the Redo build system](https://redo.rtfd.io/), adding a build system and syntax definition.

There are no packages like it in Package Control.

For bonus points, also considered how the review guidelines apply to this package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
