### PR TITLE
Add ColorSchemeCategorizer package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2758,6 +2758,16 @@
 			]
 		},
 		{
+			"name": "Color Scheme Categorizer",
+			"details": "https://github.com/maxim/ColorSchemeCategorizer",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Color Schemes by carlcalderon",
 			"details": "https://github.com/carlcalderon/sublime-color-schemes",
 			"labels": ["color scheme"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.

My package is ColorSchemeCategorizer — a way to list and select light and dark color schemes separately.

There are no packages like it in Package Control.