### PR TITLE
GitHub Desktop to replace Git​Hub.app Menu

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -30,7 +30,6 @@
 		"https://raw.githubusercontent.com/connec/Open-in-ConEmu/master/packages.json",
 		"https://raw.githubusercontent.com/corbinian/GrowlNotifier/master/packages.json",
 		"https://raw.githubusercontent.com/csch0/SublimeText-Packages/master/packages.json",
-		"https://raw.githubusercontent.com/csytan/sublime-text-2-github/master/packages.json",
 		"https://raw.githubusercontent.com/damccull/sublimetext-SolarizedToggle/master/packages.json",
 		"https://raw.githubusercontent.com/danielmagnussons/orgmode/master/packages.json",
 		"https://raw.githubusercontent.com/danielobrien/sublime-DLX-syntax/master/packages.json",

--- a/repository/g.json
+++ b/repository/g.json
@@ -701,7 +701,7 @@
 			]
 		},
 		{
-			"name": "Github Desktop",
+			"name": "GitHub Desktop",
 			"previous_names": ["Git​Hub.app Menu"],
 			"details": "https://github.com/braver/SublimeGitHub",
 			"releases": [

--- a/repository/g.json
+++ b/repository/g.json
@@ -707,6 +707,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
+					"platforms": "osx",
 					"tags": true
 				}
 			]

--- a/repository/g.json
+++ b/repository/g.json
@@ -701,6 +701,17 @@
 			]
 		},
 		{
+			"name": "Github Desktop",
+			"previous_names": ["Git​Hub.app Menu"],
+			"details": "https://github.com/braver/SublimeGitHub",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "GitHub File Fetcher",
 			"author": "Denny Korsukéwitz",
 			"details": "https://github.com/dennykorsukewitz/Sublime-GitHubFileFetcher",


### PR DESCRIPTION
Git​Hub.app Menu hasn't been updated recently and the app it tries to use has been discontinues. My repo re-implements the same idea, but based on the code I already use in SublimeGitup, and on the current GitHub Desktop app. This also modernizes the entry, removing it from the channels.json.

I hope @csytan doesn't mind.