### PR TITLE
Add comments-only color scheme

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3114,9 +3114,8 @@
 		},
 		{
 			"name": "Comments-only Color Scheme",
-			"description" : "Colorscheme without syntax highlighting",
 			"details": "https://github.com/cyevgeniy/sublime-comments-only",
-			"labels": ["colorscheme"],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/c.json
+++ b/repository/c.json
@@ -3113,6 +3113,18 @@
 			]
 		},
 		{
+			"name": "Comments-only Color Scheme",
+			"description" : "Colorscheme without syntax highlighting",
+			"details": "https://github.com/cyevgeniy/sublime-comments-only",
+			"labels": ["colorscheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Commitment",
 			"details": "https://github.com/janraasch/sublimetext-commitment",
 			"labels": ["vcs", "git", "fun"],


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **

There are no packages like it in Package Control.


<!-- 
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 

For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

For updates to existing packages:
If your package isn't using tag based releases,
please switch to tags now.
 -->

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
