### PR TITLE
Add ImperatorTools package

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -348,6 +348,17 @@
 			]
 		},
 		{
+			"name": "ImperatorTools",
+			"details": "https://github.com/dementive/ImperatorTools",
+			"labels": ["syntax", "completions"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Import Cost",
 			"details": "https://github.com/julianburr/sublime-import-cost",
 			"labels": ["js", "npm", "webpack", "import-cost"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***

My package is ImperatorTools — A plugin for Imperator: Rome scripting that has a syntax, auto completion, validation, go to definition, and a ton more features.

There are no packages like it in Package Control.