### PR TITLE
Add Victoria3Tools package

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -308,6 +308,17 @@
 			]
 		},
 		{
+			"name": "Victoria3Tools",
+			"details": "https://github.com/dementive/Victoria3Tools",
+			"labels": ["syntax", "completions"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "View Bookmarks",
 			"details": "https://github.com/adam-zethraeus/SublimeViewBookmarks",
 			"labels": ["bookmarks", "file navigation"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***

My package is Victoria3Tools — A plugin for Victoria 3 scripting that has a syntax, auto completion, validation, go to definition, and a ton more features.

There are no packages like it in Package Control.