### PR TITLE
add Dotfiles Syntax Setter

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -1505,6 +1505,17 @@
 			]
 		},
 		{
+			"name": "Dotfiles Syntax Setter",
+			"details": "https://github.com/snazzybytes/dotfiles-syntax-setter",
+			"labels": ["dotfile", "syntax", "highlight", "language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "doTjs Template Syntax Highlighting",
 			"details": "https://github.com/colelawrence/dotjs.tmLanguage",
 			"labels": ["language syntax"],


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **


There are no packages like it in Package Control:

- This "Dotfiles Syntax Setter" plugin automatically sets the syntax highlighting to Bash for **ALL** open dotfiles, enhancing the editing experience for Unix and Linux configuration files. 
- It intelligently excludes certain files where Bash syntax is inappropriate, based on a configurable list of exclusions (in some instances known dotfiles are specified in INI, YAML, JSON and other formats).
- It is truly beneficial for those who customize their shell with many separate dotfiles containing custom scripts, aliases, other customizations, etc which are scattered across many files and folders - and are sick and tired of manually setting custom dotfiles to "Bash" syntax everytime

The default configuration excludes various types of files and which be updated as dev tooling grows/changes in the future:

- Configuration files for version control systems (e.g., .gitignore, .gitconfig)
- Editor configuration files (e.g., .editorconfig, .vscode)
- Programming language and environment version managers (e.g., .ruby-version, .nvmrc)
- Linter and formatter configurations (e.g., .eslintrc, .prettierrc)
- Continuous Integration and Continuous Deployment configurations (e.g., .travis.yml, .gitlab-ci.yml)
- Cloud provider CLI configurations (e.g., .gcloud)

In short: "Set Bash syntax for ALL dotfiles - exclude known dotfiles where Bash is actually inappropriate!!!"


<!-- 
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 

For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

For updates to existing packages:
If your package isn't using tag based releases,
please switch to tags now.
 -->

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
