### PR TITLE
Added support for Carbon Syntax Highlighting

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -341,7 +341,7 @@
 			]
 		},
 		{
-			"name": "Carbon Code Colorizer",
+			"name": "Carbon Programming Language",
 			"details": "https://github.com/RohanVashisht1234/sublime_text_carbon_syntax_highlighter",
 			"labels": ["language syntax"],
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -342,7 +342,7 @@
 		},
 		{
 			"name": "Carbon Programming Language",
-			"details": "https://github.com/RohanVashisht1234/sublime_text_carbon_syntax_highlighter",
+			"details": "https://github.com/rohanvashisht1234/sublime_text_carbon_syntax_highlighter",
 			"labels": ["language syntax"],
 			"releases": [
 				{

--- a/repository/c.json
+++ b/repository/c.json
@@ -341,6 +341,17 @@
 			]
 		},
 		{
+			"name": "Carbon Syntax Highlighter",
+			"details": "https://github.com/RohanVashisht1234/sublime_text_carbon_syntax_highlighter",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Carto",
 			"details": "https://github.com/yohanboniface/Carto-sublime",
 			"labels": ["Carto", "CartoCSS", "Mapnik", "OpenStreetMap", "language syntax"],
@@ -420,17 +431,6 @@
 			"previous_names": ["Orchid Color Scheme"],
 			"details": "https://github.com/patrickfatrick/cattleya-theme-sublime",
 			"labels": ["color scheme"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "Carbon Syntax Highlighter",
-			"details": "https://github.com/RohanVashisht1234/carbonizer",
-			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/c.json
+++ b/repository/c.json
@@ -341,7 +341,7 @@
 			]
 		},
 		{
-			"name": "Carbon Syntax Highlighter",
+			"name": "Carbon Code Colorizer",
 			"details": "https://github.com/RohanVashisht1234/sublime_text_carbon_syntax_highlighter",
 			"labels": ["language syntax"],
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -342,7 +342,7 @@
 		},
 		{
 			"name": "Carbon Programming Language",
-			"details": "https://github.com/rohanvashisht1234/sublime_text_carbon_syntax_highlighter",
+			"details": "https://github.com/RohanVashisht1234/sublime_text_carbon_syntax_highlighter",
 			"labels": ["language syntax"],
 			"releases": [
 				{

--- a/repository/c.json
+++ b/repository/c.json
@@ -428,6 +428,17 @@
 			]
 		},
 		{
+			"name": "Carbon Syntax Highlighter",
+			"details": "https://github.com/RohanVashisht1234/carbonizer",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CBP Syntax Highlighter",
 			"details": "https://github.com/destruc7i0n/CBP_Sublime",
 			"labels": ["minecraft", "language syntax"],


### PR DESCRIPTION
@packagecontrol-bot

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a syntax highlighter for the carbon programming language

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
