### PR TITLE
Spin-off PyTest ST3 version

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -3175,7 +3175,11 @@
 			"labels": ["python", "pytest", "testing"],
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "<4000",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Prepare for a ST4 only release for PyTest (https://github.com/kaste/PyTest) as it is broken on Apple Silicon on py33.  
Bug report:  https://forum.sublimetext.com/t/sublime-text-pytest-package/71958/17

https://github.com/kaste/PyTest/tags