### PR TITLE
Add `Alt + E` open currt folder And Fast Print Variable Plug

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -5032,6 +5032,18 @@
 					"tags": true
 				}
 			]
+		},
+		{
+			"name": "cps plugins",
+			"details": "https://github.com/Capsion-ST-PLugins/cps-plugins",
+			"labels": ["cps", "python variable printer", "variable printer"],
+			"releases": [
+				{
+					"sublime_text": ">=3176",
+					"tags": true,
+					"branch": "release"
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

This is a basic plugin with the following main features:

When using the shortcut key alt+e, it will invoke the file manager to quickly open the directory where the current file is located.
A right-click menu item Cps Print Currt Param is added, which allows for quickly printing the variable selected by the current cursor (currently only supports Python and JavaScript).
It integrates some commonly used shell invocation methods (under Windows) for quick testing and debugging.