### PR TITLE
iOS build system

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -1073,6 +1073,18 @@
 			]
 		},
 		{
+			"name": "iOS build system",
+			"details": "https://github.com/Swift-Next/iOS-build-sublime",
+			"labels": ["build system", "swift", "objective-c", "objective-c++"],
+			"releases": [
+				{
+					"platforms": "osx",
+					"sublime_text": ">=4075",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "IpAddress",
 			"details": "https://github.com/vovayatsyuk/sublime-ip-address",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

It's [iOS sublime-build system](https://github.com/Swift-Next/iOS-build-sublime) with the first class of Sublime text support, like
- warnings/errors patterns matching within output log
- panel for presenting such warnings separately from the log itself (it could be very messy there)
- not hangs on a huge (around 100k lines) output of a xcodebuild

There are no packages for this tasks in PC yet.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
