### PR TITLE
Take over Github Tools

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -814,7 +814,7 @@
 		},
 		{
 			"name": "GitHubTools",
-			"previous_names": ["GitHub Tools"],
+			"previous_names": ["Github Tools"],
 			"details": "https://github.com/braver/GitHubTools",
 			"releases": [
 				{

--- a/repository/g.json
+++ b/repository/g.json
@@ -782,16 +782,6 @@
 			]
 		},
 		{
-			"name": "Github Tools",
-			"details": "https://github.com/temochka/sublime-text-2-github-tools",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "GithubEmoji",
 			"details": "https://github.com/akatopo/GithubEmoji",
 			"labels": ["emoji", "github", "markdown"],
@@ -818,6 +808,17 @@
 			"releases": [
 				{
 					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "GitHubTools",
+			"previous_names": ["GitHub Tools"],
+			"details": "https://github.com/braver/GitHubTools",
+			"releases": [
+				{
+					"sublime_text": "*",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
And a slight rename to GitHubTools/

<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

The context menu was there in the original package. How to disable the menu is documented in the README. 

I've had a [pull request](https://github.com/temochka/sublime-text-2-github-tools/pull/41) open on the original repo for months with no communication. The package has been [stale for about 7 years](https://packagecontrol.io/packages/Github%20Tools).

@temochka FYI, this PR is just to keep the package alive and update it again. If you object to the takeover let me know within 2 weeks.
