### PR TITLE
Move Terraform package to ST org and adjust releases

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -742,11 +742,15 @@
 		},
 		{
 			"name": "Terraform",
-			"details": "https://github.com/alexlouden/Terraform.tmLanguage",
+			"details": "https://github.com/SublimeText/Terraform",
 			"releases": [
 				{
 					"sublime_text": "*",
-					"tags": true
+					"tags": "2000-"
+				},
+				{
+					"sublime_text": ">=4169",
+					"tags": "4169-"
 				}
 			]
 		},
@@ -2760,7 +2764,7 @@
 					"tags": true
 				}
 			]
-		},	
+		},
 		{
 			"name": "Toggle Symbol to String",
 			"details": "https://github.com/zoomix/SublimeToggleSymbol",


### PR DESCRIPTION
A `2000-1.3.1` tag has already been added: https://github.com/SublimeText/Terraform/releases/tag/2000-1.3.1

See also https://github.com/alexlouden/Terraform.tmLanguage/issues/36 for the communication regarding this transfer.