### PR TITLE
Rename Better CoffeeScript to CoffeeScript

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -581,21 +581,6 @@
 			]
 		},
 		{
-			"name": "Better CoffeeScript",
-			"details": "https://github.com/SublimeText/BetterCoffeeScript",
-			"labels": ["language syntax", "snippets", "linting", "watch", "coffeescript"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": "3000-"
-				},
-				{
-					"sublime_text": "<3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Better Completion",
 			"details": "https://github.com/hilezi/Sublime-Better-Completion",
 			"labels": ["auto-complete"],

--- a/repository/c.json
+++ b/repository/c.json
@@ -2432,12 +2432,21 @@
 		},
 		{
 			"name": "CoffeeScript",
-			"details": "https://github.com/sustained/CoffeeScript-Sublime-Plugin",
-			"labels": ["language syntax"],
+			"details": "https://github.com/SublimeText/CoffeeScript",
+			"labels": ["language syntax", "snippets", "linting", "watch", "coffeescript"],
+			"previous_names": ["Better CoffeeScript"],
 			"releases": [
 				{
+					"sublime_text": ">=3143",
+					"tags": "4143-"
+				},
+				{
+					"sublime_text": "3143 - 4142",
+					"tags": "3000-"
+				},
+				{
 					"sublime_text": "<3000",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
This PR 

1. renames `Better CoffeeScript` package to `CoffeeScript`, replacing the old ST2-only package.
   The target repository has already been renamed to [SublimeText/CoffeeScript](https://github.com/SublimeText/CoffeeScript).

2. registers a ST4-only (ST4143+) tag prefix as _CoffeeScript Literate_ is planned to be extended from bundled Markdown syntax.
