### PR TITLE
Fix typo in CoffeeScript build number

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2437,7 +2437,7 @@
 			"previous_names": ["Better CoffeeScript"],
 			"releases": [
 				{
-					"sublime_text": ">=3143",
+					"sublime_text": ">=4143",
 					"tags": "4143-"
 				},
 				{


### PR DESCRIPTION
Fix a typo in build number. Latest releases should target 4143 instead of 3143.