### PR TITLE
SSH-Panel : support for macOS x64 and arm64

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3621,7 +3621,6 @@
 			"releases": [
 				{
 					"sublime_text": ">=3211",
-					"platforms": ["windows", "linux"],
 					"tags": true
 				}
 			]


### PR DESCRIPTION
support for macOS x64 and arm64
package version: v1.3.1

Need to remove the `platforms` key