### PR TITLE
Update Theme - Spacegray

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2071,11 +2071,15 @@
 		{
 			"name": "Theme - Spacegray",
 			"details": "https://github.com/SublimeText/Spacegray",
-			"labels": ["theme"],
+			"labels": ["theme", "color scheme"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=4000",
 					"tags": true
+				},
+				{
+					"sublime_text": "<4000",
+					"tags": "st3-"
 				}
 			]
 		},


### PR DESCRIPTION
Spacegray 1.4.0+ is no longer compatible with ST3.

Hence shipping ST3 version via `st3-1.3.5` tag is required.
