### PR TITLE
Update Mustage package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -2816,10 +2816,15 @@
 		},
 		{
 			"name": "Mustache",
-			"details": "https://github.com/cedeber/sublime-mustache",
+			"details": "https://github.com/SublimeText/Mustache",
+			"labels": ["language syntax", "snippets"],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": "3092 - 4151",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4152",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
_Mustache_ package has been transferred to _SublimeText_ organisation.

This PR updates repository URL and adds a release for <4152 to restore compatibility with older ST releases.