### PR TITLE
Add AutoTabClose to `a.json`

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2589,6 +2589,16 @@
 			]
 		},
 		{
+			"name": "AutoTabClose",
+			"details": "https://github.com/IPWright83/sublime-AutoTabClose",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Autotools",
 			"details": "https://github.com/ptomato/sublime_autotools",
 			"labels": ["language syntax"],


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is AutoTabClose. It is designed to automatically close certain tabs (as specified by the user). I find it incredibly useful for 'transient' tabs created by other plugins that then interfere with navigation. https://github.com/IPWright83/sublime-AutoTabClose

There are no packages like it in Package Control. (The most similar named is AutoClosePanel however it operates on something completely different).

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
