### PR TITLE
Add TestExplorer plugin to `t.json`

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -788,6 +788,16 @@
 			]
 		},
 		{
+			"name": "TestExplorer",
+			"details": "https://github.com/IPWright83/sublime-TestExplorer",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Test Plier",
 			"details": "https://github.com/asfaltboy/SublimeTestPlier",
 			"labels": ["python", "testing", "build system"],

--- a/repository/t.json
+++ b/repository/t.json
@@ -788,16 +788,6 @@
 			]
 		},
 		{
-			"name": "TestExplorer",
-			"details": "https://github.com/IPWright83/sublime-TestExplorer",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Test Plier",
 			"details": "https://github.com/asfaltboy/SublimeTestPlier",
 			"labels": ["python", "testing", "build system"],
@@ -837,6 +827,16 @@
 				{
 					"sublime_text": "<3000",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "TestExplorer",
+			"details": "https://github.com/IPWright83/sublime-TestExplorer",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is TestExplorer, designed to allow navigation around files containing unit tests. It displays a list of groups and test file names, providing a live navigation drop-down. https://github.com/IPWright83/sublime-TestExplorer

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
