### PR TITLE
Initial submission of Render View.

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1269,6 +1269,18 @@
 			]
 		},
 		{
+			"name": "Render View",
+			"details": "https://github.com/cepthomas/SbotRender",
+			"labels": ["render", "print", "markdown"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"platforms": ["windows", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Renpy Language",
 			"details": "https://github.com/koroshiya/Sublime-Renpy",
 			"releases": [


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

Renders the text in a view to html.
- Wysiwyg printing in full color: first render to html, then print from the browser.
- Renders markdown also.
- Line numbers optional.
- Supports all scheme colors including companions [Highlight Token](https://github.com/cepthomas/SbotHighlight)
  and [Notr](https://github.com/cepthomas/Notr).

I was unable to find a current plugin that supplies these features.
I did find https://packagecontrol.io/packages/Print%20to%20HTML but it appears unsupported
and doesn't support scopes.

This is one of several plugins I'm submitting to Package Control for consideration. I've been 
refining them for several years and use them daily. I think they could be useful to others, in whole or as parts.
