### PR TITLE
Initial submission of Highlight Token.

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -604,6 +604,18 @@
 			]
 		},
 		{
+			"name": "Highlight Token",
+			"details": "https://github.com/cepthomas/SbotHighlight",
+			"labels": ["highlight"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"platforms": ["windows", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Highlight Trailing Whitespace",
 			"details": "https://github.com/p3lim/sublime-highlight-trailing-whitespace",
 			"releases": [


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

Highlight words in the current document/view with user specified colors.

- Persistence per file.
- User selectable (6) colors by new scopes.
- Select whole word or not.
- Show colorized list of the scopes at the caret, or all scopes in the view.
  This is an enhanced version of the built-in function.
- Works well with [Render View](https://github.com/cepthomas/SbotRender) to generate static output.

Loosely based on [StyleToken](https://packagecontrol.io/packages/StyleToken) but with persistence and better/easier customization. Also that package appears abandoned.

This is one of several plugins I'm submitting to Package Control for consideration. I've been 
refining them for several years and use them daily. I think they could be useful to others, in whole or as parts.
