### PR TITLE
Initial submission of Notr.

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -1055,6 +1055,18 @@
 			]
 		},
 		{
+			"name": "Notr",
+			"details": "https://github.com/cepthomas/Notr",
+			"labels": ["note", "note taking", "markdown"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"platforms": ["windows", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Nova Framework Snippets",
 			"details": "https://github.com/nova-framework/Nova-Framework-Snippets",
 			"labels": ["snippets"],

--- a/repository/n.json
+++ b/repository/n.json
@@ -1061,7 +1061,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=4000",
-					"platforms": ["windows", "linux"],
+					"platforms": "*",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

Notr is a Sublime Text application plugin for displaying and managing collections of text notes.
It is a plain text format with some similarity to markdown. However there is no rendering-for-publication step: the text itself is the whole point.

Some key features:
- Sections with tags and simple (non-hierarchal) folding.
- References to section, file (image or other), uri.
- Navigation to targets via quick panel. Has MRU and sticky entries.
- Lists with several bullet types.
- Tables with insert/delete column, fit, sort.
- Multiple notr projects.
- Search in all project notr files.
- Works well with [Render View](https://github.com/cepthomas/SbotRender) to generate static output.

I couldn't find anything in current Package Control that did what I wanted because:
- Too simplistic.
- Too complicated, usually with onerous configuration and dependencies.
- Poor code quality -> unmaintainable.
- Abandoned.

A few that I looked at:
- https://packagecontrol.io/packages/Notes
- https://packagecontrol.io/packages/NotePad
- https://packagecontrol.io/packages/PlainNotes
- https://packagecontrol.io/packages/Outline%20Notes%20Publisher

This is one of several plugins I'm submitting to Package Control for consideration. I've been 
refining them for several years and use them daily. I think they could be useful to others, in whole or as parts.
