### PR TITLE
Initial submission of Plugin Pdb

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1756,6 +1756,18 @@
 			]
 		},
 		{
+			"name": "Plugin Pdb",
+			"details": "https://github.com/cepthomas/SbotPdb",
+			"labels": ["debug", "plugin", "remote"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"platforms": ["windows", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "PluginLogger",
 			"details": "https://github.com/kapitanluffy/sublime-plugin-logger",
 			"donate": "https://github.com/sponsors/kapitanluffy",


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

Sublime Text plugin for debugging plugins.

- Uses pdb remotely over a plain-text socket.
- Optional colorizing of pdb output.
- Optional timeout to unblock ST if client doesn't connect.
- Smart client manages the connection to make the edit-run-edit cycle much smoother.

There appears to be only one similar package and it has been dead for 10 years and has no
valid repository: https://packagecontrol.io/packages/Plugin%20Debugger.

There are several remote debugging packages but none specifically for ST plugin development.
I've borrowed liberally from [remote-db](https://github.com/ionelmc/python-remote-pdb).

This is one of several plugins I'm submitting to Package Control for consideration. I've been 
refining them for several years and use them daily. I think they could be useful to others, in whole or as parts.
