### PR TITLE
Added Crackboard support

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -4046,6 +4046,16 @@
 			]
 		},
 		{
+			"name": "Crackboard",
+			"details": "https://github.com/nafey/crackboard",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Crackshell",
 			"details": "https://github.com/Crackshell/sublime-text",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a client for supporting crackboard.dev which is a leaderboard for programmers. This allows Sublime Text users to compete on crackboard.dev leaderboard.


[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
