### PR TITLE
Drop non-existing Charcoal package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -742,17 +742,6 @@
 			]
 		},
 		{
-			"name": "Charcoal",
-			"details": "https://github.com/Dnld/charcoal-color-scheme",
-			"labels": ["color scheme"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Charmci",
 			"details": "https://github.com/matthiasdiener/Charmci-Sublime-Syntax",
 			"description" : "Syntax highlighting for Charm++ .ci files",


### PR DESCRIPTION
The package no longer exists and the owning user Dlnd is marked as "joined 2 weeks ago".

Maybe a new actor.