### PR TITLE
Takeover PostCSS

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1987,6 +1987,26 @@
 			]
 		},
 		{
+			"name": "PostCSS",
+			"details": "https://github.com/SublimeText/PostCSS",
+			"labels": ["language syntax"],
+			"previous_names": ["Syntax Highlighting for PostCSS"],
+			"releases": [
+				{
+					"sublime_text": "<=3091",
+					"tags": "st2-"
+				},
+				{
+					"sublime_text": "3092 - 4151",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4152",
+					"tags": "4152-"
+				}
+			]
+		},
+		{
 			"name": "PostCSS Sorting",
 			"details": "https://github.com/hudochenkov/sublime-postcss-sorting",
 			"releases": [

--- a/repository/p.json
+++ b/repository/p.json
@@ -2001,8 +2001,12 @@
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4152",
+					"sublime_text": "4152 - 4179",
 					"tags": "4152-"
+				},
+				{
+					"sublime_text": ">=4180",
+					"tags": "4180-"
 				}
 			]
 		},

--- a/repository/s.json
+++ b/repository/s.json
@@ -5925,17 +5925,6 @@
 			]
 		},
 		{
-			"name": "Syntax Highlighting for PostCSS",
-			"details": "https://github.com/hudochenkov/Syntax-highlighting-for-PostCSS",
-			"labels": ["language syntax"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Syntax Highlighting for Sass",
 			"details": "https://github.com/P233/Syntax-highlighting-for-Sass",
 			"labels": ["language syntax"],


### PR DESCRIPTION
This PR registers `SublimeText/PostCSS` as successor of archived and no longer maintained `hudochenkov/Syntax Highlighting for PostCSS`.

Version 3.0 provides a rewritten PostCSS syntax extending ST's CSS.

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.