### PR TITLE
Merge "Syntax Highlighting for Sass" into Sass

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -175,9 +175,14 @@
 			"name": "Sass",
 			"details": "https://github.com/SublimeText/Sass",
 			"labels": ["language syntax", "scss", "sass", "completions", "snippets"],
+			"previous_names": ["Syntax Highlighting for Sass"],
 			"releases": [
 				{
-					"sublime_text": "<4107",
+					"sublime_text": "<3103",
+					"tags": "st2-"
+				},
+				{
+					"sublime_text": "3103 - 4106",
 					"tags": "st3-"
 				},
 				{
@@ -5924,21 +5929,6 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "Syntax Highlighting for Sass",
-			"details": "https://github.com/P233/Syntax-highlighting-for-Sass",
-			"labels": ["language syntax"],
-			"releases": [
-				{
-					"sublime_text": "<3103",
-					"branch": "ST2"
-				},
-				{
-					"sublime_text": ">=3103",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This commit merges former "Syntax Highlighting for Sass" package into "Sass"
as "Sass" is a fork and old ST2 versions are still present.

A st2-1.0.0 tag was created in "Sass" repository to keep providing ST2
compatible packages, even though that's probably not important anymore.

Intention is to cleanup packages and get rid of heavy out-dated packages.
