### PR TITLE
Restrict JSX package to ST3

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -1346,7 +1346,7 @@
 					"tags": "st2-v"
 				},
 				{
-					"sublime_text": ">3000",
+					"sublime_text": "3000 - 3999",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
ST4 ships with better JSX / TSX syntax and JSX package hasn't been maintained for 6 years.
