### PR TITLE
Fix Ring

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1674,7 +1674,7 @@
 			"details": "https://github.com/ysdragon/ring-sublime",
 			"releases": [
 				{
-					"sublime_text": "<3092",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This commit fixes ST build selector of "Ring" package.

The package provides a sublime-syntax file, which requires at least ST3092.
