### PR TITLE
Migrate SCSS users to Sass

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -175,7 +175,7 @@
 			"name": "Sass",
 			"details": "https://github.com/SublimeText/Sass",
 			"labels": ["language syntax", "scss", "sass", "completions", "snippets"],
-			"previous_names": ["Syntax Highlighting for Sass"],
+			"previous_names": ["SCSS", "Syntax Highlighting for Sass"],
 			"releases": [
 				{
 					"sublime_text": "<3103",
@@ -681,18 +681,6 @@
 				{
 					"sublime_text": "*",
 					"tags": true
-				}
-			]
-		},
-		{
-			"name": "SCSS",
-			"details": "https://github.com/MarioRicalde/SCSS.tmbundle/tree/SublimeText2",
-			"labels": ["language syntax"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"base": "https://github.com/MarioRicalde/SCSS.tmbundle",
-					"branch": "SublimeText2"
 				}
 			]
 		},


### PR DESCRIPTION
This commit removes heavily out-dated and unmaintained SCSS package, migrating its users to Sass package.

Alternatively, we could split current Sass package into 2 (Sass and SCSS) and continue providing both as separate dedicated syntax packages.

Not sure what a perfect strategy is, but it appears many users still relying on out-dated SCSS package or even having installed both packages, not being aware they basically intend to provide same value.

SCSS saw its last update 10 years ago and it is time to sunset it.

related with https://github.com/SublimeText/Sass/issues/111