### PR TITLE
Deprecate PHP Haml package

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1151,7 +1151,7 @@
 			"details": "https://github.com/xt99/sublimetext-php-haml",
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<4000",
 					"branch": "master"
 				}
 			]


### PR DESCRIPTION
This commit disables PHP Haml package for ST4.

ST3 ships its own sublime-syntax based HAML syntax and it was even rewritten for ST4 with good chances to be a way better choice than a tmLanguage syntax, which hasn't seen any update for 10 years.

Theoretically, we could even restrict it to <3092.
