### PR TITLE
Drop non-existing PHP Modern

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1157,16 +1157,6 @@
 			]
 		},
 		{
-			"name": "PHP Modern",
-			"details": "https://github.com/jobedom/sublime-php-modern",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "PHP MySQLi connection",
 			"details": "https://github.com/misalazovic/PHP-MySQLi-connection",
 			"releases": [


### PR DESCRIPTION
The repository has been removed. The link errors with 404.
