### PR TITLE
Prepare for Twig 4.0

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -3637,7 +3637,11 @@
 					"tags": "4107-"
 				},
 				{
-					"sublime_text": ">=4142",
+					"sublime_text": "4142 - 4149",
+					"tags": "4142-"
+				},
+				{
+					"sublime_text": ">=4152",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This PR adjusts Twig package meta data for a new release based on https://github.com/Sublime-Instincts/BetterTwig/pull/39.

The pull request refactors the package following structure of Jinja2, which required quite some significant changes.

Included CSS syntax requires https://github.com/sublimehq/Packages/pull/3717, which is shipped with ST4149+. I'd suggest to use the next stable build 4152 as a starting point.

As preparation...

1. a new tag `4142-3.0.3` is added 
2. mentioned pull request is merged
3. a new (major?) release tag is added

... to Twig package.