### PR TITLE
Migrate PHP-Twig users to Twig

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1229,16 +1229,6 @@
 			]
 		},
 		{
-			"name": "PHP-Twig",
-			"details": "https://github.com/Anomareh/PHP-Twig.tmbundle",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "Phpactor",
 			"details": "https://github.com/tkotosz/sublime-phpactor-plugin",
 			"releases": [

--- a/repository/t.json
+++ b/repository/t.json
@@ -3622,6 +3622,7 @@
 			"name": "Twig",
 			"details": "https://github.com/Sublime-Instincts/BetterTwig",
 			"labels": ["Twig", "templates", "PHP", "syntax"],
+			"previous_names": ["PHP-Twig"],
 			"releases": [
 				{
 					"base": "https://github.com/purplefish32/sublime-text-2-twig",


### PR DESCRIPTION
PHP-Twig ...

1. is marked missing for a reasonable time and thus can't be installed.
2. is a tmLanguage based syntax
3. that hasn't seen any updates for about 8 years
4. seems to fail on ST4 according to its issue trackers

This PR therefore proposes to merge PHP-Twig into Twig.