### PR TITLE
Added VHS syntax package

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -321,7 +321,6 @@
 			"name": "VHS",
 			"details": "https://github.com/patopesto/Sublime-Text-VHS-Syntax",
 			"labels": ["language syntax"],
-			"author": "patopesto",
 			"releases": [
 				{
 					"sublime_text": ">=4107",

--- a/repository/v.json
+++ b/repository/v.json
@@ -318,6 +318,18 @@
 			]
 		},
 		{
+			"name": "VHS",
+			"details": "https://github.com/patopesto/Sublime-Text-VHS-Syntax",
+			"labels": ["language syntax"],
+			"author": "patopesto",
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "View Bookmarks",
 			"details": "https://github.com/adam-zethraeus/SublimeViewBookmarks",
 			"labels": ["bookmarks", "file navigation"],


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a syntax highlighter for charmbracelet's [VHS](https://github.com/charmbracelet/vhs) tape files

There are no packages like it in Package Control.