### PR TITLE
Restore Base Encoder package

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -190,6 +190,16 @@
 			]
 		},
 		{
+			"name": "Base Encoder",
+			"details": "https://github.com/socsieng/base-encoder",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Base Snippets",
 			"details": "https://github.com/base/sublime-text-base-snippets",
 			"labels": ["snippets", "JavaScript", "base", "node", "node-base"],


### PR DESCRIPTION
This restores the [Base Encoder package](https://packagecontrol.io/packages/Base%20Encoder) which has been marked as “missing“ on the website and has been removed from the channel in #8844.

The original repository is gone but the fork by @socsieng is still available and [the original author agreed](https://github.com/wbond/package_control_channel/pull/5016#issuecomment-2462770647) to have the package point to the fork as part of the discussion in #5016.