### PR TITLE
Add MarkdownCodeExporter

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -608,7 +608,7 @@
 		},
 		{
 			"name": "MarkdownCodeExporter",
-			"details": "https://github.com/maliayas/SublimeText_MarkdownCodeExporter",
+			"details": "https://github.com/SublimeText-Markdown/MarkdownCodeExporter",
 			"labels": ["markdown"],
 			"releases": [
 				{

--- a/repository/m.json
+++ b/repository/m.json
@@ -607,6 +607,17 @@
 			]
 		},
 		{
+			"name": "MarkdownCodeExporter",
+			"details": "https://github.com/maliayas/SublimeText_MarkdownCodeExporter",
+			"labels": ["markdown"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MarkdownComplements",
 			"details": "https://github.com/junShimoji/MarkdownComplements",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is [MarkdownCodeExporter](https://github.com/maliayas/SublimeText_MarkdownCodeExporter)

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
