### PR TITLE
Add UniqueLine

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -669,6 +669,16 @@
 					"tags": true
 				}
 			]
+		},
+		{
+			"name": "UniqueLine",
+			"details": "https://github.com/guisaisai/UniqueLine",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
I'm the package's author and/or maintainer.
 I have have read [the docs](https://packagecontrol.io/docs/submitting_a_package).
 I have tagged a release with a [semver](https://semver.org/) version number.
 My package repo has a description and a README describing what it's for and how to use it.
 My package doesn't add context menu entries. *
 My package doesn't add key bindings. **
 Any commands are available via the command palette.
 Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
 If my package is a syntax it doesn't also add a color scheme. ***
 If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
 I use [.gitattributes](https://www.git-scm.com/docs/gitattributes#_export_ignore) to exclude files from the package: images, test files, sublime-project/workspace.

My package is [UniqueLine](https://github.com/guisaisai/UniqueLine)

There are no packages like it in Package Control. It performs especially well when handling large files. Less dependency and simple operation