### PR TITLE
Update Vue Package

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -779,20 +779,25 @@
 			]
 		},
 		{
-			"name": "Vue Syntax Highlight",
-			"details": "https://github.com/vuejs/vue-syntax-highlight",
+			"name": "Vue",
+			"details": "https://github.com/SublimeText/Vue",
+			"previous_names": ["Vue Syntax Highlight"],
 			"releases": [
 				{
 					"sublime_text": "<3153",
 					"tags": "oldsyntax-"
 				},
 				{
-					"sublime_text": "3153 - 3999",
+					"sublime_text": "3153 - 4106",
 					"tags": "newsyntax-"
 				},
 				{
-					"sublime_text": ">4000",
-					"tags": "st4-"
+					"sublime_text": "4107 - 4125",
+					"tags": "4107-"
+				},
+				{
+					"sublime_text": ">=4126",
+					"tags": "4126-"
 				}
 			]
 		},


### PR DESCRIPTION
This commit...

1. renames "Vue Syntax Highlight" package to "Vue"
2. retargets the package to SublimeText organization see: https://github.com/SublimeText/Vue/pull/2
3. changes tag-prefixes from `st4-` to `<build>-`
   
   Note: Existing tags have been renamed/updated on the repo!

4. adds another waypoint for ST4126+ releases with various backward compatibility only contexts removed.

5. as there are no plans to check compatibility with early ST4 dev builds before ST4107, those will be delivered with old ST3 syntax.