### PR TITLE
Update XSL package

### DIFF
--- a/repository/x.json
+++ b/repository/x.json
@@ -236,23 +236,21 @@
 		},
 		{
 			"name": "XSL",
-			"details": "https://github.com/packagecontrol/XSL",
-			"labels": ["language syntax"],
+			"details": "https://github.com/SublimeText/XSL",
+			"labels": ["language syntax", "snippets"],
+			"previous_names": ["XSLT Snippets"],
 			"releases": [
 				{
-					"sublime_text": ">3083",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "XSLT Snippets",
-			"details": "https://github.com/hoest/SublimeXSLT",
-			"labels": ["snippets"],
-			"releases": [
+					"sublime_text": "3083 - 4106",
+					"tags": "st3-"
+				},
 				{
-					"sublime_text": "*",
-					"branch": "master"
+					"sublime_text": "4107 - 4125",
+					"tags": "4107-"
+				},
+				{
+					"sublime_text": ">=4126",
+					"tags": "4126-"
 				}
 			]
 		},


### PR DESCRIPTION
This commit...

1. transfers "XSL" package to https://github.com/SublimeText/XSL
2. merges "XSLT Snippets" package into "XSL".

Despite its name "XSLT Snippets" provides also syntax definition, completions and symbol list definitions.

XSL was primarily intended as backward compatibility package as ST3083 dropped that syntax from core packages. It defines same main scope `text.xml.xsl` as syntax from "XSLT Snippets".

For ST4 XSL packages provides rewritten syntax for XML Stylesheets (XSL) and XML Schemas (XSD) with full support for XPath and RegExp highlighting.


- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
