### PR TITLE
Update Ngx HTML package

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -624,16 +624,19 @@
 		},
 		{
 			"name": "Ngx HTML",
-			"previous_names": ["Angular2 HTML Syntax"],
 			"details": "https://github.com/princemaple/ngx-html-syntax",
 			"labels": ["language syntax", "angular"],
 			"releases": [
 				{
-					"sublime_text": "3156 - 4076",
+					"sublime_text": "3156 - 4106",
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4077",
+					"sublime_text": "4107 - 4151",
+					"tags": "4107-"
+				},
+				{
+					"sublime_text": ">=4152",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
1. ship ST4 syntax as of first stable release 4107.
2. add a way point for releases, requiring ST 4152.

~~requires https://github.com/princemaple/ngx-html-syntax/issues/35~~

EDIT: required tag was created.