### PR TITLE
Update LaTeXTools package

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -546,12 +546,12 @@
 					"tags": "st2-"
 				},
 				{
-					"sublime_text": "3000 - 3124",
-					"tags": "st3until3125-"
+					"sublime_text": "3143 - 4106",
+					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=3125",
-					"tags": "st3-"
+					"sublime_text": ">=4107",
+					"tags": "st4-"
 				}
 			]
 		},


### PR DESCRIPTION
1. drop support for early ST3 beta builds, leaving ST3143+ (1.0)
2. add entry for ST4-only releases