### PR TITLE
Package added: BBC BASIC Modern Syntax

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -283,6 +283,17 @@
 			]
 		},
 		{
+			"name": "BBC BASIC Modern Syntax",
+			"details": "https://github.com/sarev/BBC-BASIC-Sublime-Syntax",
+			"labels": ["basic", "bbc basic", "risc os", "language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "BBC BASIC Syntax",
 			"details": "https://github.com/gerph/sublimetext-bbcbasic-syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- [y] I'm the package's author and/or maintainer.
- [y] I have have read [the docs][1].
- [y] I have tagged a release with a [semver][2] version number.
- [n] My package repo has a description and a README describing what it's for and how to use it.
- [y] My package doesn't add context menu entries. *
- [y] My package doesn't add key bindings. **
- [n/a] Any commands are available via the command palette.
- [n/a] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [y] If my package is a syntax it doesn't also add a color scheme. ***
- [y&n] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [n/a] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is BBC BASIC Modern Syntax. 

This is a more comprehensive version of the BBC BASIC language syntax than the pre-existing "BBC BASIC Syntax" package. This language syntax is more targeted at source code developed on or for RISC OS (the native home of BBC BASIC) and supports expressions and inline assembler (for example).

The pre-existing "BBC BASIC Syntax" package provides a simplified/generic syntax so as to support various ports of BBC BASIC (e.g. BBC BASIC for Windows, Brandy, etc.).
