### PR TITLE
Update PowerShell package

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2140,12 +2140,12 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": "<3156",
-					"tags": "version/st3155/"
+					"sublime_text": "<4000",
+					"tags": "st2-"
 				},
 				{
-					"sublime_text": ">=3156",
-					"tags": "version/st/"
+					"sublime_text": ">=4000",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
PowerShell v4.0 requires ST4 as it uses sublime-syntax "version 2".

This commit therefore introduces a release based on `st2-` tags for ST2 and ST3, continuing with ST4-only releases without prefixed tags.

@michaelblyons 
