### PR TITLE
Add Ollama Plugin

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -301,6 +301,17 @@
 			]
 		},
 		{
+			"name": "OllamaSublime",
+			"details": "https://github.com/dapepe/OllamaSublime",
+			"labels": ["ollama","llm","ai"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "OmniDocs",
 			"details": "https://github.com/bordaigorl/sublime-omnidocs",
 			"labels": ["search", "documentation"],


### PR DESCRIPTION
- [x ] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is adding Ollama support inside Sublime text.

My package is similar to Yollama. However it should still be added because it has more commands, e.g. let's me switch models on the fly, adds a palette of prompts, shows my prompt history, etc.


