### PR TITLE
Move 'Excel formula' to `s.json`, rename to 'Spreadsheet Formula,' add coauthor, labels, releases

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -1528,16 +1528,6 @@
 			]
 		},
 		{
-			"name": "Excel formula",
-			"details": "https://github.com/axemonk/Excel-formula",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"details": "https://github.com/SublimeText/ExcelExec",
 			"releases": [
 				{

--- a/repository/s.json
+++ b/repository/s.json
@@ -3439,7 +3439,7 @@
 			"name": "Spreadsheet formula",
 			"details": "https://github.com/axemonk/Excel-formula",
 			"author": ["axemonk", "michaelblyons"],
-			"labels": ["language", "syntax", "snippets", "completions", "microsoft excel", "google sheets", "libreoffice calc", "spreadsheet"],
+			"labels": ["language syntax", "snippets", "completions"],
 			"previous_names": ["Excel formula"],
 			"releases": [
 				{

--- a/repository/s.json
+++ b/repository/s.json
@@ -3436,6 +3436,19 @@
 			]
 		},
 		{
+			"name": "Spreadsheet formula",
+			"details": "https://github.com/axemonk/Excel-formula",
+			"author": ["axemonk", "michaelblyons"],
+			"labels": ["language", "syntax", "snippets", "completions", "microsoft excel", "google sheets", "libreoffice calc", "spreadsheet"],
+			"previous_names": ["Excel formula"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SproutCore Snippets and JSHint Integration",
 			"details": "https://github.com/sproutcore/sproutcore-sublime-text-2-package",
 			"labels": ["snippets"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -3439,7 +3439,7 @@
 			"name": "Spreadsheet formula",
 			"details": "https://github.com/axemonk/Excel-formula",
 			"author": ["axemonk", "michaelblyons"],
-			"labels": ["language syntax", "snippets", "auto-complete"],
+			"labels": ["language syntax", "snippets", "auto-complete", "completions"],
 			"previous_names": ["Excel formula"],
 			"releases": [
 				{

--- a/repository/s.json
+++ b/repository/s.json
@@ -3437,7 +3437,7 @@
 		},
 		{
 			"name": "Spreadsheet Formula",
-			"details": "https://github.com/axemonk/Excel-formula",
+			"details": "https://github.com/axemonk/Spreadsheet-Formula",
 			"author": ["axemonk", "michaelblyons"],
 			"labels": ["language syntax", "snippets", "completions"],
 			"previous_names": ["Excel formula"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -3436,10 +3436,10 @@
 			]
 		},
 		{
-			"name": "Spreadsheet formula",
+			"name": "Spreadsheet Formula",
 			"details": "https://github.com/axemonk/Excel-formula",
 			"author": ["axemonk", "michaelblyons"],
-			"labels": ["language syntax", "snippets", "auto-complete", "completions"],
+			"labels": ["language syntax", "snippets", "completions"],
 			"previous_names": ["Excel formula"],
 			"releases": [
 				{

--- a/repository/s.json
+++ b/repository/s.json
@@ -3443,7 +3443,7 @@
 			"previous_names": ["Excel formula"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=4075",
 					"tags": true
 				}
 			]

--- a/repository/s.json
+++ b/repository/s.json
@@ -3443,8 +3443,12 @@
 			"previous_names": ["Excel formula"],
 			"releases": [
 				{
+					"sublime_text": "3092 - 4074",
+					"tags": "st3-"
+				},
+				{
 					"sublime_text": ">=4075",
-					"tags": true
+					"tags": "st4-"
 				}
 			]
 		},

--- a/repository/s.json
+++ b/repository/s.json
@@ -3439,7 +3439,7 @@
 			"name": "Spreadsheet formula",
 			"details": "https://github.com/axemonk/Excel-formula",
 			"author": ["axemonk", "michaelblyons"],
-			"labels": ["language syntax", "snippets", "completions"],
+			"labels": ["language syntax", "snippets", "auto-complete"],
 			"previous_names": ["Excel formula"],
 			"releases": [
 				{


### PR DESCRIPTION
This PR is a resubmission of #9029 

FWIW, I just stumbled across this while going through the checklist: [Link-to-highlight of potential issue](https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition:~:text=Packages%20hosted%20on%20GitHub%20or%20Bitbucket%20should%20not%20provide%20%22description%22%2C%20%22issues%22%2C%20%22readme%22%20or%20%22author%22%20fields%3A%20they%20are%20taken%20from%20the%20repo%20directly.)
Does the above apply to github packages with multiple authors?

1. Move package `Excel formula` to `s.json`
2. Rename package to `Spreadsheet formula`. Add `previous_names`
3. Add coauthor @michaelblyons
4. Add `labels`
5. Add build requirement `>=4075` for use of `extends`
6. Tag legacy release for builds `3092` to `4074` for use of `.sublime-syntax`

- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
