### PR TITLE
Add OpenInCursor

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -497,6 +497,18 @@
 			]
 		},
 		{
+			"name": "Open In Cursor",
+			"details": "https://github.com/spencerchristensen/sublime-open-in-cursor",
+			"labels": ["open files", "external editor", "cursor"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Open in Default Application",
 			"details": "https://github.com/SublimeText/OpenDefaultApplication",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

(The final four checkboxes are non-applicable to my package)

My package is a way to quickly open your current Sublime file + project in the Cursor editor. I love Sublime Text as a text editor and purposely choose not to turn it into an IDE or AI-powered experience. However, sometimes I do want to quickly hop into Cursor to hash out a quick problem, task, etc.