### PR TITLE
Move Laravel Blade package to SublimeText

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -73,7 +73,6 @@
 		"https://raw.githubusercontent.com/lucifr/CNPunctuationAutopair/master/packages.json",
 		"https://raw.githubusercontent.com/lyapun/sublime-text-2-python-test-runner/master/packages.json",
 		"https://raw.githubusercontent.com/MattDMo/Neon-sublime-theme/master/packages.json",
-		"https://raw.githubusercontent.com/Medalink/laravel-blade/master/packages.json",
 		"https://raw.githubusercontent.com/mekwall/obsidian-color-scheme/master/packages.json",
 		"https://raw.githubusercontent.com/Mendor/sublime-erlyman/master/packages.json",
 		"https://raw.githubusercontent.com/mischah/Console-API-Snippets/master/packages.json",

--- a/repository/l.json
+++ b/repository/l.json
@@ -220,6 +220,26 @@
 			]
 		},
 		{
+			"name": "Laravel Blade",
+			"details": "https://github.com/SublimeText/Blade",
+			"labels": ["php", "laravel", "blade", "language syntax"],
+			"previous_names": ["Laravel Blade Highlighter"],
+			"releases": [
+				{
+					"sublime_text": "<3092",
+					"tags": "st2-"
+				},
+				{
+					"sublime_text": "3092 - 4142",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4143",
+					"tags": "st4143-"
+				}
+			]
+		},
+		{
 			"name": "Laravel Blade AutoComplete",
 			"details": "https://github.com/ahmedash95/sublime-laravel-blade-autocomplete",
 			"releases": [


### PR DESCRIPTION
This commit...

1. moves laravel blade to SublimeText
2. directly registers package releases replacing dedicated repository.

Repository transfer has already been discussed at https://github.com/Medalink/laravel-blade/pull/206 in October 2024.

As nothing has happened since then, repository has been forked with said PR merged in order to continue maintanance.