### PR TITLE
Add AskPerplexity

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1935,6 +1935,17 @@
 			]
 		},
 		{
+			"name": "AskPerplexity",
+			"details": "https://github.com/spencerchristensen/sublime-ask-perplexity",
+			"labels": ["ai", "browser", "perplexity"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ASL Syntax Highlight",
 			"details": "https://github.com/Fansaly/ASL-Syntax-Highlight",
 			"author": "Fansaly",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

Last 4 don't apply to this.

Ask a question to [Perplexity](https://perplexity.ai/) and have it answered in your default browser (not Sublime). Facilitate a seamless transition between Sublime and Perplexity while maintaining a clear and defined boundary: no AI in your text editor.

Workflow:

- lovely coding in Sublime
- hey, I have a question to ask AI
- run "Ask Perplexity" command
- type question
- submit, opening a browser window with Perplexity

Makes it easier to context switch directly from Sublime to Perplexity. Doesn't insert Perplexity output into Sublime itself.
