### PR TITLE
Revert Laravel Blade package name

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -220,10 +220,19 @@
 			]
 		},
 		{
-			"name": "Laravel Blade",
+			"name": "Laravel Blade AutoComplete",
+			"details": "https://github.com/ahmedash95/sublime-laravel-blade-autocomplete",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "Laravel Blade Highlighter",
 			"details": "https://github.com/SublimeText/Blade",
 			"labels": ["php", "laravel", "blade", "language syntax"],
-			"previous_names": ["Laravel Blade Highlighter"],
 			"releases": [
 				{
 					"sublime_text": "<3092",
@@ -236,16 +245,6 @@
 				{
 					"sublime_text": ">=4143",
 					"tags": "st4143-"
-				}
-			]
-		},
-		{
-			"name": "Laravel Blade AutoComplete",
-			"details": "https://github.com/ahmedash95/sublime-laravel-blade-autocomplete",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
It appears moving from external repo and renaming in one step doesn't work.

"Laravel Blade" hasn't been picked up.

So let's try to make a step backward and keep original name.