### PR TITLE
Rename Laravel Blade and fix tag prefix

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -220,19 +220,10 @@
 			]
 		},
 		{
-			"name": "Laravel Blade AutoComplete",
-			"details": "https://github.com/ahmedash95/sublime-laravel-blade-autocomplete",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "Laravel Blade Highlighter",
+			"name": "Laravel Blade",
 			"details": "https://github.com/SublimeText/Blade",
 			"labels": ["php", "laravel", "blade", "language syntax"],
+			"previous_names": ["Laravel Blade Highlighter"],
 			"releases": [
 				{
 					"sublime_text": "<3092",
@@ -244,7 +235,17 @@
 				},
 				{
 					"sublime_text": ">=4143",
-					"tags": "st4143-"
+					"tags": "4143-"
+				}
+			]
+		},
+		{
+			"name": "Laravel Blade AutoComplete",
+			"details": "https://github.com/ahmedash95/sublime-laravel-blade-autocomplete",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
This PR...

1. fixes tag prefix of ST4 releases (needs to be `4143-` instead of `st4143-`)
2. finally renames package to _Laravel Blade_ again.

The overall reason for recent PRs not being successful was the wrong tag prefix. 
So crawler wasn't able to pick up valid releases for ST4.