### PR TITLE
Fix: Correct indentation and alphabetical order for AutoTagMate entry…

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2621,6 +2621,16 @@
 			]
 		},
 		{
+			"name": "AutoTagMate",
+			"details": "https://github.com/baslie/AutoTagMate",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Autotools",
 			"details": "https://github.com/ptomato/sublime_autotools",
 			"labels": ["language syntax"],


### PR DESCRIPTION
… in a.json

<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what's not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is AutoTagMate, a unique Sublime Text plugin that automatically generates closing tags in plain text and .txt files. There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
