### PR TITLE
Drop and replace WakaTime

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -146,23 +146,23 @@
 			]
 		},
 		{
-			"name": "Banned",
-			"details": "https://github.com/SublimeText/Banned",
-			"previous_names": ["WakaTime"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Bang Search",
 			"details": "https://github.com/bsoun/bang-search",
 			"labels": ["search"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "Banned",
+			"details": "https://github.com/SublimeText/Banned",
+			"previous_names": ["WakaTime"],
+			"releases": [
+				{
+					"sublime_text": "*",
 					"tags": true
 				}
 			]

--- a/repository/b.json
+++ b/repository/b.json
@@ -146,6 +146,17 @@
 			]
 		},
 		{
+			"name": "Banned",
+			"details": "https://github.com/SublimeText/Banned",
+			"previous_names": ["WakaTime"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Bang Search",
 			"details": "https://github.com/bsoun/bang-search",
 			"labels": ["search"],

--- a/repository/w.json
+++ b/repository/w.json
@@ -35,17 +35,6 @@
 			]
 		},
 		{
-			"name": "WakaTime",
-			"details": "https://github.com/wakatime/sublime-wakatime",
-			"labels": ["time tracking", "coding", "utilities", "productivity"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Wanderlei Color Scheme",
 			"details": "https://github.com/JeremySaks/wanderlei-color-scheme",
 			"labels": ["color scheme"],


### PR DESCRIPTION
This commit therefore removes WakaTime and replaces existing entry by a common "Banned" package name on packagecontrol.io to vanish all its presence and force removal from all clients, which still have it installed.

This drastic step is a response of WakaTime having repetitively attacked packagecontrol.io by insane high (400 per second) fake install stat requests even though it hasn't been installed by anybody for years or within attacks.

#### Stats from Feb/16/2025

![grafik](https://github.com/user-attachments/assets/b6951a59-bf47-41b1-aa19-2fc50ca8f168)

![grafik](https://github.com/user-attachments/assets/fd7b9047-15f8-4ed1-9a23-28c0be841542)

related with: https://github.com/wakatime/sublime-wakatime/issues/118