### PR TITLE
Add Dhall

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -817,6 +817,17 @@
 			]
 		},
 		{
+			"name": "Dhall",
+			"details": "https://github.com/kukimik/dhall-sublime-syntax-highlighting",
+			"labels": ["language syntax", "dhall"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Diagram",
 			"details": "https://github.com/jvantuyl/sublime_diagram_plugin",
 			"labels": ["diagrams", "plantuml"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is named [Dhall](https://github.com/kukimik/dhall-sublime-syntax-highlighting). It is a syntax highlighting package for the [Dhall configuration language](https://dhall-lang.org).

It replaces the original [Dhall](https://packagecontrol.io/packages/Dhall) package that was removed from GitHub in 2020. The present package is based on the original `.sublime-syntax` file, republished with the original author's permission.

There are no packages like it in Package Control.

This is a second attempt at adding this package, see [#8681](https://github.com/wbond/package_control_channel/pull/8681) for the first one, which failed because back then I only had a `.tmLanguage` syntax definition.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
