### PR TITLE
Add Sone - Theme & Color Scheme

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2885,6 +2885,17 @@
 			]
 		},
 		{
+			"name": "Sone",
+			"details": "https://github.com/predragnikolic/Sone",
+			"labels": ["theme", "color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Sonic Pi",
 			"details": "https://github.com/fbehrens/sublime_sonic_pi",
 			"labels": ["music"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -2885,17 +2885,6 @@
 			]
 		},
 		{
-			"name": "Sone",
-			"details": "https://github.com/predragnikolic/Sone",
-			"labels": ["theme", "color scheme"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Sonic Pi",
 			"details": "https://github.com/fbehrens/sublime_sonic_pi",
 			"labels": ["music"],

--- a/repository/t.json
+++ b/repository/t.json
@@ -2082,6 +2082,17 @@
 			]
 		},
 		{
+			"name": "Theme - Sone",
+			"details": "https://github.com/predragnikolic/Sone",
+			"labels": ["theme", "color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Theme - Spaceblack",
 			"details": "https://github.com/TheBaronHimself/Spaceblack",
 			"labels": ["theme", "color scheme"],


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package `Sone` is a Theme & Color Scheme.

`Sone` is similar to other themes and color schemes.