### PR TITLE
Add AutoWrapStrings

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2673,6 +2673,16 @@
 			]
 		},
 		{
+			"name": "AutoWrapStrings",
+			"details": "https://github.com/davidAlgis/AutoWrapStrings",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "AVA",
 			"details": "https://github.com/avajs/sublime-ava",
 			"labels": ["snippets", "javascript", "nodejs", "testing", "auto-complete", "completions"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is : A string wrapper for python to make sure they does not exceed a given column length.

There are no packages like it in Package Control.