### PR TITLE
Add Pyperclip to dependencies

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -825,6 +825,21 @@
 			]
 		},
 		{
+			"name": "pyperclip",
+			"description": "Python module for cross-platform clipboard functions",
+			"author": "asweigart",
+			"issues": "https://github.com/asweigart/pyperclip/issues",
+			"load_order": "10",
+			"releases": [
+				{
+					"base": "https://github.com/asweigart/pyperclip",
+					"platforms": ["*"],
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "pyte",
 			"description": "Python pyte module",
 			"author": "randy3k",


### PR DESCRIPTION
- [x] I have have read [the docs]
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.

This package is required as a dependency for another package I am maintaining, in order to put the transpiled code onto system clipboard, when the transpiler is executed from CLI.

Thanks!