### PR TITLE
Reduce duplicate tags of "language syntax"

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1206,7 +1206,7 @@
 		{
 			"name": "Ansible",
 			"details": "https://github.com/clifford-github/sublime-ansible",
-			"labels": ["language syntax", "ansible", "syntax"],
+			"labels": ["language syntax", "ansible"],
 			"releases": [
 				{
 					"sublime_text": "<4000",

--- a/repository/b.json
+++ b/repository/b.json
@@ -1287,7 +1287,7 @@
 		{
 			"name": "Bottle",
 			"details": "https://github.com/eric-wieser/sublime-bottle",
-			"labels": ["snippets", "python", "language-syntax"],
+			"labels": ["snippets", "python", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -1663,7 +1663,7 @@
 		{
 			"name": "build2",
 			"details": "https://github.com/build2/build2-sublime-text",
-			"labels": ["syntax highlighting"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1759,7 +1759,7 @@
 		{
 			"name": "Butane",
 			"details": "https://github.com/jdoss/sublime-butane",
-			"labels": ["language syntax", "snippets", "syntax highlighting", "syntax", "yaml"],
+			"labels": ["language syntax", "snippets", "yaml"],
 			"author": ["Joe Doss (jdoss)"],
 			"releases": [
 				{

--- a/repository/c.json
+++ b/repository/c.json
@@ -116,7 +116,7 @@
 		{
 			"name": "C++YouCompleteMe",
 			"details": "https://github.com/glymehrvrd/CppYCM",
-			"labels": ["c++", "code completion", "syntax check"],
+			"labels": ["c++", "code completion", "linting"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -170,7 +170,7 @@
 		{
 			"name": "Caddyfile Syntax",
 			"details": "https://github.com/caddyserver/sublimetext",
-			"labels": ["language syntax", "syntax highlighting"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1224,7 +1224,7 @@
 		{
 			"name": "CJSX Syntax",
 			"details": "https://github.com/Guidebook/sublime-cjsx",
-			"labels": ["CJSX", "syntax"],
+			"labels": ["CJSX", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -3856,7 +3856,7 @@
 		{
 			"name": "Coq",
 			"details": "https://github.com/whitequark/Sublime-Coq",
-			"labels": ["syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -5007,7 +5007,7 @@
 		{
 			"name": "CWL Syntax Highlighting",
 			"details": "https://github.com/manabuishii/sublime-cwl-syntax",
-			"labels": ["language syntax", "syntax highlighting", "cwl"],
+			"labels": ["language syntax", "cwl"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/d.json
+++ b/repository/d.json
@@ -1574,7 +1574,7 @@
 			"name": "dotsyntax",
 			"author": "Sean Morris <dotsyntax@seanmorr.is>",
 			"details": "https://github.com/seanmorris/dotsyntax-sublime",
-			"labels": ["syntax", "hightlight", "config", "per-project", "dotfile"],
+			"labels": ["language syntax", "config", "per-project", "dotfile"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/e.json
+++ b/repository/e.json
@@ -255,7 +255,7 @@
 		{
 			"name": "Ebitengine Kage",
 			"details": "https://github.com/sedyh/ebitengine-kage-sublime",
-			"labels": ["kage", "ebitengine", "syntax highlight", "snippets"],
+			"labels": ["kage", "ebitengine", "language syntax", "snippets"],
 			"releases": [
 				{
 					"sublime_text": ">=4107",
@@ -725,7 +725,7 @@
 		{
 			"name": "Elm Syntax Highlighting",
 			"details": "https://github.com/evancz/elm-syntax-highlighting",
-			"labels": ["elm", "language syntax", "highlighting"],
+			"labels": ["elm", "language syntax"],
 			"previous_names": ["Elm Language Support"],
 			"releases": [
 				{
@@ -828,7 +828,7 @@
 		{
 			"name": "Ember Single-File Component Syntax",
 			"details": "https://github.com/urbany/ember-sfc-syntax-highlight",
-			"labels": ["ember", "sfc", "single-file", "syntax", "highlighting", "handlebars", "glimmer"],
+			"labels": ["ember", "sfc", "single-file", "language syntax", "handlebars", "glimmer"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1401,7 +1401,7 @@
 		{
 			"name": "ETPL",
 			"details": "https://github.com/ecomfe/sublime-etpl",
-			"labels": ["snippets", "language", "syntax"],
+			"labels": ["snippets", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/f.json
+++ b/repository/f.json
@@ -1013,7 +1013,7 @@
 		{
 			"name":"Firebase Rules Syntax",
 			"details":"https://github.com/jingyuexing/Sublime-Firebase-Syntax",
-			"labels":["language syntax","syntax"],
+			"labels":["language syntax"],
 			"releases":[
 				{
 					"sublime_text":"*",
@@ -1873,7 +1873,7 @@
 		{
 			"name": "FSP Syntax",
 			"details": "https://github.com/toboid/sublime-fsp-syntax",
-			"labels": ["syntax", "fsp", "ltsa"],
+			"labels": ["language syntax", "fsp", "ltsa"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/g.json
+++ b/repository/g.json
@@ -1460,7 +1460,7 @@
 		{
 			"name": "Gomod",
 			"details": "https://github.com/Mitranim/sublime-gomod",
-			"labels": ["golang", "go", "syntax"],
+			"labels": ["golang", "go", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/h.json
+++ b/repository/h.json
@@ -1230,7 +1230,7 @@
 		{
 			"name": "HTML Syntax in Script",
 			"details": "https://github.com/cmcleese/sublime-html-script-all",
-			"labels": ["syntax", "html", "script", "highlighting"],
+			"labels": ["language syntax", "html", "script"],
 			"releases": [
 				{
 					"sublime_text": ">=3170",
@@ -1456,7 +1456,7 @@
 		{
 			"name": "HTTP Spec Syntax",
 			"details": "https://github.com/samsalisbury/Sublime-HTTP",
-			"labels": ["syntax", "http", "spec"],
+			"labels": ["language syntax", "http", "spec"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1601,7 +1601,7 @@
 		{
 			"name": "Hyperscript",
 			"details": "https://github.com/gnat/hyperscript-sublime",
-			"labels": ["language syntax", "syntax", "html", "script", "highlighting", "htmx", "javascript"],
+			"labels": ["language syntax", "html", "script", "htmx", "javascript"],
 			"releases": [
 				{
 					"sublime_text": ">=4121",

--- a/repository/i.json
+++ b/repository/i.json
@@ -177,7 +177,7 @@
 		{
 			"name": "IFJCode2017-syntax-highlight",
 			"details": "https://github.com/SonyPony/IFJCode2017-syntax-highlight",
-			"labels": ["language syntax", "syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -603,7 +603,7 @@
 		{
 			"name": "Indentor",
 			"details": "https://github.com/omkarjc27/sublime_indentor",
-			"labels": ["convert", "converting", "formatting", "indent", "language_syntax", "scope"],
+			"labels": ["convert", "converting", "formatting", "indent", "language syntax", "scope"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/j.json
+++ b/repository/j.json
@@ -81,7 +81,7 @@
 		{
 			"name": "JamfLog",
 			"details": "https://github.com/jorks/sublime-jamflog",
-			"labels": ["jamf","log","highlighting"],
+			"labels": ["jamf", "log", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -232,7 +232,7 @@
 		{
 			"name": "Java Bytecode",
 			"details": "https://github.com/xdrop/Java-Bytecode",
-			"labels": ["java","bytecode","syntax","highlighting"],
+			"labels": ["java", "bytecode", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -995,7 +995,7 @@
 		{
 			"name": "JSCustom",
 			"details": "https://github.com/Thom1729/Sublime-JS-Custom",
-			"labels": ["javascript", "syntax"],
+			"labels": ["javascript", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "<4000",

--- a/repository/k.json
+++ b/repository/k.json
@@ -15,7 +15,7 @@
 		{
 			"name": "KABEMS",
 			"details": "https://github.com/konstantin24121/sublime-kabems",
-			"labels": ["KABEMS", "BEM", "syntax highlight"],
+			"labels": ["KABEMS", "BEM", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -70,7 +70,7 @@
 		{
 			"name": "Kconfig Syntax Highlight",
 			"details": "https://github.com/fallrisk/Kconfig-Highlighter",
-			"labels": ["Kconfig", "syntax highlight", "kernel config"],
+			"labels": ["Kconfig", "language syntax", "kernel config"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -595,7 +595,7 @@
 		{
 			"name": "Kusto Syntax Highlighter",
 			"details": "https://github.com/mmanela/kusto-sublime",
-			"labels": ["syntax highlight", "kusto", "azure data explorer"],
+			"labels": ["language syntax", "kusto", "azure data explorer"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/l.json
+++ b/repository/l.json
@@ -92,7 +92,7 @@
 		{
 			"name": "Language 1C (BSL)",
 			"details": "https://github.com/1c-syntax/sublime-language-1c-bsl",
-			"labels": ["language syntax", "highlighting"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -707,7 +707,7 @@
 		{
 			"name": "LDIF Syntax Highlighting",
 			"details": "https://github.com/FlashSystems/LDIF-Syntax",
-			"labels": ["language syntax", "syntax", "highlighting"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -922,7 +922,7 @@
 		{
 			"name": "Liberty",
 			"details": "https://github.com/mtmoreira/sublime-liberty",
-			"labels": ["syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1609,7 +1609,7 @@
 		{
 			"name": "Log Highlight",
 			"details": "https://github.com/poucotm/Log-Highlight",
-			"labels": ["log", "syntax", "highlighting"],
+			"labels": ["log", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1676,7 +1676,7 @@
 		{
 			"name": "Logos Syntax Highlighting",
 			"details": "https://github.com/wolfposd/Sublime-Logos",
-			"labels": ["language syntax", "syntax", "highlighting"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1698,7 +1698,7 @@
 		{
 			"name": "Logstash Syntax Highlighting",
 			"details": "https://github.com/nir0s/sublime-logstash-syntax-highlighter",
-			"labels": ["language syntax", "syntax", "highlighting"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1709,7 +1709,7 @@
 		{
 			"name": "LogView",
 			"details": "https://github.com/FlashSystems/LogView",
-			"labels": ["highlighting", "logs"],
+			"labels": ["language syntax", "logs"],
 			"releases": [
 				{
 					"sublime_text": ">=3065",
@@ -1720,7 +1720,7 @@
 		{
 			"name": "LOLCODE",
 			"details": "https://github.com/ofekih/lolcode-sublime",
-			"labels": ["lolcode"],
+			"labels": ["lolcode", "language syntax", "completions"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/m.json
+++ b/repository/m.json
@@ -1731,7 +1731,7 @@
 			"name": "MiniZinc Language",
 			"details": "https://github.com/astenmark/sublime-mzn",
 			"author": "Andreas Stenmark",
-			"labels": ["minizinc", "language syntax", "mzn" "build system"],
+			"labels": ["minizinc", "language syntax", "mzn", "build system"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/m.json
+++ b/repository/m.json
@@ -1546,7 +1546,7 @@
 		{
 			"name": "Microsoft Power Query Syntax",
 			"details": "https://github.com/dannysummerlin/PowerQuerySublimeSyntax",
-			"labels": ["language syntax" "query", "excel", "powerbi", "microsoft", "ms"],
+			"labels": ["language syntax", "query", "excel", "powerbi", "microsoft", "ms"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/m.json
+++ b/repository/m.json
@@ -4,7 +4,7 @@
 		{
 			"name": "M3U Syntax",
 			"details": "https://github.com/sal0max/sublime-m3u",
-			"labels": ["text syntax", "syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1004,7 +1004,7 @@
 		{
 			"name": "MathML",
 			"details": "https://github.com/Sensibility/MathML-Sublime-Plugin",
-			"labels": ["language syntax", "syntax", "MathML-syntax"],
+			"labels": ["language syntax", "MathML"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1377,7 +1377,7 @@
 		{
 			"name": "Mermaid",
 			"details": "https://github.com/SublimeText/Mermaid",
-			"labels": ["build system", "language_syntax", "graph"],
+			"labels": ["build system", "language syntax", "graph"],
 			"releases": [
 				{
 					"sublime_text": "3092 - 4049",
@@ -1392,7 +1392,7 @@
 		{
 			"name": "Meson",
 			"details": "https://github.com/Monochrome-Sauce/sublime-meson",
-			"labels": ["build system", "language_syntax"],
+			"labels": ["build system", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=4095",
@@ -1546,7 +1546,7 @@
 		{
 			"name": "Microsoft Power Query Syntax",
 			"details": "https://github.com/dannysummerlin/PowerQuerySublimeSyntax",
-			"labels": ["language","syntax","highlighting","query","excel","powerbi","microsoft","ms"],
+			"labels": ["language syntax" "query", "excel", "powerbi", "microsoft", "ms"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1557,7 +1557,7 @@
 		{
 			"name": "Mika",
 			"details": "https://github.com/kyoto-shift/Mika",
-			"labels": ["mika", "language", "syntax", "highlighting"],
+			"labels": ["mika", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1569,7 +1569,7 @@
 			"name": "Miking Syntax Highlighting",
 			"previous_names": ["MCore Syntax Highlighting"],
 			"details": "https://github.com/miking-lang/miking-sublime-text",
-			"labels": ["mcore", "miking", "language", "syntax", "highlighting"],
+			"labels": ["mcore", "miking", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1708,7 +1708,7 @@
 			"name": "Miniscript",
 			"details": "https://github.com/thmour/sublime-miniscript",
 			"author": "Mouratidis Theofilos",
-			"labels": ["miniscript", "language", "syntax", "highlighting"],
+			"labels": ["miniscript", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1731,7 +1731,7 @@
 			"name": "MiniZinc Language",
 			"details": "https://github.com/astenmark/sublime-mzn",
 			"author": "Andreas Stenmark",
-			"labels": ["minizinc", "language", "mzn", "syntax", "highlighting", "build", "system"],
+			"labels": ["minizinc", "language syntax", "mzn" "build system"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2827,7 +2827,7 @@
 		{
 			"name": "Murphi",
 			"details": "https://bitbucket.org/timlinsc/sublimemurphi",
-			"labels": ["text syntax", "syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/n.json
+++ b/repository/n.json
@@ -48,7 +48,7 @@
 		{
 			"name": "Nano RC Syntax",
 			"details": "https://github.com/gerph/sublimetext-nanorc-syntax",
-			"labels": ["syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -70,7 +70,7 @@
 		{
 			"name": "Naomi",
 			"details": "https://github.com/borela/naomi",
-			"labels": ["enhanced", "syntax", "highlight"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -81,7 +81,7 @@
 		{
 			"name": "naomi-syntax",
 			"details": "https://github.com/foisonocean/naomi-syntax",
-			"labels": ["syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -125,7 +125,7 @@
 		{
 			"name": "NativeScript Core XML Syntax",
 			"details": "https://github.com/CatchABus/sublime-nativescript-xml-syntax",
-			"labels": ["nativescript", "syntax", "highlight"],
+			"labels": ["nativescript", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1095,7 +1095,7 @@
 		{
 			"name": "Nova Template Highlighter",
 			"details": "https://github.com/nova-framework/template-highlighter-sublime-text",
-			"labels": ["nova", "syntax highlighter"],
+			"labels": ["nova", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/o.json
+++ b/repository/o.json
@@ -975,7 +975,7 @@
 		{
 			"name": "OPUS",
 			"details": "https://github.com/spywhere/OPUS",
-			"labels": ["syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/p.json
+++ b/repository/p.json
@@ -1021,7 +1021,7 @@
 		{
 			"name": "phJade",
 			"details": "https://github.com/konstantin24121/phJade",
-			"labels": ["jade-php", "syntax highlight"],
+			"labels": ["jade-php", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2172,7 +2172,7 @@
 		{
 			"name": "PPCL Language Syntax and Editor",
 			"details": "https://github.com/blandfbt/PPCL",
-			"labels": ["PPCL", "syntax", "siemens", "apogee"],
+			"labels": ["PPCL", "language syntax", "siemens", "apogee"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3170,7 +3170,7 @@
 		{
 			"name": "PyScript",
 			"details": "https://github.com/Sublime-Instincts/PyScript",
-			"labels": ["syntax highlight", "python", "pyscript", "language syntax"],
+			"labels": ["python", "pyscript", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=4126",

--- a/repository/q.json
+++ b/repository/q.json
@@ -364,7 +364,7 @@
 		{
 			"name": "QuickTemplate (Go)",
 			"details": "https://github.com/SharanSharathi/sublime_qtpl",
-			"labels": ["template", "go", "qtpl", "syntax", "auto-complete", "build-system"],
+			"labels": ["template", "go", "qtpl", "language syntax", "auto-complete", "build system"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/r.json
+++ b/repository/r.json
@@ -229,7 +229,7 @@
 		{
 			"name": "rainbow_csv",
 			"details": "https://github.com/mechatroner/sublime_rainbow_csv",
-			"labels": ["csv", "tsv", "highlight"],
+			"labels": ["csv", "tsv", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1730,7 +1730,7 @@
 		{
 			"name": "RISC OS CMHG Syntax",
 			"details": "https://github.com/gerph/sublimetext-riscoscmhg-syntax",
-			"labels": ["syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1741,7 +1741,7 @@
 		{
 			"name": "RISC OS Command Syntax",
 			"details": "https://github.com/gerph/sublimetext-riscoscommand-syntax",
-			"labels": ["syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1872,7 +1872,7 @@
 			"name": "Rockstar Syntax Highlighter",
 			"details": "https://github.com/brownian-motion/sublime-rockstar-syntax",
 			"readme": "https://raw.githubusercontent.com/paxromana96/sublime-rockstar-syntax/master/README.md",
-			"labels": ["syntax-highlight", "rockstar", "language syntax"],
+			"labels": ["rockstar", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">3092",

--- a/repository/s.json
+++ b/repository/s.json
@@ -98,7 +98,7 @@
 			"name": "SAMB",
 			"description" : "SAMB (server assembly framework) syntax and snippets",
 			"details": "https://github.com/cheikhshift/samb-sublime",
-			"labels": ["SAMB syntax highlight", "snippets"],
+			"labels": ["language syntax", "snippets"],
 			"releases": [
 				{
 					"sublime_text": ">=3126",
@@ -109,7 +109,7 @@
 		{
 			"name": "San Syntax Highlight",
 			"details": "https://github.com/kekee000/san-sublime",
-			"labels": ["san syntax highlight", "snippets"],
+			"labels": ["language syntax", "snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1192,7 +1192,7 @@
 			"details": "https://github.com/beaugunderson/serpent-syntax",
 			"homepage": "https://github.com/beaugunderson/serpent-syntax",
 			"author": ["beaugunderson"],
-			"labels": ["serpent", "language-syntax"],
+			"labels": ["serpent", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2074,7 +2074,7 @@
 			"details": "https://github.com/budlabs/SimpleSyntax",
 			"description": "Comment syntax for config files",
 			"author": "Nils Kvist",
-			"labels": ["configfile", "syntax"],
+			"labels": ["configfile", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3367,7 +3367,7 @@
 			"name": "Splunk Conf File Syntax Highlighting",
 			"details": "https://github.com/shakeelmohamed/sublime-splunk-conf-highlighting",
 			"author": "Shakeel Mohamed",
-			"labels": ["language", "syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3451,7 +3451,7 @@
 			"name": "Sprak Syntax & Completions for else Heartbreak()",
 			"details": "https://github.com/Eforen/sublime-syntax-sprak",
 			"author": "Eforen (Ariel Lothlorien)",
-			"labels": ["language", "syntax", "snippets", "completions", "game"],
+			"labels": ["language syntax", "snippets", "completions", "game"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3617,7 +3617,7 @@
 			"name": "Squirrel",
 			"details": "https://github.com/Enduriel/Sublime-Squirrel",
 			"author": ["Enduriel", "micheg", "Roland Piirsoo"],
-			"labels": ["language", "syntax", "snippets", "completions", "squirrel"],
+			"labels": ["language syntax", "snippets", "completions", "squirrel"],
 			"releases": [
 				{
 					"sublime_text": ">=4107",
@@ -3629,7 +3629,7 @@
 			"name": "SRT",
 			"details": "https://github.com/SalGnt/Sublime-SRT",
 			"author": "Salvatore Gentile",
-			"labels": ["language", "syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3996,7 +3996,7 @@
 		{
 			"name": "Stencil",
 			"details": "https://github.com/kgston/stencil-syntax-sublime",
-			"labels": ["language", "syntax", "stencil"],
+			"labels": ["language syntax", "stencil"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4047,7 +4047,7 @@
 		{
 			"name": "StoryScript Highlight",
 			"details": "https://github.com/swwind/StoryScript-Highlight",
-			"labels": ["syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -4610,7 +4610,7 @@
 			"details": "https://github.com/AnarchyTools/SublimeAnarchy",
 			"homepage": "http://anarchytools.org",
 			"author": ["drewcrawford", "dunkelstern"],
-			"labels": ["build-system", "auto-complete", "language-syntax"],
+			"labels": ["build system", "auto-complete", "language syntax"],
 			"releases": [
 				{
 					"platforms": ["osx", "linux"],

--- a/repository/t.json
+++ b/repository/t.json
@@ -581,7 +581,7 @@
 			"name": "TemplateToolkit",
 			"details": "https://github.com/znuny/TemplateToolkit-sublime",
 			"author": "Znuny GmbH",
-			"labels": ["TemplateToolkit", "Template Toolkit", "syntax", "snippets"],
+			"labels": ["TemplateToolkit", "Template Toolkit", "language syntax", "snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1228,7 +1228,7 @@
 			"name": "Theme - City Lights",
 			"details": "https://github.com/Yummygum/city-lights-sublime",
 			"homepage": "http://citylights.xyz/",
-			"labels": ["theme", "color scheme", "City Lights", "syntax"],
+			"labels": ["theme", "color scheme", "City Lights"],
 			"author": "Yummygum",
 			"releases": [
 				{
@@ -3138,7 +3138,7 @@
 			"name": "Tornado",
 			"description": "Template syntax for Python's Tornado web framework.",
 			"details": "https://github.com/nickbaum/sublime-tornado/",
-			"labels": ["syntax highlight", "python", "html"],
+			"labels": ["language syntax", "python", "html"],
 			"releases": [
 				{
 					"sublime_text": ">=3084",
@@ -3296,7 +3296,7 @@
 			"homepage": "http://trainz-sachsen.com",
 			"readme": "https://raw.githubusercontent.com/Dangoo/trainz_config/master/README.md",
 			"author": "Daniel Gooß",
-			"labels": ["syntax highlight", "language"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3675,7 +3675,7 @@
 		{
 			"name": "Twig",
 			"details": "https://github.com/Sublime-Instincts/BetterTwig",
-			"labels": ["Twig", "templates", "PHP", "syntax"],
+			"labels": ["Twig", "templates", "PHP", "language syntax"],
 			"previous_names": ["PHP-Twig"],
 			"releases": [
 				{

--- a/repository/v.json
+++ b/repository/v.json
@@ -100,7 +100,7 @@
 		{
 			"name": "Varicolor",
 			"details": "https://github.com/evan-erdos/varicolor",
-			"labels": ["highlighting","tmLanguage","sublime-syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3084",
@@ -122,7 +122,7 @@
 		{
 			"name": "Varnish VCL",
 			"details": "https://github.com/brandonwamboldt/sublime-varnish",
-			"labels": ["vcl", "varnish", "language", "syntax"],
+			"labels": ["vcl", "varnish", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -195,7 +195,7 @@
 		{
 			"name": "VDP Logs",
 			"details": "https://github.com/narendrans/sublime-vdp-logs",
-			"labels": ["syntax","vdp","denodo"],
+			"labels": ["language syntax","vdp","denodo"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -384,7 +384,7 @@
 			"name": "VimL",
 			"details": "https://github.com/SalGnt/Sublime-VimL",
 			"author": "Salvatore Gentile",
-			"labels": ["language", "syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/w.json
+++ b/repository/w.json
@@ -330,7 +330,7 @@
 		{
 			"name": "WEOML Syntax",
 			"details": "https://github.com/weo-media/WEOML",
-			"labels": ["weo", "keys", "syntax"],
+			"labels": ["weo", "keys", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -498,7 +498,7 @@
 			"name": "Wildlife Color Scheme",
 			"previous_names":["Wildlife"],
 			"details": "https://github.com/tushortz/wildlife",
-			"labels": ["color scheme","highlighting","linting"],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -628,7 +628,7 @@
 		{
 			"name": "WML",
 			"details": "https://github.com/sevu/Sublime-WML",
-			"labels": ["wesnoth", "markup", "language", "syntax", "definition", "highlighting", "highlighter"],
+			"labels": ["wesnoth", "markup", "language syntax"],
 			"donate": "https://liberapay.com/Battle_for_Wesnoth",
 			"description": "Adds support for the Wesnoth Markup Language.",
 			"author": "Severin Glöckner",

--- a/repository/x.json
+++ b/repository/x.json
@@ -14,7 +14,7 @@
 		{
 			"name": "X10Language",
 			"details": "https://github.com/ltronky/sublime-x10",
-			"labels": ["syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -37,6 +37,7 @@
 		{
 			"name": "XAML",
 			"details": "https://github.com/maslbl4/sublime-xaml",
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/y.json
+++ b/repository/y.json
@@ -80,7 +80,7 @@
 		{
 			"name": "Yara Rule Syntax",
 			"details": "https://github.com/nyx0/YaraSyntax",
-			"labels": ["Yara", "syntax", "snippets"],
+			"labels": ["Yara", "language syntax", "snippets"],
 			"previous_names": ["Yara Rule"],
 			"releases": [
 				{
@@ -123,7 +123,7 @@
 		{
 			"name": "YASMJinja2",
 			"details": "https://github.com/m-messiah/yasm-jinja2",
-			"labels": ["yasm", "jinja2", "yandex", "formatting", "syntax"],
+			"labels": ["yasm", "jinja2", "yandex", "formatting", "language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -237,7 +237,7 @@
 		{
 			"name": "Yosys",
 			"details": "https://github.com/YosysHQ/Sublime-Yosys",
-			"labels": ["syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",


### PR DESCRIPTION
This is not a new package. I am attempting to simplify the [Labels page](https://packagecontrol.io/browse/labels) on PC.

I didn't know what to do with @malexer's syntax history package, which is closer to AutoSetSyntax and ApplySyntax, so I left tags for that one alone.