### PR TITLE
Drop numpy dependency

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -555,21 +555,6 @@
 			]
 		},
 		{
-			"name": "numpy",
-			"description": "Python numpy module",
-			"author": "komsit37",
-			"issues": "https://github.com/komsit37/sublime-numpy/issues",
-			"load_order": "01",
-			"releases": [
-				{
-					"base": "https://github.com/komsit37/sublime-numpy",
-					"platforms": ["windows-x64","osx-x64","linux-x64"],
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "oauthlib",
 			"description": "Python oauthlib module",
 			"author": "csch0",


### PR DESCRIPTION
This commit removes `numpy` dependency as related repository no longer exists.