### PR TITLE
Reduce duplicate tags of "build system"

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -432,7 +432,7 @@
 			"name": "Advanced PLSQL",
 			"previous_names": ["Oracle PL SQL"],
 			"details": "https://github.com/TheEggi/Advanced-PLSQL",
-			"labels": ["snippets", "plsql", "oracle", "build"],
+			"labels": ["snippets", "plsql", "oracle", "build system"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1764,7 +1764,7 @@
 		{
 			"name": "ArmaBuild",
 			"details": "https://github.com/jonpas/Sublime-ArmaBuild",
-			"labels": ["build", "build system"],
+			"labels": ["build system"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/c.json
+++ b/repository/c.json
@@ -3248,7 +3248,7 @@
 			"name": "Compass",
 			"details": "https://github.com/whatwedo/sublime-text-compass",
 			"author": "whatwedo",
-			"labels": ["compass", "scss", "sass", "css", "precompiler", "build", "watch", "css3", "build system", "minification"],
+			"labels": ["compass", "scss", "sass", "css", "precompiler", "watch", "css3", "build system", "minification"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3480,7 +3480,7 @@
 			"name": "Console Exec",
 			"details": "https://github.com/joeyespo/sublimetext-console-exec",
 			"author": "Joe Esposito",
-			"labels": ["build", "console", "terminal", "utilities"],
+			"labels": ["build system", "console", "terminal", "utilities"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/d.json
+++ b/repository/d.json
@@ -1345,7 +1345,7 @@
 		{
 			"name": "Docker Based Build Systems",
 			"details": "https://github.com/domeide/sublime-docker",
-			"labels": ["build system","build"],
+			"labels": ["build system"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/e.json
+++ b/repository/e.json
@@ -1251,7 +1251,7 @@
 			"name": "eScript Syntax",
 			"details": "https://github.com/polserver/sublime-escript",
 			"author": "POL Team",
-			"labels": ["color scheme", "autocompletion","tooltips","buildsystem"],
+			"labels": ["color scheme", "autocompletion","tooltips","build system"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/j.json
+++ b/repository/j.json
@@ -25,7 +25,7 @@
 		{
 			"name": "Jade Build",
 			"details": "https://github.com/mutian/Sublime-Jade-Build",
-			"labels": ["jade", "build", "build system"],
+			"labels": ["jade", "build system"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -70,7 +70,7 @@
 		{
 			"name": "Jam Language",
 			"details": "https://github.com/BenjaminSchaaf/jam-sublime-syntax",
-			"labels": ["jam", "language syntax", "build"],
+			"labels": ["jam", "language syntax", "build system"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -102,7 +102,7 @@
 		{
 			"name": "Janet",
 			"details": "https://github.com/archydragon/sublime-janet",
-			"labels": ["janet", "language syntax", "build"],
+			"labels": ["janet", "language syntax", "build system"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/m.json
+++ b/repository/m.json
@@ -290,6 +290,7 @@
 		},
 		{
 			"name": "Makefile Plus",
+			"labels": ["language syntax"],
 			"details": "https://github.com/Altomare/sublime-makefile-plus",
 			"releases": [
 				{
@@ -301,7 +302,7 @@
 		{
 			"name": "makensis",
 			"details": "https://github.com/idleberg/sublime-makensis",
-			"labels": ["build", "nsis"],
+			"labels": ["build system", "nsis"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -312,7 +313,7 @@
 		{
 			"name": "MakeTargets",
 			"details": "https://github.com/dusk125/sublime-maketargets",
-			"labels": ["make", "makefile", "target"],
+			"labels": ["make", "makefile", "target", "build system"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -493,7 +494,7 @@
 		{
 			"name": "Markdown HTML Preview",
 			"details": "https://github.com/zeyon/MarkdownHtmlPreview",
-			"labels": ["markdown", "preview", "build", "html"],
+			"labels": ["markdown", "preview", "build system", "html"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -692,7 +693,7 @@
 		{
 			"name": "MarkdownPreview",
 			"details": "https://github.com/facelessuser/MarkdownPreview",
-			"labels": ["markdown", "preview", "build"],
+			"labels": ["markdown", "preview", "build system"],
 			"previous_names": ["Markdown Preview"],
 			"releases": [
 				{
@@ -726,7 +727,7 @@
 		{
 			"name": "Marked App Menu",
 			"details": "https://github.com/icio/sublime-text-marked",
-			"labels": ["markdown", "preview", "build", "marked.app"],
+			"labels": ["markdown", "preview", "build system", "marked.app"],
 			"previous_names": ["Marked.app Menu"],
 			"releases": [
 				{

--- a/repository/o.json
+++ b/repository/o.json
@@ -1129,7 +1129,7 @@
 			"details": "https://github.com/mozart/sublime-oz",
 			"readme": "https://raw.githubusercontent.com/mozart/sublime-oz/master/README.md",
 			"author": "Robert Koeninger",
-			"labels": ["build-system", "language syntax", "snippets"],
+			"labels": ["build system", "language syntax", "snippets"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/p.json
+++ b/repository/p.json
@@ -3092,7 +3092,7 @@
 		{
 			"name": "Pynsist",
 			"details": "https://github.com/idleberg/sublime-pynsist",
-			"labels": ["build-system", "language syntax", "nsis", "python"],
+			"labels": ["build system", "language syntax", "nsis", "python"],
 			"releases": [
 				{
 					"sublime_text": ">=3103",

--- a/repository/s.json
+++ b/repository/s.json
@@ -148,7 +148,7 @@
 			"name": "SAS Programming",
 			"description": "For using SAS Institute's Analytics & Data Management system.",
 			"details": "https://github.com/rpardee/sas",
-			"labels": ["language syntax", "build-system", "snippets"],
+			"labels": ["language syntax", "build system", "snippets"],
 			"author": ["rpardee", "friedegg", "seemack"],
 			"releases": [
 				{
@@ -162,7 +162,7 @@
 			"description": "A Sublime Text 3 package for SAS syntax highlighting and the corresponding SAS Theme" ,
 			"details": "https://github.com/77QingLiu/SAS-Syntax-and-Theme",
 			"homepage": "https://github.com/77QingLiu/SAS-Syntax-and-Theme",
-			"labels": ["language syntax", "Theme", "build-system", "snippets"],
+			"labels": ["language syntax", "color scheme", "build system", "snippets"],
 			"author": ["Qing"],
 			"releases": [
 				{
@@ -202,6 +202,7 @@
 		{
 			"name": "SASS Build",
 			"details": "https://github.com/jaumefontal/SASS-Build-SublimeText2",
+			"labels": ["build system"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3583,7 +3584,7 @@
 		{
 			"name": "Sqlx Builder",
 			"details": "https://github.com/taojy123/SublimeText-Sqlx",
-			"labels": ["sql", "sqlx", "extension", "builder", "tools"],
+			"labels": ["sql", "sqlx", "extension", "build system", "tools"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
Similar to #9088

Please be aware: I am not auditing all packages to see if any have a `*.sublime-build` or equivalent Python but are missing the label. I am only checking permutations of existing labels (`make`, `build-system`, etc.) that suggest they might include a build system.