### PR TITLE
Fix .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 text eol=lf
-* -crlf


### PR DESCRIPTION
Removed line is causing lots of trouble on Windows, when resolving conflicts with Sublime Merge, with files being committed with CRLF - exactly what is intended to be avoided.

Properly set-up (default) installation of Git for Windows already ensures files being committed with LF.
