### PR TITLE
Update Terraform package

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -760,12 +760,12 @@
 			"details": "https://github.com/SublimeText/Terraform",
 			"releases": [
 				{
-					"sublime_text": "<4169",
+					"sublime_text": "<4180",
 					"tags": "2000-"
 				},
 				{
-					"sublime_text": ">=4169",
-					"tags": "4169-"
+					"sublime_text": ">=4180",
+					"tags": "4180-"
 				}
 			]
 		},


### PR DESCRIPTION
This commit bumps minimum required ST build for not yet released ST4-only releases to build 4180, as it is required to extend on ST's JSON syntax.

caused by: https://github.com/SublimeText/Terraform/pull/71
