### PR TITLE
Add Zmpl language syntax

### DIFF
--- a/repository/z.json
+++ b/repository/z.json
@@ -201,6 +201,18 @@
 			]
 		},
 		{
+			"name": "Zmpl",
+			"details": "https://github.com/uzyn/zmpl-grammar",
+			"author": "U-Zyn Chua",
+			"labels": ["zmpl", "zig", "jetzig", "language syntax", "grammar", "html", "markdown"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "main"
+				}
+			]
+		},
+		{
 			"name": "zmq",
 			"details": "https://github.com/reqshark/sublimezmq",
 			"labels": ["zeromq", "binding", "zmq"],

--- a/repository/z.json
+++ b/repository/z.json
@@ -204,7 +204,7 @@
 			"name": "Zmpl",
 			"details": "https://github.com/uzyn/zmpl-grammar",
 			"author": "U-Zyn Chua",
-			"labels": ["zmpl", "zig", "jetzig", "language syntax", "grammar", "html", "markdown"],
+			"labels": ["zmpl", "zig", "jetzig", "language syntax", "html", "markdown"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/z.json
+++ b/repository/z.json
@@ -207,8 +207,8 @@
 			"labels": ["zmpl", "zig", "jetzig", "language syntax", "html", "markdown"],
 			"releases": [
 				{
-					"sublime_text": "*",
-					"branch": "main"
+					"sublime_text": ">=3092",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is [Zmpl](https://github.com/uzyn/zmpl-grammar) and it adds [Zmpl language](https://github.com/jetzig-framework/zmpl) syntax highlighting.

There are no packages like it in Package Control.
