### PR TITLE
switch colinta to 'main' branch

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -18,7 +18,7 @@
 		"https://raw.githubusercontent.com/bradfeehan/SublimePHPCoverage/master/packages.json",
 		"https://raw.githubusercontent.com/buildersbrewery/sublime-lsl/master/package_control_channel.json",
 		"https://raw.githubusercontent.com/chikatoike/IMESupport/master/packages.json",
-		"https://raw.githubusercontent.com/colinta/sublime_packages/master/packages.json",
+		"https://raw.githubusercontent.com/colinta/sublime_packages/main/packages.json",
 		"https://raw.githubusercontent.com/csch0/SublimeText-Packages/master/packages.json",
 		"https://raw.githubusercontent.com/damccull/sublimetext-SolarizedToggle/master/packages.json",
 		"https://raw.githubusercontent.com/danielmagnussons/orgmode/master/packages.json",


### PR DESCRIPTION
The packages.json file that was being pulled down was out of date - I've pushed to `master` in the meantime, but also figured I would update this to the correct branch name.