### PR TITLE
Add SaveThemAll plugin

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -285,6 +285,21 @@
 			]
 		},
 		{
+		    "name": "SaveThemAll",
+		    "details": "https://github.com/hardrockhodl/SaveThemAll",
+		    "author": "Hardrockhodl",
+		    "issues": "https://github.com/hardrockhodl/SaveThemAll/issues",
+		    "labels": ["file creation", "text manipulation", "productivity"],
+		    "releases": [
+		        {
+		            "sublime_text": ">=3000",
+		            "platforms": ["*"],
+		            "python_versions": ["3.3", "3.8"],
+		            "tags": true
+		        }
+		    ]
+		},
+		{
 			"name": "SBT Runner",
 			"details": "https://github.com/chiappone/Sublime-SBT-Runner",
 			"releases": [


### PR DESCRIPTION
## **SaveThemAll** 
Autosaves unsaved Sublime Text buffers to project-based, date-organized directories with timestamped names (e.g., `2025-05-01_123456-abcd1234.txt`). 

Features include:
- configurable paths
- project mappings,
- commands to save buffers in the active window or all windows.

---

- Hosted at: [github.com/hardrockhodl/SaveThemAll](https://github.com/hardrockhodl/SaveThemAll)
- Tested on Sublime Text 3/4 (macOS; Windows/Linux [specify: tested/untested]).
- Includes LICENSE (MIT), README.md, Default.sublime-commands, Default.sublime-keymap, CHANGELOG.md.
- No .pyc or invalid files included.
- Supports Python 3.3 and 3.8.
---
## **Checklist**:
- [x] I'm the package's author (hardrockhodl).
- [x] I have read the docs (https://packagecontrol.io/docs/submitting_a_package).
- [x] Tagged release with semver (v1.0.0 or v1.0.1).
- [x] Repo has description and detailed README.
- [x] No context menu entries.
- [x] No key bindings (commented suggestions in Default.sublime-keymap).
- [x] Commands will be available via Command Palette (Default.sublime-commands added).
- [x] Preferences accessible via Package Settings; keybindings manual.
- [x] Not a syntax package.
- [x] No unnecessary files; .gitattributes not needed (no images/tests).
- No similar packages in Package Control; SaveThemAll is unique for autosaving unsaved buffers.

@packagecontrol-bot please review
