### PR TITLE
Add Bash Completions package

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -244,6 +244,17 @@
 			]
 		},
 		{
+			"name": "Bash Completions",
+			"details": "https://github.com/SublimeText/BashCompletions",
+			"labels": ["auto-complete"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Bats",
 			"previous_names": ["Bats (Bash Automated Testing System)"],
 			"details": "https://github.com/SublimeText/bash-automated-testing-system",


### PR DESCRIPTION
This commit adds Bash auto completion plugin, which leverages `compgen` to provide context sensitive completions for commands, files/paths and environment variables.

<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
