### PR TITLE
Rename SuperSettings and switch to manual hosting

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -123,6 +123,7 @@
 		"https://raw.githubusercontent.com/x3ns/x3-alpha-theme/master/packages.json",
 		"https://raw.githubusercontent.com/xgenvn/InputHelper/master/packages.json",
 		"https://raw.githubusercontent.com/zfkun/sublime-kissy-snippets/master/packages.json",
-		"https://tinkerwell.app/plugins/sublime/packages.json"
+		"https://tinkerwell.app/plugins/sublime/packages.json",
+		"https://tobygiacometti.com/sublime/packages.json"
 	]
 }

--- a/repository/s.json
+++ b/repository/s.json
@@ -5422,17 +5422,6 @@
 			]
 		},
 		{
-			"name": "SuperSettings",
-			"details": "https://github.com/TobyGiacometti/SublimeSuperSettings",
-			"previous_names": ["Directory Settings"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Suricate",
 			"details": "https://github.com/nsubiron/SublimeSuricate",
 			"labels": [


### PR DESCRIPTION
I recently migrated all my projects from GitHub to Codeberg. As a result, manual hosting is now necessary for SuperSettings. I also decided to rename SuperSettings to DirectorySettings since it is a more descriptive name.