### PR TITLE
create naming and labelling guide

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ feel free to remove what't not applicable.
 - [ ] Any commands are available via the command palette.
 - [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
 - [ ] If my package is a syntax it doesn't also add a color scheme. ***
-- [ ] If my package is a syntax it is named after the language it supports (without suffixes like "syntax" or "highlighting").
+- [ ] I have read the [style guide](https://github.com/wbond/package_control_channel/?tab=readme-ov-file#style-guide)
 - [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.
 
 My package is ...

--- a/readme.md
+++ b/readme.md
@@ -17,11 +17,20 @@ A few words towards naming conventions etc, for entries in these files:
 
 - Packages avoid having the word "Sublime" in their name (see [docs](https://packagecontrol.io/docs/submitting_a_package#Step_2)). 
 - Language support (aka "syntax" or "grammar") packages are named after the language it supports, without suffixes like "syntax" or "highlighting" (e.g. #8801).
-- Labels:
-  - Packages that introduce a [language syntax](https://www.sublimetext.com/docs/syntax.html) have the "language syntax" label (see #9088).
-  - Packages that provide (the colors for) [syntax highlighting](https://www.sublimetext.com/docs/color_schemes.html) have the "color scheme" label, whereas packages that provide [theming for the UI](https://www.sublimetext.com/docs/themes.html) have the "theme" label.
-  - Packages that introduce a [build system](https://www.sublimetext.com/docs/build_systems.html) have the "build system" label (see #9093).
-  - Packages that introduce [snippets](https://www.sublimetext.com/docs/completions.html#snippets) have the "snippets" label (see #9095).
-  - Packages that introduce [completion metadata](https://www.sublimetext.com/docs/completions.html#completion-metadata) have the "completions" label (see #9095).
-  - Packages that introduce any other kind of auto-complete have the "auto-complete" label (see #9095).
-  - Utility packages have the "utilities" label (see #9094).
+- Labels are always in lowercase.
+- Packages that provide ... 
+  - a [language syntax](https://www.sublimetext.com/docs/syntax.html) have the "language syntax" label (see #9088).
+  - (the colors for) [syntax highlighting](https://www.sublimetext.com/docs/color_schemes.html) have the "color scheme" label, whereas packages that provide [theming for the UI](https://www.sublimetext.com/docs/themes.html) have the "theme" label.
+  - a [build system](https://www.sublimetext.com/docs/build_systems.html) have the "build system" label (see #9093).
+  - [snippets](https://www.sublimetext.com/docs/completions.html#snippets) have the "snippets" label (see #9095).
+  - [completion metadata](https://www.sublimetext.com/docs/completions.html#completion-metadata) have the "completions" label (see #9095).
+  - any other kind of auto-complete have the "auto-complete" label (see #9095).
+  - formatters have the "formatting" label, and optionally "prettify" or "minify", if appropriate.
+- Utility packages have the "utilities" label (see #9094).
+
+## Other notable repositories
+
+This is the main repository of Sublime Text packages. However:
+
+- Linter packages should in most cases be submitted over at [SublimeLinter](https://github.com/SublimeLinter/package_control_channel).
+- Similarly, any language server protocol packages are managed via [SublimeLSP](https://github.com/sublimelsp/repository).

--- a/readme.md
+++ b/readme.md
@@ -10,3 +10,16 @@ and is included with Package Control as the default channel.
 **Please be sure to follow the instructions at
 https://packagecontrol.io/docs/submitting_a_package to help the process of adding your
 package or repository go smoothly.**
+
+## Style guide
+
+A few words towards naming conventions etc, for entries in these files:
+
+- Syntax packages are named after the language it supports, without suffixes like "syntax" or "highlighting" (e.g. #8801).
+- Labels:
+  - Syntax packages have the "language syntax" label (see #9088).
+  - Utility packages have the "utilities" label (see #9094).
+  - Packages that introduce a [build system](https://www.sublimetext.com/docs/build_systems.html) have the "build system" label (see #9093).
+  - Packages that introduce [snippets](https://www.sublimetext.com/docs/completions.html#snippets) have the "snippets" label (see #9095).
+  - Packages that introduce [completion metadata](https://www.sublimetext.com/docs/completions.html#completion-metadata) have the "completions" label (see #9095).
+  - Packages that introduce any other kind of auto-complete have the "auto-complete" label (see #9095).

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ package or repository go smoothly.**
 
 A few words towards naming conventions etc, for entries in these files:
 
+- Packages avoid having the word "Sublime" in their name (see [docs](https://packagecontrol.io/docs/submitting_a_package#Step_2)). 
 - Syntax packages are named after the language it supports, without suffixes like "syntax" or "highlighting" (e.g. #8801).
 - Labels:
   - Syntax packages have the "language syntax" label (see #9088).

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ A few words towards naming conventions etc, for entries in these files:
 - Language support (aka "syntax" or "grammar") packages are named after the language it supports, without suffixes like "syntax" or "highlighting" (e.g. #8801).
 - Labels:
   - Packages that introduce a [language syntax](https://www.sublimetext.com/docs/syntax.html) have the "language syntax" label (see #9088).
-  - Packages that provide (the colors for)[ syntax highlighting](https://www.sublimetext.com/docs/color_schemes.html) have the "color scheme" label, whereas packages that provide [theming for the UI](https://www.sublimetext.com/docs/themes.html) have the "theme" label.
+  - Packages that provide (the colors for) [syntax highlighting](https://www.sublimetext.com/docs/color_schemes.html) have the "color scheme" label, whereas packages that provide [theming for the UI](https://www.sublimetext.com/docs/themes.html) have the "theme" label.
   - Packages that introduce a [build system](https://www.sublimetext.com/docs/build_systems.html) have the "build system" label (see #9093).
   - Packages that introduce [snippets](https://www.sublimetext.com/docs/completions.html#snippets) have the "snippets" label (see #9095).
   - Packages that introduce [completion metadata](https://www.sublimetext.com/docs/completions.html#completion-metadata) have the "completions" label (see #9095).

--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,9 @@ A few words towards naming conventions etc, for entries in these files:
 - Packages avoid having the word "Sublime" in their name (see [docs](https://packagecontrol.io/docs/submitting_a_package#Step_2)). 
 - Syntax packages are named after the language it supports, without suffixes like "syntax" or "highlighting" (e.g. #8801).
 - Labels:
-  - Syntax packages have the "language syntax" label (see #9088).
+  - Language support (aka "syntax" or "grammar") packages have the "language syntax" label (see #9088).
   - Utility packages have the "utilities" label (see #9094).
+  - Packages that provide (the colors for) syntax highlighting have the "color scheme" label, whereas packages that provide theming for the UI have the "theme" label.
   - Packages that introduce a [build system](https://www.sublimetext.com/docs/build_systems.html) have the "build system" label (see #9093).
   - Packages that introduce [snippets](https://www.sublimetext.com/docs/completions.html#snippets) have the "snippets" label (see #9095).
   - Packages that introduce [completion metadata](https://www.sublimetext.com/docs/completions.html#completion-metadata) have the "completions" label (see #9095).

--- a/readme.md
+++ b/readme.md
@@ -16,12 +16,12 @@ package or repository go smoothly.**
 A few words towards naming conventions etc, for entries in these files:
 
 - Packages avoid having the word "Sublime" in their name (see [docs](https://packagecontrol.io/docs/submitting_a_package#Step_2)). 
-- Syntax packages are named after the language it supports, without suffixes like "syntax" or "highlighting" (e.g. #8801).
+- Language support (aka "syntax" or "grammar") packages are named after the language it supports, without suffixes like "syntax" or "highlighting" (e.g. #8801).
 - Labels:
-  - Language support (aka "syntax" or "grammar") packages have the "language syntax" label (see #9088).
-  - Utility packages have the "utilities" label (see #9094).
-  - Packages that provide (the colors for) syntax highlighting have the "color scheme" label, whereas packages that provide theming for the UI have the "theme" label.
+  - Packages that introduce a [language syntax](https://www.sublimetext.com/docs/syntax.html) have the "language syntax" label (see #9088).
+  - Packages that provide (the colors for)[ syntax highlighting](https://www.sublimetext.com/docs/color_schemes.html) have the "color scheme" label, whereas packages that provide [theming for the UI](https://www.sublimetext.com/docs/themes.html) have the "theme" label.
   - Packages that introduce a [build system](https://www.sublimetext.com/docs/build_systems.html) have the "build system" label (see #9093).
   - Packages that introduce [snippets](https://www.sublimetext.com/docs/completions.html#snippets) have the "snippets" label (see #9095).
   - Packages that introduce [completion metadata](https://www.sublimetext.com/docs/completions.html#completion-metadata) have the "completions" label (see #9095).
   - Packages that introduce any other kind of auto-complete have the "auto-complete" label (see #9095).
+  - Utility packages have the "utilities" label (see #9094).


### PR DESCRIPTION
RE #9095: describe how package should be named and labelled so we can refer to it during package review. 

By the way, I do notice that any package that adds any kind of "completion" related functionality, be it .sublime-snippets, .sublime-completions, or any kind of scripting based auto complete is likely to have a mix of "completions" and "auto-complete". So that doesn't render the effort less useful or anything, it just shows that there isn't a pre-existing and well known convention around those words. And honestly I just came up with what I propose here on the spot just to decide something. But now is as good at time as any to come up with some logic and attach some meaning to the labels.

@deathaxe @michaelblyons 

---

fixes #9096