### PR TITLE
Fix duplicate BBCode Syntax registration

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -94,7 +94,6 @@
 		"https://raw.githubusercontent.com/seanliang/ConvertToUTF8/master/packages.json",
 		"https://raw.githubusercontent.com/sentience/DokuWiki/master/packages.json",
 		"https://raw.githubusercontent.com/sentience/HyperlinkHelper/master/packages.json",
-		"https://raw.githubusercontent.com/Skullmonkey/sublime/master/packages.json",
 		"https://raw.githubusercontent.com/sokolovstas/SublimeWebInspector/master/packages.json",
 		"https://raw.githubusercontent.com/soncy/AutoComments-for-Sublime-Text-2/master/packages.json",
 		"https://raw.githubusercontent.com/spectacles/CodeComplice/master/packages.json",

--- a/repository/i.json
+++ b/repository/i.json
@@ -1115,6 +1115,18 @@
 			]
 		},
 		{
+			"name": "IPS BBCode",
+			"author": "LTM",
+			"details": "https://github.com/Skullmonkey/IPS-BBCode",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "IPS Package Manifest Syntax",
 			"details": "https://github.com/carsonoid/IPS-Pkg-Syntax",
 			"labels": ["language syntax", "markup"],

--- a/repository/l.json
+++ b/repository/l.json
@@ -1667,6 +1667,18 @@
 			]
 		},
 		{
+			"name": "Logitech G-Series LUA API",
+			"author": "LTM",
+			"details": "https://github.com/Skullmonkey/LGS-LUA",
+			"labels": ["auto-complete", "completions", "language syntax", "lua"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LogMagic",
 			"details": "https://github.com/syko/SublimeLogMagic",
 			"labels": ["logging", "logger", "logs", "debugging", "debug", "console", "output", "javascript", "utilities"],

--- a/repository/w.json
+++ b/repository/w.json
@@ -828,6 +828,18 @@
 			]
 		},
 		{
+			"name": "WordPress Gutenburg Blocks Autocompletions",
+			"author": "LTM",
+			"details": "https://github.com/Skullmonkey/Wordpress-Gutenberg-Blocks-Autocomplete",
+			"labels": ["auto-complete", "completions", "formatting", "wordpress"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "WordPress Internationalization (i18n)",
 			"details": "https://github.com/maheshwaghmare/sublime-wp-i18n",
 			"releases": [


### PR DESCRIPTION
Issue: "BBCode Syntax" is defined in local b.json and an external repository.

This commit moves packages into local repositories and removes reference to the external one to resolve the conflict, given that local BBCode syntax package is newer.

It was found by https://github.com/wbond/package_control/pull/1698#issuecomment-2878149450