### PR TITLE
Added LaTeXOutline

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -554,7 +554,7 @@
 		{
 			"name": "LaTeXOutline",
 			"details": "https://github.com/odapg/LaTeXOutline",
-			"labels": ["LaTeX"],
+			"labels": ["latex"],
 			"releases": [
 				{
 					"sublime_text": ">=4085",

--- a/repository/l.json
+++ b/repository/l.json
@@ -557,7 +557,7 @@
 			"labels": ["latex"],
 			"releases": [
 				{
-					"sublime_text": ">=4085",
+					"sublime_text": ">=4149",
 					"tags": true
 				}
 			]

--- a/repository/l.json
+++ b/repository/l.json
@@ -552,6 +552,17 @@
 			]
 		},
 		{
+			"name": "LaTeXOutline",
+			"details": "https://github.com/odapg/LaTeXOutline",
+			"labels": ["LaTeX"],
+			"releases": [
+				{
+					"sublime_text": ">=4085",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LaTeXSmartQuotes",
 			"details": "https://github.com/r-stein/sublime-text-latex-smart-quotes",
 			"labels": ["latex"],


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
   Suggested keybindings are commented in sublime-keymaps files
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
   It is not a syntax, but has a specific (hidden) one, with specific (hidden) color-scheme
- [X] I have read the [style guide](https://github.com/wbond/package_control_channel/?tab=readme-ov-file#style-guide)
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is similar to [Outline](https://packagecontrol.io/packages/Outline) at first glance.
However i still believe it should be added because of the following reasons.
Outline is a general tool for markdown/latex languages that puts the symbols list in a side view in a clickable way.
By specializing to LaTeX files, LaTeXOutline can:
- show a table of contents of the document, with suitable indentation and color highlighting
- show the sections and labelled environment numbers (by parsing the .aux file)
- show the environment name corresponding to a label (by looking into the .tex file)
- propose to easily copy a label/have a look at it without moving the selection (something I believe is quite helpful, at least to me!)

I don't think that this "LaTeX table of contents" feature (that one can see for instance on overleaf) presently exists in Package Control.


<!-- 
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 

For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

For updates to existing packages:
If your package isn't using tag based releases,
please switch to tags now.
 -->

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
