### PR TITLE
Drop one dead channel

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -5,7 +5,6 @@
 		"https://codexns.io/packages/packages.json",
 		"https://donkirkby.github.io/live-py-plugin/sublime-package/package.json",
 		"https://emmetio.github.io/sublime-text-plugin/registry.json",
-		"https://eoa-cdn.s3.amazonaws.com/extensions/packages.json",
 		"https://packages.monokai.pro/packages.json",
 		"https://raw.githubusercontent.com/20Tauri/DoxyDoxygen/master/DoxyDoxygen.json",
 		"https://raw.githubusercontent.com/accerqueira/sublime/master/packages.json",


### PR DESCRIPTION
The channel 		

```
"https://eoa-cdn.s3.amazonaws.com/extensions/packages.json",
```

is dead for (at least) weeks.  Just remove it.  