### PR TITLE
Add GPT Explain package

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -2006,6 +2006,16 @@
 			]
 		},
 		{
+		  "name": "GPT Explain",
+		  "details": "https://github.com/promontorycoder/sublime-gpt-explain",
+		  "releases": [
+		    {
+		      "sublime_text": ">=4100",
+		      "tags": true
+		    }
+		  ]
+		},
+		{
 			"name": "Grace",
 			"details": "https://github.com/zmthy/grace-tmbundle",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries by default.*
- [x] My package doesn't add key bindings by default.**
- [x] Any commands are available via the command palette (planned).
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view (to be added).
- [x] I have read the [style guide](https://github.com/wbond/package_control_channel/?tab=readme-ov-file#style-guide)
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is ...

An AI-powered productivity tool for developers to quickly understand and document unfamiliar code using GPT-4o. It supports any programming language and integrates directly into the Sublime Text UI.

There are no packages like it in Package Control.