### PR TITLE
Add CopyPathAndContents to channel

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -3827,6 +3827,17 @@
 			]
 		},
 		{
+			"name": "CopyPathAndContents",
+			"details": "https://github.com/CodeByZach/sublime_copy_path_and_contents",
+			"labels": ["clipboard", "files", "ai", "snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/adzenith/CopyEdit",
 			"releases": [
 				{


### PR DESCRIPTION
This commit adds the **CopyPathAndContents** package to Package Control. The plugin allows users to copy a file's full path and contents, with support for copying multiple selected tabs and customizable separators.

<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I have read the [style guide](https://github.com/wbond/package_control_channel/?tab=readme-ov-file#style-guide)
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is **CopyPathAndContents**

There are no packages in Package Control that offer this exact functionality — namely, copying both path and content from multiple selected tabs with user-defined formatting. This is particularly helpful for interacting with AI assistants (e.g., pasting into ChatGPT) or reporting bugs with exact source context.


<!-- 
*)   Unless it definitely really needs them,
     they apply to the cursor's context
     and their visibility is conditional.
     Space in this menu is limited!
**)  There aren't enough keys for all packages,
     you'd risk overriding those of other packages.
     You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) We have hundreds of color schemes,
     and plenty of scopes to make any syntax work. 

For bonus points also considered how the review guidelines apply to your package:
https://github.com/wbond/package_control_channel/wiki#reviewing-a-package-addition

For updates to existing packages:
If your package isn't using tag based releases,
please switch to tags now.
 -->

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
