### PR TITLE
Update NgxHTML package

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -636,7 +636,11 @@
 					"tags": "4107-"
 				},
 				{
-					"sublime_text": ">=4152",
+					"sublime_text": "4152 - 4179",
+					"tags": "4152-"
+				},
+				{
+					"sublime_text": ">=4180",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This PR adds a new release branch for ST4180+ to _Ngx HTML_ package.

caused by: https://github.com/princemaple/ngx-html-syntax/pull/38
