### PR TITLE
Remove "previous_names" entries older than 2 years

### DIFF
--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -59,7 +59,6 @@
 			"name": "3D Tool (Async Burst-Mode)",
 			"details": "https://github.com/leoheck/sublime-3d-tool/",
 			"labels": ["3d-tool", "burst-mode", "async"],
-			"previous_names": ["3D Tool Syntax Hilight"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/a.json
+++ b/repository/a.json
@@ -3,7 +3,6 @@
 	"packages": [
 		{
 			"name": "A File Icon",
-			"previous_names": ["File Icons Extended", "zz File Icons"],
 			"details": "https://github.com/SublimeText/AFileIcon",
 			"author": ["ihodev", "DeathAxe"],
 			"labels": ["theme", "file", "icons"],
@@ -96,7 +95,6 @@
 			"name": "AcademicMarkdown",
 			"details": "https://github.com/mangecoeur/AcademicMarkdown",
 			"labels": ["language syntax"],
-			"previous_names": ["Academic Markdown"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -418,7 +416,6 @@
 		},
 		{
 			"name": "Advanced PLSQL",
-			"previous_names": ["Oracle PL SQL"],
 			"details": "https://github.com/TheEggi/Advanced-PLSQL",
 			"labels": ["snippets", "plsql", "oracle", "build system"],
 			"releases": [
@@ -575,7 +572,6 @@
 			"name": "Alan",
 			"details": "https://github.com/alan-platform/AlanForSublime",
 			"labels": ["language syntax"],
-			"previous_names": ["Fabric"],
 			"releases": [
 				{
 					"sublime_text": ">=3143",
@@ -773,7 +769,6 @@
 		{
 			"name": "Alternative Autocompletion",
 			"details": "https://github.com/atombender/sublime_text_alternative_autocompletion",
-			"previous_names": ["alternative_autocompletion"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -838,7 +833,6 @@
 		},
 		{
 			"details": "https://github.com/wukkuan/AMD-Module-Editor",
-			"previous_names": ["AMD Module Editor"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -908,7 +902,6 @@
 		},
 		{
 			"name": "AMPscript Syntax Highlighter",
-			"previous_names": ["AmpScript Highlighter"],
 			"details": "https://github.com/wvpv/ampscript-syntax-highlighter",
 			"labels": ["language syntax"],
 			"releases": [
@@ -922,7 +915,6 @@
 			"name": "AmxxEditor",
 			"details": "https://github.com/evandrocoan/AmxxEditor",
 			"labels": ["auto-complete", "build system", "amxmodx", "amx mod x", "amxx", "pawn"],
-			"previous_names": ["Amxmodx"],
 			"releases": [
 				{
 					"sublime_text": ">=3114",
@@ -933,7 +925,6 @@
 		{
 			"name": "AmxxPawn",
 			"details": "https://github.com/evandrocoan/AmxxPawn",
-			"previous_names": ["Amxx Pawn"],
 			"labels": ["language syntax", "amxmodx", "amx mod x"],
 			"releases": [
 				{
@@ -1605,7 +1596,6 @@
 			"name": "AppleScript Extensions",
 			"details": "https://github.com/idleberg/sublime-applescript",
 			"labels": ["auto-complete", "build system", "snippets"],
-			"previous_names": ["AppleScript Completions and Snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1860,7 +1850,6 @@
 		{
 			"name": "ASCII Replacer",
 			"details": "https://github.com/pjlamb12/AsciiReplacerPlugin",
-			"previous_names": ["Replacer"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/b.json
+++ b/repository/b.json
@@ -36,7 +36,6 @@
 		},
 		{
 			"name": "Babel",
-			"previous_names": ["6to5"],
 			"details": "https://github.com/babel/babel-sublime",
 			"labels": ["language syntax", "javascript"],
 			"releases": [
@@ -74,7 +73,6 @@
 		{
 			"name": "Backbone",
 			"details": "https://github.com/tomasztunik/Sublime-Text-2-Backbone.js-package",
-			"previous_names": ["Backbone.js"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -116,7 +114,6 @@
 			"name": "Badges",
 			"details": "https://github.com/idleberg/sublime-badges",
 			"labels": ["snippets", "badges", "markdown", "restructuredtext", "textile"],
-			"previous_names": ["Shields.io Badges"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -597,7 +594,6 @@
 			"name": "Better Completion",
 			"details": "https://github.com/hilezi/Sublime-Better-Completion",
 			"labels": ["auto-complete"],
-			"previous_names": ["JavaScript and jQuery API Completions"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -631,7 +627,6 @@
 			"details": "https://github.com/whitequark/sublime-better-ocaml",
 			"description": "An improved version of default OCaml package",
 			"labels": ["language syntax"],
-			"previous_names": ["OCaml"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1242,7 +1237,6 @@
 		},
 		{
 			"name": "Bootstrap 4x Autocomplete",
-			"previous_names": ["Bootstrap 4.3 Autocomplete"],
 			"details": "https://github.com/proficientdesigners/sublime-text-bs4-autocomplete",
 			"author": "Proficient Designers",
 			"labels": ["auto-complete", "bootstrap"],
@@ -1255,7 +1249,6 @@
 		},
 		{
 			"name": "Bootstrap 4x Snippets",
-			"previous_names": ["Bootstrap 4.3 Snippets"],
 			"details": "https://github.com/proficientdesigners/sublime-text-bs4-snippets",
 			"author": "Proficient Designers",
 			"labels": ["snippets", "bootstrap"],
@@ -1425,7 +1418,6 @@
 		{
 			"name": "Breadboard",
 			"details": "https://github.com/breadboard-xyz/taskmill-editor-sublime",
-			"previous_names": ["Task Mill", "TaskMill"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1683,7 +1675,6 @@
 		},
 		{
 			"name": "Buildview",
-			"previous_names": ["sublime-text-2-buildview", "sublime-text-buildview"],
 			"details": "https://github.com/rctay/sublime-text-buildview",
 			"releases": [
 				{

--- a/repository/c.json
+++ b/repository/c.json
@@ -202,7 +202,6 @@
 		{
 			"name": "CakePHP (tmbundle)",
 			"details": "https://github.com/cakephp/cakephp-tmbundle",
-			"previous_names": ["CakePHP"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -255,7 +254,6 @@
 			"name": "caniuse_local",
 			"details": "https://github.com/leecade/caniuse_local",
 			"labels": ["caniuse", "offline"],
-			"previous_names": ["Can I Use(offline)"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -439,7 +437,6 @@
 		},
 		{
 			"name": "Cattleya Color Scheme",
-			"previous_names": ["Orchid Color Scheme"],
 			"details": "https://github.com/patrickfatrick/cattleya-theme-sublime",
 			"labels": ["color scheme"],
 			"releases": [
@@ -464,7 +461,6 @@
 			"name": "CComplete",
 			"details": "https://github.com/ibensw/CComplete",
 			"labels": ["auto-complete"],
-			"previous_names": ["C Complete"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -886,7 +882,6 @@
 		{
 			"name": "Chinese-English Bilingual Dictionary",
 			"details": "https://github.com/divinites/cndict",
-			"previous_names": ["Cndict", "Youdao English-Chinese Translate"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -896,7 +891,6 @@
 		},
 		{
 			"name": "ChineseLocalizations",
-			"previous_names": ["ChineseLocalization"],
 			"details": "https://github.com/rexdf/ChineseLocalization",
 			"labels": ["localization", "chinese", "中文", "japanese", "日本語"],
 			"releases": [
@@ -967,7 +961,6 @@
 		{
 			"name": "ChoiceScript",
 			"details": "https://github.com/fawkesy/choicescript-syntax",
-			"previous_names": ["Choice Script"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1089,7 +1082,6 @@
 		},
 		{
 			"name": "ChromiumXRefs",
-			"previous_names": ["Chromium X-Refs"],
 			"author": "Josh Karlin",
 			"description": "Shows Chromium code cross-references from cs.chromium.org",
 			"details": "https://github.com/karlinjf/ChromiumXRefs",
@@ -1303,7 +1295,6 @@
 			"name": "Clarion",
 			"details": "https://github.com/fushnisoft/SublimeClarion",
 			"labels": ["language syntax"],
-			"previous_names": ["SublimeClarion"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1789,9 +1780,6 @@
 		},
 		{
 			"name": "CNC Sinumerik",
-			"previous_names": [
-				"CNC SINUMERIK 840D language support"
-			],
 			"details": "https://github.com/deathaxe/sublime-s840d",
 			"labels": ["completions", "language syntax", "snippets"],
 			"releases": [
@@ -2220,7 +2208,6 @@
 		{
 			"name": "CodeLines",
 			"details": "https://github.com/absop/ST-CodeLines",
-			"previous_names": ["CodeCounter"],
 			"labels": ["analytics", "statistics", "status bar", "utilities"],
 			"author": "absop",
 			"releases": [
@@ -2326,7 +2313,6 @@
 		},
 		{
 			"name": "CodeTime",
-			"previous_names": ["Software"],
 			"details": "https://github.com/swdotcom/swdc-sublime",
 			"labels": ["utilities", "status bar", "javascript", "google", "productivity"],
 			"releases": [
@@ -2514,7 +2500,6 @@
 		{
 			"name": "ColdFusion Docs Launcher",
 			"details": "https://github.com/linkarys/CFDocsLauncher",
-			"previous_names": ["CFDocsLauncher"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2666,7 +2651,6 @@
 			"name": "Color Scheme - Eazy Light",
 			"details": "https://github.com/txdm/Eazy-Light",
 			"labels": ["color scheme"],
-			"previous_names": ["Eazy Light"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2678,7 +2662,6 @@
 			"name": "Color Scheme - Eggplant Parm",
 			"details": "https://github.com/mimshwright/sublime-eggplant-parm",
 			"labels": ["color scheme"],
-			"previous_names": ["Eggplant Parm Color Scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2690,7 +2673,6 @@
 			"name": "Color Scheme - Frontend Delight",
 			"details": "https://github.com/bernatfortet/sublime-frontend-delight",
 			"labels": ["color scheme"],
-			"previous_names": ["Frontend Delight Theme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2925,7 +2907,6 @@
 			"name": "Colorsublime",
 			"details": "https://github.com/Colorsublime/Colorsublime-Plugin",
 			"labels": ["color scheme"],
-			"previous_names": ["Color Switch"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3493,7 +3474,6 @@
 			"details": "https://github.com/unknownuser88/consolewrap",
 			"author": "David Bekoyan",
 			"labels": ["auto-complete", "completions", "debug", "console", "logs", "output", "javascript"],
-			"previous_names": ["Console Wrap for js"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3637,7 +3617,6 @@
 		},
 		{
 			"name": "Cool & Clear - Color Scheme",
-			"previous_names": ["Cool & Clear"],
 			"details": "https://github.com/Doodpants/Cool-and-Clear-Color-Scheme",
 			"author": "Karl von Laudermann",
 			"labels": ["color scheme"],
@@ -3888,7 +3867,6 @@
 		{
 			"name": "Corona Editor",
 			"details": "https://github.com/coronalabs/CoronaSDK-SublimeText",
-			"previous_names": ["Corona SDK"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4218,7 +4196,6 @@
 		{
 			"name": "Crontab",
 			"details": "https://github.com/michaelblyons/SublimeSyntax-Crontab",
-			"previous_names": ["Crontab Syntax"],
 			"labels": ["language syntax", "completions"],
 			"releases": [
 				{
@@ -4553,7 +4530,6 @@
 		{
 			"name": "CSScomb",
 			"details": "https://github.com/csscomb/sublime-csscomb",
-			"previous_names": ["CSScomb.js", "CSScomb JS"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -5049,7 +5025,6 @@
 			"name": "Cython+",
 			"details": "https://github.com/petervaro/python",
 			"labels": ["language syntax"],
-			"previous_names": ["Modern Cython"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/d.json
+++ b/repository/d.json
@@ -183,7 +183,6 @@
 		},
 		{
 			"name": "DarkDonut Color Schemes",
-			"previous_names": ["DarkDonut Forest Coders"],
 			"details": "https://github.com/DarkDonut-theme/DarDonut_sublime",
 			"releases": [
 				{
@@ -578,7 +577,6 @@
 		{
 			"name": "Delphi IDE",
 			"details": "https://github.com/JeisonJHA/Delphi-IDE",
-			"previous_names": ["Delphi API"],
 			"labels": ["delphi", "ide"],
 			"releases": [
 				{
@@ -643,7 +641,6 @@
 		{
 			"name": "Derby",
 			"details": "https://github.com/rossedman/derby",
-			"previous_names": ["Bourbon & Neat Autocompletions", "Derby - Bourbon & Neat Autocompletions"],
 			"labels": ["auto-complete"],
 			"releases": [
 				{
@@ -784,7 +781,6 @@
 		},
 		{
 			"name": "Deviot (Arduino IDE)",
-			"previous_names": ["Deviot"],
 			"details": "https://github.com/gepd/Deviot",
 			"donate": "https://gratipay.com/~gepd/",
 			"labels": ["build system", "ide", "arduino", "iot", "platformio"],
@@ -992,7 +988,6 @@
 		{
 			"name": "Direct Open",
 			"details": "https://github.com/UniFreak/SublimeDirectOpen",
-			"previous_names": ["Direct Edit", "DirectEdit"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1065,7 +1060,6 @@
 		},
 		{
 			"name": "Display numbers",
-			"previous_names": ["Highlight Number"],
 			"details": "https://github.com/nia40m/sublime-display-nums",
 			"releases": [
 				{
@@ -1326,7 +1320,6 @@
 			"details": "https://github.com/spadgos/sublime-jsdocs",
 			"donate": "http://pledgie.com/campaigns/16316",
 			"labels": ["documentation", "comments"],
-			"previous_names": ["JSDocs"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1618,7 +1611,6 @@
 		{
 			"name": "Dpaste Sublime",
 			"details": "https://github.com/hieuh25/dpaste-sublime",
-			"previous_names": ["sublime-dpaste"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1893,7 +1885,6 @@
 		},
 		{
 			"name": "DustBuster",
-			"previous_names": ["Dust.js"],
 			"details": "https://github.com/zanuka/dust-buster",
 			"labels": ["auto-complete", "language syntax", "snippets", "dust"],
 			"releases": [

--- a/repository/e.json
+++ b/repository/e.json
@@ -26,7 +26,6 @@
 			"readme": "https://raw.githubusercontent.com/benbusby/earthbound-themes/main/README.md",
 			"author": "Ben Busby",
 			"labels": ["theme", "color scheme"],
-			"previous_names": ["EarthboundThemes"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -347,7 +346,6 @@
 					"tags": true
 				}
 			],
-			"previous_names": ["Edge Syntax Highliter"]
 		},
 		{
 			"name": "Edge Theme",
@@ -456,7 +454,6 @@
 			"description" : "Send text to the editmode API & insert a snippet in its place.",
 			"details": "https://github.com/tonyennis145/editmode-sublime",
 			"labels": ["snippets", "utilities"],
-			"previous_names": ["Chunks"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -719,7 +716,6 @@
 			"name": "Elm Syntax Highlighting",
 			"details": "https://github.com/evancz/elm-syntax-highlighting",
 			"labels": ["elm", "language syntax"],
-			"previous_names": ["Elm Language Support"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -761,7 +757,6 @@
 		},
 		{
 			"name": "Emacs Pro Essentials",
-			"previous_names": ["sublemacspro"],
 			"details": "https://github.com/sublime-emacs/sublemacspro",
 			"releases": [
 				{
@@ -1337,7 +1332,6 @@
 		},
 		{
 			"name": "ESpec",
-			"previous_names": ["ESpec syntax highlighting"],
 			"details": "https://github.com/retgoat/ESpec",
 			"labels":["build system", "language syntax", "snippets"],
 			"releases": [
@@ -1584,7 +1578,6 @@
 		},
 		{
 			"name": "exercism",
-			"previous_names": ["STexercism"],
 			"details": "https://github.com/thosgood/STexercism",
 			"releases": [
 				{
@@ -1814,7 +1807,6 @@
 		{
 			"name": "ExpressionEngine Add-On Builder",
 			"details": "https://github.com/lukewilkins/EE-Add-On-Builder",
-			"previous_names": ["EE Add-On Builder"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -1841,7 +1833,6 @@
 		{
 			"name": "ExtendedTabSwitcher",
 			"details": "https://github.com/rajeshvaya/Sublime-Extended-Tab-Switcher",
-			"previous_names": ["GotoOpenFile", "OpenFileList"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1863,7 +1854,6 @@
 			"name": "External Command",
 			"details": "https://github.com/greneholt/SublimeExternalCommand",
 			"labels": ["text manipulation"],
-			"previous_names": ["SublimeExternalCommand"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -1974,7 +1964,6 @@
 		{
 			"name": "EZWebSequenceDiagrams",
 			"details": "https://github.com/patrickayoup/sublimetext-sequencediagrams",
-			"previous_names": ["WebSequenceDiagrams"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/e.json
+++ b/repository/e.json
@@ -345,7 +345,7 @@
 					"sublime_text": ">=3092",
 					"tags": true
 				}
-			],
+			]
 		},
 		{
 			"name": "Edge Theme",

--- a/repository/f.json
+++ b/repository/f.json
@@ -536,7 +536,6 @@
 			"name": "File Rename",
 			"details": "https://github.com/brianlow/FileRename",
 			"labels": ["rename", "file rename"],
-			"previous_names": ["FileRename"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1015,7 +1014,6 @@
 			"details": "https://github.com/MarkMichos/firecode-color-scheme",
 			"author": "Mark Michos",
 			"labels": ["color scheme"],
-			"previous_names": ["FireCode Theme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1035,7 +1033,6 @@
 		},
 		{
 			"name": "fish",
-			"previous_names": ["fish-shell"],
 			"details": "https://github.com/Phidica/sublime-fish",
 			"labels": ["language syntax", "snippets"],
 			"releases": [
@@ -1533,7 +1530,6 @@
 		},
 		{
 			"name": "FoldFunctions",
-			"previous_names": ["Fold Functions"],
 			"details": "https://github.com/math2001/FoldFunctions",
 			"releases": [
 				{

--- a/repository/g.json
+++ b/repository/g.json
@@ -144,7 +144,6 @@
 		{
 			"name": "gcode",
 			"details": "https://github.com/ElectricRCAircraftGuy/sublime_gcode",
-			"previous_names": ["G-code Syntax Highlighting"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -430,7 +429,6 @@
 			"issues": "https://github.com/fregante/GhostText/issues",
 			"donate": "https://github.com/sponsors/fregante",
 			"homepage": "https://ghosttext.fregante.com",
-			"previous_names": ["ChromeTextArea"],
 			"labels": [
 				"browser integration"
 			],
@@ -597,7 +595,6 @@
 		},
 		{
 			"name": "Git Message Auto Save",
-			"previous_names": ["Git Commit Message Auto Save"],
 			"details": "https://github.com/franciscolourenco/sublime-git-message-auto-save",
 			"labels": ["git", "vcs", "commit", "save", "auto", "message", "close", "exit", "rebase"],
 			"releases": [
@@ -678,7 +675,6 @@
 		},
 		{
 			"details": "https://github.com/jisaacks/GitGutter",
-			"previous_names": ["Git Gutter", "GitGutter-Edge"],
 			"releases": [
 				{
 					"sublime_text": "<3176",
@@ -814,7 +810,6 @@
 		},
 		{
 			"name": "GitHubTools",
-			"previous_names": ["Github Tools"],
 			"details": "https://github.com/braver/GitHubTools",
 			"releases": [
 				{
@@ -879,7 +874,6 @@
 		{
 			"name": "GitLink",
 			"details": "https://github.com/rscherf/GitLink",
-			"previous_names": ["GitHubLink"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1020,7 +1014,6 @@
 		{
 			"name": "GlassIt",
 			"details": "https://github.com/ivellioscolin/sublime-plugin-glassit",
-			"previous_names": ["Glass It"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1133,7 +1126,6 @@
 		},
 		{
 			"name": "Gmail",
-			"previous_names": ["Oauth Mail", "QuickMail"],
 			"details": "https://github.com/divinites/oauth-mail",
 			"releases": [
 				{
@@ -1286,7 +1278,6 @@
 			"name": "Gocc BNF Syntax",
 			"details": "https://github.com/awalterschulze/sublime-gocc-syntax",
 			"labels": ["language syntax"],
-			"previous_names": ["Gocc BNF Buffer Syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1353,7 +1344,6 @@
 			"name": "GoGdb",
 			"details": "https://github.com/Centny/GoGdb",
 			"labels": ["go"],
-			"previous_names": ["Sublime GDB Plugin For Golang"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1416,7 +1406,6 @@
 		},
 		{
 			"name": "Golang Tools Integration",
-			"previous_names": ["GoTools Ex"],
 			"details": "https://github.com/liuhewei/gotools-sublime",
 			"labels": ["go", "golang", "gocode", "oracle", "golint", "gorename"],
 			"releases": [
@@ -1536,7 +1525,6 @@
 		{
 			"name": "Google Search",
 			"details": "https://github.com/nwjlyons/google-search",
-			"previous_names": ["google-search"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1820,7 +1808,6 @@
 			"name": "GotoDocumentation",
 			"details": "https://github.com/kemayo/sublime-text-2-goto-documentation",
 			"labels": ["search", "documentation"],
-			"previous_names": ["Goto Documentation"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1851,7 +1838,6 @@
 		},
 		{
 			"name": "GoToLastEdit",
-			"previous_names": ["GotoLastEdit"],
 			"details": "https://github.com/khrizt/GotoLastEdit",
 			"releases": [
 				{
@@ -2405,7 +2391,6 @@
 		{
 			"name": "Gulp",
 			"details": "https://github.com/NicoSantangelo/sublime-gulp",
-			"previous_names": ["Gulp Snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/h.json
+++ b/repository/h.json
@@ -226,7 +226,6 @@
 		},
 		{
 			"name": "haoide",
-			"previous_names": ["Salesforce IDE"],
 			"details": "https://github.com/xjsender/haoide",
 			"releases": [
 				{
@@ -354,7 +353,6 @@
 		{
 			"name": "Haxe",
 			"details": "https://github.com/clemos/haxe-sublime-bundle",
-			"previous_names": ["HaXe"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -427,7 +425,6 @@
 		{
 			"name": "Helium",
 			"details": "https://github.com/SublimeText/Helium",
-			"previous_names": ["Hermes"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -620,7 +617,6 @@
 		{
 			"name": "Highlight Duplicates",
 			"details": "https://github.com/LordBrom/HighlightDuplicates",
-			"previous_names": ["HighlightDuplicates"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -665,7 +661,6 @@
 			"name": "Highlighter",
 			"details": "https://github.com/bluegray/Highlighter",
 			"labels": ["formatting"],
-			"previous_names": ["Highlight-Mixed-Whitespace"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -736,7 +731,6 @@
 		},
 		{
 			"name": "Hivacruz Theme",
-			"previous_names": ["Hivacruz Color Scheme"],
 			"details": "https://github.com/kinoute/hivacruz-sublime-theme",
 			"labels": ["color scheme", "theme", "hivacruz", "dark"],
 			"releases": [
@@ -988,7 +982,6 @@
 			"name": "Hosts",
 			"details": "https://github.com/tijn/hosts.tmLanguage",
 			"labels": ["language syntax"],
-			"previous_names": ["hosts"],
 			"author": ["tijn", "michaelblyons"],
 			"releases": [
 				{
@@ -1570,7 +1563,6 @@
 		{
 			"name": "Hyperion for gettext",
 			"details": "https://github.com/thie1210/hyperion",
-			"previous_names": ["Hyperion"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/i.json
+++ b/repository/i.json
@@ -81,7 +81,6 @@
 			"name": "Icon Fonts",
 			"details": "https://github.com/idleberg/sublime-icon-fonts",
 			"labels": ["snippets", "icon_fonts", "fonts"],
-			"previous_names": ["Font Awesome"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -284,7 +283,6 @@
 		},
 		{
 			"name": "ImagePreview",
-			"previous_names": ["Hover Image Preview"],
 			"description": "The Sublime Text image previewing plugin",
 			"labels": ["hover", "image", "preview", "file", "url"],
 			"details": "https://github.com/alvesjtiago/hover-preview",
@@ -434,7 +432,6 @@
 			"name": "Inc-Dec-Value",
 			"details": "https://github.com/rmaksim/Sublime-Text-2-Inc-Dec-Value",
 			"author": "Razumenko Maksim",
-			"previous_names": ["IncDecValue"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -649,7 +646,6 @@
 		{
 			"name": "industrial-coding-theme",
 			"details": "https://github.com/zaizupro/industrial-coding-theme",
-			"previous_names": ["industrial coding theme"],
 			"labels": ["theme", "color scheme"],
 			"releases": [
 				{
@@ -749,7 +745,6 @@
 			"name": "Inno Setup",
 			"details": "https://github.com/idleberg/sublime-innosetup",
 			"labels": ["language syntax", "build system", "inno setup", "innosetup"],
-			"previous_names": ["InnoSetup"],
 			"releases": [
 				{
 					"sublime_text": "<3103",
@@ -776,7 +771,6 @@
 			"name": "InQlik-Tools",
 			"details": "https://github.com/inqlik/inqlik-tools",
 			"labels": ["language syntax", "build system"],
-			"previous_names": ["QlikView Tools"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -811,7 +805,6 @@
 			"author": ["jbrooksuk", "FichteFoll"],
 			"details": "https://github.com/SublimeText/InsertNums",
 			"labels": ["automation", "utilities", "text manipulation"],
-			"previous_names": ["Insert Sequences", "InsertNums"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1282,7 +1275,6 @@
 		{
 			"name": "isorted",
 			"details": "https://github.com/rimvaliulin/isorted",
-			"previous_names": ["Isorted"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/j.json
+++ b/repository/j.json
@@ -48,7 +48,6 @@
 			"name": "Jaggeryjs",
 			"details": "https://github.com/dakshika/jaggeryjs-sublime-text",
 			"labels": ["auto-complete", "language syntax", "snippets"],
-			"previous_names": ["Jaggery Snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -58,7 +57,6 @@
 		},
 		{
 			"name": "JaiTools",
-			"previous_names": ["Jai"],
 			"details": "https://github.com/RobinWragg/JaiTools",
 			"releases": [
 				{
@@ -259,7 +257,6 @@
 			"name": "Java Velocity",
 			"details": "https://github.com/jampow/velocity-sublime",
 			"labels": ["language syntax", "snippets"],
-			"previous_names": ["Velocity Snippets + Synthax Highlight"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -514,7 +511,6 @@
 			"name": "JCommander",
 			"details": "https://github.com/zanuka/jcommander",
 			"labels": ["auto-complete", "snippets", "utilities"],
-			"previous_names": ["JunoCommander"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -569,7 +565,6 @@
 			"name": "Jedi - Python autocompletion",
 			"details": "https://github.com/srusskih/SublimeJEDI",
 			"labels": ["auto-complete", "code navigation"],
-			"previous_names": ["SublimeJEDI", "Jedi - Python autocompetion"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -781,7 +776,6 @@
 			"name": "jolie",
 			"details": "https://github.com/thesave/sublime-Jolie",
 			"labels": ["language syntax", "snippets"],
-			"previous_names" : ["Jolie Language"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1321,7 +1315,6 @@
 			"name": "JsValidate",
 			"details": "https://github.com/duereg/sublime-jsvalidate",
 			"labels": ["javascript", "js", "linting", "validation", "validate", "esprima"],
-			"previous_names": ["JS Validate using Esprima", "JS Validation using Esprima"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/k.json
+++ b/repository/k.json
@@ -190,7 +190,6 @@
 		},
 		{
 			"name": "KeyboardNavigation",
-			"previous_names": ["KeyboardSelection"],
 			"details": "https://github.com/robertcollier4/KeyboardNavigation",
 			"releases": [
 				{
@@ -417,7 +416,6 @@
 			"author": "phil65",
 			"donate": "https://blockchain.info/de/address/1KzWm7XtW42gyZQqg5CqW6k9fb3zWinM15",
 			"labels": ["auto-complete", "completions", "language syntax", "snippets"],
-			"previous_names": ["SublimeKodi"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -563,7 +561,6 @@
 		{
 			"name": "Kulture",
 			"details": "https://github.com/OmniSharp/Kulture",
-			"previous_names": ["vNext"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -574,7 +571,6 @@
 		{
 			"name": "Kung Fury",
 			"details": "https://github.com/argyleink/Kung-Fury-Theme",
-			"previous_names": [],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/l.json
+++ b/repository/l.json
@@ -198,7 +198,6 @@
 		},
 		{
 			"name": "Laravel 5 Snippets",
-			"previous_names": ["Laravel Five Snippets"],
 			"details": "https://github.com/patricksamson/laravel-5-snippets",
 			"labels": ["snippets"],
 			"releases": [
@@ -251,7 +250,6 @@
 		},
 		{
 			"name": "Laravel Blade Spacer",
-			"previous_names": ["Blade Spacer"],
 			"details": "https://github.com/austenc/blade-spacer",
 			"releases": [
 				{
@@ -837,7 +835,6 @@
 			"name": "Less",
 			"details": "https://github.com/SublimeText/Less",
 			"labels": ["auto-complete", "language syntax"],
-			"previous_names": ["LESS", "LessImproved"],
 			"releases": [
 				{
 					"sublime_text": "3143 - 4106",
@@ -1235,7 +1232,6 @@
 		},
 		{
 			"name": "lioshiTheme",
-			"previous_names": ["lioshi Color Scheme"],
 			"details": "https://github.com/lioshi/lioshiScheme",
 			"labels": ["theme", "color scheme"],
 			"releases": [
@@ -1461,7 +1457,6 @@
 			"name": "Lo-Dash Snippets for CoffeeScript",
 			"details": "https://github.com/maximbaz/CoffeeScript-Lodash-snippets-for-Sublime-Text-2",
 			"labels": ["snippets"],
-			"previous_names": ["CoffeeScript-Lodash-Snippets-for-Sublime-Text-2"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1473,7 +1468,6 @@
 			"name": "Load file to REPL",
 			"details": "https://github.com/laughedelic/LoadFileToRepl",
 			"labels": ["repl"],
-			"previous_names": ["LoadFileToRepl"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1582,7 +1576,6 @@
 			"name": "Lodestone Color Scheme",
 			"details": "https://github.com/mattchanner/lodestone-theme",
 			"labels": ["color scheme"],
-			"previous_names": ["Ansible Color Scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1927,7 +1920,6 @@
 		{
 			"name": "LuaJumpDefinition",
 			"details": "https://github.com/RuiZhuo/LuaJumpDefinition",
-			"previous_names": ["Lua Jump Definition"],
 			"labels": ["code navigation", "lua"],
 			"releases": [
 				{

--- a/repository/m.json
+++ b/repository/m.json
@@ -684,7 +684,6 @@
 			"name": "MarkdownPreview",
 			"details": "https://github.com/facelessuser/MarkdownPreview",
 			"labels": ["markdown", "preview", "build system"],
-			"previous_names": ["Markdown Preview"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -718,7 +717,6 @@
 			"name": "Marked App Menu",
 			"details": "https://github.com/icio/sublime-text-marked",
 			"labels": ["markdown", "preview", "build system", "marked.app"],
-			"previous_names": ["Marked.app Menu"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -803,7 +801,6 @@
 		},
 		{
 			"name": "Marshal Command Code",
-			"previous_names": ["MinecraftCommandCode"],
 			"description": "Syntax highlighting for Minecraft Commands",
 			"details": "https://github.com/42iscool42/MCC",
 			"releases": [
@@ -1188,7 +1185,6 @@
 			"name": "MDN Search Doc",
 			"details": "https://github.com/nucliweb/MDNSearchDoc",
 			"labels": ["doc", "documentation"],
-			"previous_names": ["MDN Serach Doc"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1200,7 +1196,6 @@
 			"name": "MDX",
 			"details": "https://github.com/SublimeText/MDX",
 			"labels": ["jsx", "language syntax", "markdown", "mdx"],
-			"previous_names": ["MDX Syntax Highlighting"],
 			"releases": [
 				{
 					"sublime_text": "3143 - 3211",
@@ -1310,7 +1305,6 @@
 			"name": "Mercurial",
 			"details": "https://github.com/guillermooo/mercurial",
 			"labels": ["vcs", "hg"],
-			"previous_names": ["SublimeHg"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1558,7 +1552,6 @@
 		},
 		{
 			"name": "Miking Syntax Highlighting",
-			"previous_names": ["MCore Syntax Highlighting"],
 			"details": "https://github.com/miking-lang/miking-sublime-text",
 			"labels": ["mcore", "miking", "language syntax"],
 			"releases": [
@@ -1866,7 +1859,6 @@
 		},
 		{
 			"name": "Miva IDE",
-			"previous_names": ["Miva Template Language (MVT)"],
 			"details": "https://github.com/mghweb/sublime-miva-ide",
 			"author": "Max Hegler",
 			"labels": ["auto-complete", "formatting", "language syntax", "snippets", "miva", "mvt", "mivascript", "miva script"],
@@ -2518,7 +2510,6 @@
 		{
 			"name": "Move By Paragraph",
 			"details": "https://github.com/xsleonard/sublime-MoveByParagraph",
-			"previous_names": ["Move Better"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/n.json
+++ b/repository/n.json
@@ -358,7 +358,6 @@
 		},
 		{
 			"name": "NeoVintageousToggle",
-			"previous_names": ["ToggleNeoVintageous"],
 			"details": "https://github.com/NeoVintageous/NeoVintageousToggle",
 			"labels": ["vim", "neovintageous", "vintageous", "vintage"],
 			"releases": [
@@ -1084,7 +1083,6 @@
 			"name": "Nova Framework Snippets",
 			"details": "https://github.com/nova-framework/Nova-Framework-Snippets",
 			"labels": ["snippets"],
-			"previous_names": ["SMVC-Snippets", "Simple MVC Framework Snippets"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1197,7 +1195,6 @@
 			"name": "NSIS Completions & Snippets",
 			"details": "https://github.com/idleberg/sublime-nsis",
 			"labels": ["auto-complete", "snippets", "nsis"],
-			"previous_names": ["NSIS Autocomplete and Snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1209,7 +1206,6 @@
 			"name": "NSIS for Translators",
 			"details": "https://github.com/idleberg/sublime-nlf",
 			"labels": ["language syntax", "nsis"],
-			"previous_names": ["NSIS Language File Syntax"],
 			"releases": [
 				{
 					"sublime_text": "<3103",
@@ -1225,7 +1221,6 @@
 			"name": "NSIS Plug-in Completions",
 			"details": "https://github.com/idleberg/sublime-nsis-plugins",
 			"labels": ["auto-complete", "nsis"],
-			"previous_names": ["NSIS Autocomplete (Add-ons)"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1333,7 +1328,6 @@
 			"name": "Nunjucks",
 			"details": "https://github.com/alsolovyev/Nunjucks",
 			"labels": ["language syntax", "snippets", "nunjucks"],
-			"previous_names": ["Nunjucks Syntax"],
 			"releases": [
 				{
 					"sublime_text": "<=4180",

--- a/repository/o.json
+++ b/repository/o.json
@@ -37,7 +37,6 @@
 			"name": "Object Pascal",
 			"details": "https://github.com/avdotion/pascal-snippets",
 			"labels": ["language syntax"],
-			"previous_names": ["Free Pascal Support"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/p.json
+++ b/repository/p.json
@@ -68,7 +68,6 @@
 		{
 			"name": "PackageDev",
 			"details": "https://github.com/SublimeText/PackageDev",
-			"previous_names": ["AAAPackageDev"],
 			"author": ["FichteFoll"],
 			"releases": [
 				{
@@ -343,7 +342,6 @@
 			"name": "Paraiso Color Scheme",
 			"details": "https://github.com/idleberg/Paraiso.tmTheme",
 			"labels": ["color scheme"],
-			"previous_names": ["Paraíso Color Scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -450,7 +448,6 @@
 			"name": "Paste As Column",
 			"details": "https://github.com/TheClams/PasteAsColumn",
 			"labels": ["text manipulation", "clipboard", "paste"],
-			"previous_names": ["Paste as Column"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -551,7 +548,6 @@
 			"author": "XenHat",
 			"description": "Colorful, low-saturation, supports several languages and plugins",
 			"labels": ["color scheme", "colorful", "pastel", "dark"],
-			"previous_names": ["Molokai-Pastel", "Pastel-Paws Color Scheme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -746,7 +742,6 @@
 		{
 			"name": "PeopleCodeTools",
 			"details": "https://github.com/Jatz/PeopleCodeTools",
-			"previous_names": ["PeopleCode Tools"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1336,7 +1331,6 @@
 		},
 		{
 			"name": "PHPGrammar",
-			"previous_names": ["php-grammar"],
 			"details": "https://github.com/gerardroche/sublime-php-grammar",
 			"labels": ["auto-complete", "completions", "formatting", "php"],
 			"releases": [
@@ -1350,7 +1344,6 @@
 			"name": "PHPIntel",
 			"details": "https://github.com/jotson/SublimePHPIntel",
 			"labels": ["auto-complete", "completions", "php"],
-			"previous_names": ["MagentoIntel"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -1482,7 +1475,6 @@
 		},
 		{
 			"name": "PHPUnitKit",
-			"previous_names": ["phpunitkit"],
 			"details": "https://github.com/gerardroche/sublime-phpunit",
 			"labels": ["php", "phpunit", "testing"],
 			"releases": [
@@ -2266,7 +2258,6 @@
 		},
 		{
 			"name": "PreTeXtual",
-			"previous_names": ["MBXTools"],
 			"details": "https://github.com/daverosoff/PreTeXtual",
 			"author": "Dave Rosoff",
 			"labels": ["mbx", "mathbook xml", "pretext", "ptx"],
@@ -2330,7 +2321,6 @@
 		},
 		{
 			"name": "Pretty Protobuf",
-			"previous_names": ["Pretty Proto"],
 			"details": "https://github.com/hanfezh/pretty-protobuf",
 			"labels": ["formatting", "prettify", "protobuf", "debug"],
 			"releases": [
@@ -2548,7 +2538,6 @@
 			"details": "https://github.com/tonsky/sublime-profiles",
 			"donate": "https://www.patreon.com/tonsky",
 			"labels": ["preferences"],
-			"previous_names": ["Switch Settings"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2654,7 +2643,6 @@
 		},
 		{
 			"name": "ProjectEnvironment",
-			"previous_names": ["Project Environment", "Environment Settings"],
 			"details": "https://bitbucket.org/daniele-niero/sublimeprojectenvironment",
 			"labels": ["environment", "variables", "project"],
 			"releases": [
@@ -2693,7 +2681,6 @@
 			"name": "ProjectMaker",
 			"details": "https://github.com/bit101/ProjectMaker",
 			"labels": ["project", "template", "project-templates", "cookiecutter", "jinja2"],
-			"previous_names" : ["STProjectMaker"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2932,7 +2919,6 @@
 			"name": "PureScript",
 			"details": "https://github.com/b123400/purescript-ide-sublime",
 			"labels": ["language syntax", "ide"],
-			"previous_names": ["PureScript IDE"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3017,7 +3003,6 @@
 		{
 			"name": "PyCover",
 			"details": "https://github.com/perimosocordiae/PyCover",
-			"previous_names": ["Python Coverage"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3214,7 +3199,6 @@
 			"name": "Python 3",
 			"details": "https://github.com/petervaro/python",
 			"labels": ["language syntax"],
-			"previous_names": ["Modern Python"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3255,7 +3239,6 @@
 		},
 		{
 			"name": "Python Completions",
-			"previous_names": ["Python Auto-Complete"],
 			"details": "https://github.com/eliquious/Python-Auto-Complete",
 			"labels": ["completions", "python"],
 			"releases": [
@@ -3393,7 +3376,6 @@
 		{
 			"name": "Python Path to Clipboard",
 			"details": "https://github.com/Mimino666/SublimeText2-python-package-to-clipboard",
-			"previous_names": ["Python Package to Clipboard"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/q.json
+++ b/repository/q.json
@@ -190,7 +190,6 @@
 		{
 			"name": "Quick File Move",
 			"details": "https://github.com/wulftone/sublime-text-quick-file-move",
-			"previous_names": ["Quick File Renamer", "QuickFileMove"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -304,7 +303,6 @@
 		{
 			"name": "QuickRef Command Lookup",
 			"details": "https://bitbucket.org/rablador/quickref",
-			"previous_names": ["QuickRef"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/r.json
+++ b/repository/r.json
@@ -218,7 +218,6 @@
 		{
 			"name": "RailsGoToSpec",
 			"details": "https://github.com/sporto/rails-go-to-spec-sublime",
-			"previous_names": ["rails_go_to_spec", "Rails Go To Spec"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1340,7 +1339,6 @@
 		{
 			"name": "Require CommonJS Modules Helper",
 			"details": "https://github.com/jfromaniello/sublime-node-require",
-			"previous_names": ["Require Node.js Modules Helper"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1543,7 +1541,6 @@
 			"name": "REXX",
 			"details": "https://github.com/mblocker/rexx-sublime",
 			"labels": ["language syntax"],
-			"previous_names": ["REXX Language Support"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1555,7 +1552,6 @@
 			"name": "RGBDS",
 			"details": "https://github.com/ISSOtm/sublime-RGBDS",
 			"labels": ["language syntax", "game boy", "rgbds"],
-			"previous_names": ["Z80 Assembly (RGBDS)"],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1748,7 +1744,6 @@
 		{
 			"name": "RobotFrameworkAssistant",
 			"details": "https://github.com/andriyko/sublime-robot-framework-assistant",
-			"previous_names": ["Robot Framework Assistant"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -1895,7 +1890,6 @@
 		{
 			"name": "Roy",
 			"details": "https://github.com/joneshf/sublime-roy",
-			"previous_names": ["RoyCompile"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2087,7 +2081,6 @@
 			"labels": ["auto-complete", "code navigation", "file navigation", "linting", "language syntax", "search"],
 			"readme": "https://raw.githubusercontent.com/tillt/RTagsComplete/master/site/package_readme.md",
 			"donate": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=AY5UC3W9NDUGL",
-			"previous_names": ["RtagsComplete", "sublime-rtags", "SublimeRtags"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2203,7 +2196,6 @@
 		{
 			"name": "Ruby Hash Converter",
 			"details": "https://github.com/iltempo/sublime-text-2-hash-syntax",
-			"previous_names": ["Ruby 1.9 Hash Converter"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2256,7 +2248,6 @@
 		{
 			"name": "Ruby Slim",
 			"details": "https://github.com/SublimeText/Slim",
-			"previous_names": ["ruby-slim.tmbundle", "ruby-slim"],
 			"releases": [
 				{
 					"sublime_text": "<4107",
@@ -2468,7 +2459,6 @@
 		{
 			"name": "Rust Enhanced",
 			"details": "https://github.com/rust-lang/rust-enhanced",
-			"previous_names": ["Rust"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/s.json
+++ b/repository/s.json
@@ -222,7 +222,6 @@
 		},
 		{
 			"name": "Sass-Director",
-			"previous_names": ["SassDirector"],
 			"details": "https://github.com/Sass-Director/Sass-Director_Sublime",
 			"labels": ["sass", "director", "manifest"],
 			"releases": [
@@ -787,7 +786,6 @@
 			"name": "Search in Project",
 			"details": "https://github.com/leonid-shevtsov/SearchInProject_SublimeText",
 			"labels": ["search"],
-			"previous_names": ["SearchInProject"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1168,7 +1166,6 @@
 		},
 		{
 			"details": "https://github.com/facelessuser/SerializedDataConverter",
-			"previous_names": ["PlistJsonConverter"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1191,7 +1188,6 @@
 		},
 		{
 			"name": "Sesame",
-			"previous_names": ["open-sesame"],
 			"details": "https://github.com/gerardroche/sublime-sesame",
 			"labels": ["project", "file navigation"],
 			"releases": [
@@ -1295,7 +1291,6 @@
 			"homepage": "https://github.com/felquis/SexySnippets",
 			"author": "felquis",
 			"labels": ["snippets", "css", "html", "javascript"],
-			"previous_names": ["Sexy Snippets"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1339,7 +1334,6 @@
 			"name": "Shader Syntax (GLSL HLSL Cg)",
 			"details": "https://github.com/noct/sublime-shaders",
 			"labels": ["language syntax"],
-			"previous_names": ["SublimeSL"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1417,7 +1411,6 @@
 			"name": "ShellCommand",
 			"details": "https://github.com/markbirbeck/sublime-text-shell-command",
 			"labels": ["shell", "emacs"],
-			"previous_names": ["Shell Command"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1605,7 +1598,6 @@
 		},
 		{
 			"name": "ShowTexdoc",
-			"previous_names": ["Show Texdoc"],
 			"details": "https://github.com/CareF/Show-Texdoc",
 			"releases": [
 				{
@@ -1640,7 +1632,6 @@
 			"details": "https://github.com/jgbishop/sxs-settings",
 			"donate": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=4FJM9Y54FV6E4",
 			"labels": ["utilities"],
-			"previous_names": ["SxS Settings"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1663,7 +1654,6 @@
 		},
 		{
 			"name": "SideBarHider",
-			"previous_names": ["Hide Sidebar When Not Focussed"],
 			"details": "https://github.com/akrabat/SideBarHider",
 			"releases": [
 				{
@@ -2173,7 +2163,6 @@
 			"name": "Six - Future JavaScript Syntax",
 			"details": "https://github.com/matthewrobb/Six.tmLanguage",
 			"labels": ["language syntax"],
-			"previous_names": ["Six: Future JavaScript Syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2206,7 +2195,6 @@
 		{
 			"name": "SKILL from Cadence",
 			"details": "https://github.com/leoheck/sublime-cadence-skill",
-			"previous_names": ["Cadence Skill"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2335,7 +2323,6 @@
 			"name": "Slugify",
 			"details": "https://github.com/alimony/sublime-slugify",
 			"labels": ["text manipulation"],
-			"previous_names": ["Slug"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3087,7 +3074,6 @@
 			"name": "SourceTalk",
 			"details": "https://github.com/malroc/sourcetalk_st2",
 			"labels": ["code sharing", "remote collaboration"],
-			"previous_names": ["SoucreTalk (real time code discussions)"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3097,7 +3083,6 @@
 		},
 		{
 			"name": "Sourcetrail",
-			"previous_names": ["coati"],
 			"details": "https://github.com/CoatiSoftware/sublime-sourcetrail",
 			"labels": ["utilities"],
 			"releases": [
@@ -3280,7 +3265,6 @@
 			"name": "SPICE Circuit Simulator",
 			"details": "https://github.com/leoheck/sublime-spice",
 			"labels": ["circuit simulator"],
-			"previous_names": ["Spice"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3389,7 +3373,6 @@
 			"name": "Spotify",
 			"details": "https://github.com/smpanaro/sublime-spotify",
 			"labels": ["music"],
-			"previous_names": ["Spotify Control"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3453,7 +3436,6 @@
 			"details": "https://github.com/axemonk/Spreadsheet-Formula",
 			"author": ["axemonk", "michaelblyons"],
 			"labels": ["completions", "language syntax", "snippets"],
-			"previous_names": ["Excel formula"],
 			"releases": [
 				{
 					"sublime_text": "3092 - 4074",
@@ -3819,7 +3801,6 @@
 			"name": "Stata Enhanced",
 			"details": "https://github.com/andrewheiss/SublimeStataEnhanced",
 			"labels": ["stata"],
-			"previous_names": ["Stata 13"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4059,7 +4040,6 @@
 		{
 			"name": "Strapdown Markdown Preview",
 			"details": "https://github.com/michfield/sublime-strapdown-preview",
-			"previous_names": ["Strapdown.js Markdown Preview"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -4122,7 +4102,6 @@
 		},
 		{
 			"name": "Strings Resource File",
-			"previous_names": ["Xcode Strings"],
 			"details": "https://github.com/p4t5h3/strings-resource-file-language-for-sublime-text",
 			"labels": ["language syntax"],
 			"releases": [
@@ -4195,7 +4174,6 @@
 		},
 		{
 			"name": "Stylefmt",
-			"previous_names": ["CSSfmt"],
 			"details": "https://github.com/dmnsgn/sublime-stylefmt",
 			"labels": ["formatting", "css", "style"],
 			"releases": [
@@ -4687,7 +4665,6 @@
 			"name": "SublimeERB",
 			"details": "https://github.com/eddorre/SublimeERB",
 			"labels": ["formatting", "snippets", "text_manipulation"],
-			"previous_names": ["ERB Insert and Toggle Commands"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4899,7 +4876,6 @@
 		{
 			"details": "https://github.com/JulianEberius/SublimePythonIDE",
 			"labels": ["auto-complete", "linting", "refactoring", "python"],
-			"previous_names": ["Python IDE"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -5565,7 +5541,6 @@
 			"name": "Swap Selections",
 			"details": "https://github.com/gillibrand/sublimetext-swap-selections",
 			"labels": ["text manipulation"],
-			"previous_names": ["SwapSelection"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/t.json
+++ b/repository/t.json
@@ -81,7 +81,6 @@
 		},
 		{
 			"name": "Tabnine",
-			"previous_names": ["TabNine"],
 			"details": "https://github.com/codota/tabnine-sublime",
 			"author": "Tabnine",
 			"labels": [
@@ -369,7 +368,6 @@
 		},
 		{
 			"name": "TamarinProver",
-			"previous_names": ["TamarinAssist"],
 			"details": "https://github.com/tamarin-prover/editor-sublime",
 			"labels": ["tamarin prover", "spthy", "language syntax"],
 			"releases": [
@@ -721,7 +719,6 @@
 		},
 		{
 			"name": "termX",
-			"previous_names": ["MacTerminal"],
 			"homepage": "http://malinowski.be/termX",
 			"details": "https://github.com/afterdesign/termX",
 			"labels": ["terminal"],
@@ -927,7 +924,6 @@
 		{
 			"name": "TestRSpec",
 			"details": "https://github.com/astrauka/TestRSpec",
-			"previous_names": ["Test RSpec"],
 			"labels": ["ruby", "testing", "rspec", "spec"],
 			"releases": [
 				{
@@ -1224,7 +1220,6 @@
 			"name": "Theme - Centurion",
 			"details": "https://github.com/allanhortle/Centurion",
 			"labels": ["theme"],
-			"previous_names": ["Theme - Centurion Blue"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1329,7 +1324,6 @@
 		{
 			"name": "Theme - Dark Material",
 			"details": "https://github.com/artifactdev/Theme-Dark-Material",
-			"previous_names": ["Theme - Dark Marterial"],
 			"labels": ["theme"],
 			"releases": [
 				{
@@ -1397,7 +1391,6 @@
 			"name": "Theme - El Capitan",
 			"details": "https://github.com/iccir/El-Capitan-Theme",
 			"labels": ["theme"],
-			"previous_names": ["El Capitan Theme"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1409,7 +1402,6 @@
 			"name": "Theme - Elementary",
 			"details": "https://github.com/piotrkubisa/sublime-elementary",
 			"labels": ["theme", "color scheme"],
-			"previous_names": ["Mustang Extended Color Scheme"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1552,7 +1544,6 @@
 			"name": "Theme - Haft Lang",
 			"details": "https://github.com/amirrustam/haft-lang",
 			"labels": ["theme", "color scheme"],
-			"previous_names": ["Haft Lang - Theme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1628,7 +1619,6 @@
 		},
 		{
 			"name": "Theme - Legacy",
-			"previous_names": ["Theme - Retina"],
 			"details": "https://github.com/SublimeText/LegacyTheme",
 			"labels": ["theme", "legacy"],
 			"releases": [
@@ -1695,7 +1685,6 @@
 		},
 		{
 			"name": "Theme - Midnight",
-			"previous_names": ["Theme - Mignight"],
 			"details": "https://github.com/avvyas/theme-midnight",
 			"labels": ["theme"],
 			"releases": [
@@ -1923,7 +1912,6 @@
 		},
 		{
 			"name": "Theme - Pure",
-			"previous_names": ["Theme - Hsiang"],
 			"details": "https://github.com/xianghongai/Theme-Pure",
 			"labels": ["theme", "color scheme"],
 			"author": "xianghongai",
@@ -2116,7 +2104,6 @@
 			"name": "Theme - Spacefunk",
 			"details": "https://github.com/jasperjorna/ST-Spacefunk",
 			"labels": ["theme", "color scheme"],
-			"previous_names": ["Spacefunk"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2195,7 +2182,6 @@
 		},
 		{
 			"name": "Theme - Toxin",
-			"previous_names": ["Toxin Color Scheme"],
 			"details": "https://github.com/p3lim/sublime-toxin",
 			"labels": ["theme", "color scheme"],
 			"releases": [
@@ -2344,7 +2330,6 @@
 		{
 			"name": "Thinkphp",
 			"details": "https://github.com/yangweijie/SublimeThinkPHP",
-			"previous_names": ["ThinkPHP Snippets"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -2391,7 +2376,6 @@
 		},
 		{
 			"name": "Threejs Autocomplete",
-			"previous_names": ["Three.js Autocomplete"],
 			"details": "https://github.com/wrbing728/threejs-sublime",
 			"author": "wrbing728",
 			"releases": [
@@ -2491,7 +2475,6 @@
 		},
 		{
 			"name": "Tint Terminal",
-			"previous_names": ["Tint"],
 			"details": "https://github.com/joshgoebel/sublime-tint-terminal",
 			"author": "Josh Goebel",
 			"labels": [
@@ -2632,7 +2615,6 @@
 		},
 		{
 			"name": "tmux",
-			"previous_names": ["tmux_open"],
 			"details": "https://github.com/huntie/sublime-tmux",
 			"labels": ["tmux", "terminal"],
 			"releases": [
@@ -2708,7 +2690,6 @@
 			"name": "ToDone",
 			"details": "https://github.com/tiffon/sublime-to-done",
 			"labels": ["todo", "productivity", "tasks"],
-			"previous_names": ["To-Done"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2720,7 +2701,6 @@
 			"name": "TodoReview",
 			"details": "https://github.com/jonathanrdelgado/SublimeTodoReview",
 			"labels": ["todo", "search", "review", "comments", "tasks"],
-			"previous_names": ["SublimeTODO"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2730,7 +2710,6 @@
 		},
 		{
 			"name": "TodoTxt Syntax",
-			"previous_names": ["Todo.txt Syntax"],
 			"details": "https://github.com/dertuxmalwieder/SublimeTodoTxt",
 			"labels": ["language syntax"],
 			"releases": [
@@ -2847,7 +2826,6 @@
 		{
 			"name": "Toggle Words",
 			"details": "https://github.com/gordio/ToggleWords",
-			"previous_names": ["Toggle words"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3054,7 +3032,6 @@
 		{
 			"name": "Tony Water",
 			"details": "https://github.com/evercyan/tony-water",
-			"previous_names": ["subryan"],
 			"labels": ["json", "utilities"],
 			"releases": [
 				{
@@ -3316,7 +3293,6 @@
 		},
 		{
 			"name": "Translator",
-			"previous_names": ["Inline Google Translate"],
 			"details": "https://github.com/dmytrovoytko/sublimetext-translate",
 			"author": "Dmytro Voytko",
 			"labels": ["translate", "text manipulation"],
@@ -3817,7 +3793,6 @@
 			"name": "TypescriptCompletion",
 			"details": "https://github.com/RonanDrouglazet/TypescriptCompletion",
 			"labels": ["auto-complete", "text manipulation", "typescript"],
-			"previous_names": ["TSCompletion"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/u.json
+++ b/repository/u.json
@@ -79,7 +79,6 @@
 			"name": "UIkit autocomplete",
 			"details": "https://github.com/uikit/uikit-sublime",
 			"labels": ["auto-complete"],
-			"previous_names": ["UIkit class autocomplete"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -234,7 +233,6 @@
 			"name": "Unicode Escape",
 			"details": "https://github.com/iahu/unicode-escape",
 			"labels": ["escape", "unescape", "utf8"],
-			"previous_names": ["escape & unescape tool"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -276,7 +274,6 @@
 		},
 		{
 			"name": "UNIFA",
-			"previous_names": ["UFA Syntax"],
 			"details": "https://github.com/sal0max/sublime-unifa",
 			"releases": [
 				{

--- a/repository/v.json
+++ b/repository/v.json
@@ -332,7 +332,6 @@
 			"name": "View Bookmarks",
 			"details": "https://github.com/adam-zethraeus/SublimeViewBookmarks",
 			"labels": ["bookmarks", "file navigation"],
-			"previous_names": ["LsBookmarks"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -529,7 +528,6 @@
 		{
 			"name": "VintageousOrigami",
 			"details": "https://github.com/rodcloutier/Vintageous-Origami",
-			"previous_names": ["Vintageous Origami"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/w.json
+++ b/repository/w.json
@@ -146,7 +146,6 @@
 		},
 		{
 			"name": "webAgent",
-			"previous_names": ["WebAgent"],
 			"details": "https://github.com/seanfagan/webagent_syntax",
 			"labels": ["webagent", "language syntax"],
 			"releases": [
@@ -287,7 +286,6 @@
 		},
 		{
 			"name": "Webloc",
-			"previous_names": ["Webloc-open"],
 			"details": "https://github.com/andrewp-as-is/sublime-webloc",
 			"labels": ["build system"],
 			"releases": [
@@ -382,7 +380,6 @@
 			"name": "White Night Color Scheme",
 			"details": "https://github.com/strongliang/WhiteNight.tmTheme",
 			"labels": ["color scheme"],
-			"previous_names": ["White Night Theme"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -445,7 +442,6 @@
 		{
 			"name": "WhoCalled Function Finder",
 			"details": "https://bitbucket.org/rablador/whocalled",
-			"previous_names": ["WhoCalled"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -496,7 +492,6 @@
 		},
 		{
 			"name": "Wildlife Color Scheme",
-			"previous_names":["Wildlife"],
 			"details": "https://github.com/tushortz/wildlife",
 			"labels": ["color scheme"],
 			"releases": [
@@ -552,7 +547,6 @@
 		{
 			"name": "WinSCP",
 			"details": "https://github.com/thecotne/sublime-WinSCP",
-			"previous_names": ["sublime WinSCP"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -755,7 +749,6 @@
 		{
 			"name": "WordingStatus",
 			"details": "https://github.com/evandrocoan/WordingStatus",
-			"previous_names": ["WordCount"],
 			"author": "evandrocoan",
 			"releases": [
 				{
@@ -777,7 +770,6 @@
 		{
 			"name": "WordPress",
 			"details": "https://github.com/purplefish32/sublime-text-2-wordpress",
-			"previous_names": ["Wordpress"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -937,7 +929,6 @@
 		},
 		{
 			"name": "WoWDevelopment",
-			"previous_names": ["WoW Development"],
 			"details": "https://github.com/Resike/WoWDevelopment",
 			"releases": [
 				{
@@ -970,7 +961,6 @@
 		{
 			"name": "wpseek WordPress Developer Assistant",
 			"details": "https://github.com/wpseek/sublime-text-2-wpseek",
-			"previous_names": ["wpseek.com WordPress Developer Assistant", "wpseek.com WordPress Function Lookup"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1032,7 +1022,6 @@
 			"name": "WrapIt",
 			"description": "Wrap Contents With Specific Code",
 			"details": "https://github.com/pykong/WrapIt",
-			"previous_names": ["Wrapper"],
 			"labels": ["text manipulation"],
 			"releases": [
 				{

--- a/repository/x.json
+++ b/repository/x.json
@@ -24,7 +24,6 @@
 		},
 		{
 			"name": "x86 and x86_64 Assembly",
-			"previous_names": ["X86 and X86_64 assembly"],
 			"details": "https://github.com/13xforever/x86-assembly-textmate-bundle",
 			"labels": ["language syntax"],
 			"releases": [
@@ -58,7 +57,6 @@
 		},
 		{
 			"name": "Xcode Configuration Settings",
-			"previous_names": ["Xcode Build Configuration", "Xcode Build Configuration and Project Syntax Definitions", "Xcode Project"],
 			"details": "https://github.com/p4t5h3/xcode-build-configuration-language-for-sublime-text",
 			"labels": ["language syntax"],
 			"releases": [

--- a/repository/y.json
+++ b/repository/y.json
@@ -23,7 +23,6 @@
 		},
 		{
 			"name": "YAMLMacros",
-			"previous_names": ["YAML Macros"],
 			"details": "https://github.com/Thom1729/YAML-Macros",
 			"releases": [
 				{
@@ -47,7 +46,6 @@
 			"name": "YandexTranslate",
 			"details": "https://github.com/pafnuty/sublime-yandex-translate",
 			"labels": ["translate", "yandex"],
-			"previous_names": ["Yandex Translate"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -81,7 +79,6 @@
 			"name": "Yara Rule Syntax",
 			"details": "https://github.com/nyx0/YaraSyntax",
 			"labels": ["language syntax", "snippets", "yara"],
-			"previous_names": ["Yara Rule"],
 			"releases": [
 				{
 					"sublime_text": ">=3084",
@@ -176,7 +173,6 @@
 		},
 		{
 			"name": "Yii Framework 1.1 Snippets",
-			"previous_names": ["Yii Framework Snippets"],
 			"details": "https://github.com/david-soyez/sublime-yii-snippets",
 			"labels": ["snippets"],
 			"releases": [

--- a/repository/z.json
+++ b/repository/z.json
@@ -214,7 +214,6 @@
 		},
 		{
 			"name": "Znuny",
-			"previous_names": ["Znuny4OTRS"],
 			"details": "https://github.com/znuny/Znuny-Sublime",
 			"author": "Znuny GmbH",
 			"labels": ["snippets", "perl", "znuny"],


### PR DESCRIPTION
This commit cleans up previous names entries, which haven't been modified for at least 2 years.