### PR TITLE
Takeover PHP Getters and Setters package

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -38,7 +38,6 @@
 		"https://raw.githubusercontent.com/FichteFoll/sublime_packages/master/package_control.json",
 		"https://raw.githubusercontent.com/filcab/SublimeLLDB/master/packages.json",
 		"https://raw.githubusercontent.com/Floobits/floobits-sublime/master/packages.json",
-		"https://raw.githubusercontent.com/francodacosta/sublime-php-getters-setters/master/packages.json",
 		"https://raw.githubusercontent.com/freewizard/sublime_packages/master/package_control.json",
 		"https://raw.githubusercontent.com/gcollazo/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/Harrison-M/indent.txt-sublime/master/packages.json",

--- a/repository/p.json
+++ b/repository/p.json
@@ -1147,6 +1147,18 @@
 			]
 		},
 		{
+			"name": "PHP Getters and Setters",
+			"author": "Nuno Franco da Costa",
+			"details": "https://github.com/SublimeText/PHPGettersSetters",
+			"labels": ["auto-complete", "code generation", "formatting", "snippets", "text manipulation", "php"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "PHP Haml",
 			"details": "https://github.com/xt99/sublimetext-php-haml",
 			"releases": [


### PR DESCRIPTION
This commit updates registration of "PHP Getters and Setters" to point to repository on SublimeText org, which ships various compatibility fixes for ST4.

Handover for original repository has been requested in Jan 25 without any respond at the point of writing this.

see: https://github.com/francodacosta/sublime-php-getters-setters/issues/76