### PR TITLE
Replace external repositories

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -7,7 +7,6 @@
 		"https://emmetio.github.io/sublime-text-plugin/registry.json",
 		"https://packages.monokai.pro/packages.json",
 		"https://raw.githubusercontent.com/20Tauri/DoxyDoxygen/master/DoxyDoxygen.json",
-		"https://raw.githubusercontent.com/accerqueira/sublime/master/packages.json",
 		"https://raw.githubusercontent.com/afterdesign/jshintify/master/packages.json",
 		"https://raw.githubusercontent.com/ajryan/CSharpreter/master/packages.json",
 		"https://raw.githubusercontent.com/amazedkoumei/SublimeKnifeSolo/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -26,7 +26,6 @@
 		"https://raw.githubusercontent.com/Exafunction/codeium-sublime/main/packages.json",
 		"https://raw.githubusercontent.com/FichteFoll/sublime_packages/master/package_control.json",
 		"https://raw.githubusercontent.com/filcab/SublimeLLDB/master/packages.json",
-		"https://raw.githubusercontent.com/Floobits/floobits-sublime/master/packages.json",
 		"https://raw.githubusercontent.com/fnkr/ST-Repository/master/repository.json",
 		"https://raw.githubusercontent.com/francodacosta/sublime-php-getters-setters/master/packages.json",
 		"https://raw.githubusercontent.com/freewizard/sublime_packages/master/package_control.json",

--- a/channel.json
+++ b/channel.json
@@ -24,7 +24,6 @@
 		"https://raw.githubusercontent.com/danielobrien/sublime-DLX-syntax/master/packages.json",
 		"https://raw.githubusercontent.com/enriquein/JavaSetterGetter/master/packages.json",
 		"https://raw.githubusercontent.com/Exafunction/codeium-sublime/main/packages.json",
-		"https://raw.githubusercontent.com/farcaller/DashDoc/master/packages.json",
 		"https://raw.githubusercontent.com/FichteFoll/sublime_packages/master/package_control.json",
 		"https://raw.githubusercontent.com/filcab/SublimeLLDB/master/packages.json",
 		"https://raw.githubusercontent.com/Floobits/floobits-sublime/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -75,7 +75,6 @@
 		"https://raw.githubusercontent.com/SublimeLinter/package_control_channel/master/packages.json",
 		"https://raw.githubusercontent.com/sublimelsp/repository/main/repository.json",
 		"https://raw.githubusercontent.com/SublimeText/wbond-packages/main/packages.json",
-		"https://raw.githubusercontent.com/superbob/SublimeTextLanguageFrench/master/packages.json",
 		"https://raw.githubusercontent.com/tbfisher/sublimetext-Pandoc/master/packages.json",
 		"https://raw.githubusercontent.com/tcrosen/recessify/master/packages.json",
 		"https://raw.githubusercontent.com/Ted-Mohamed/Split/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -82,7 +82,6 @@
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",
 		"https://raw.githubusercontent.com/wallabyjs/sublime-text-releases/main/packages.json",
 		"https://raw.githubusercontent.com/wallysalami/QuickLook/master/packages.json",
-		"https://raw.githubusercontent.com/x3ns/x3-alpha-theme/master/packages.json",
 		"https://raw.githubusercontent.com/xgenvn/InputHelper/master/packages.json",
 		"https://raw.githubusercontent.com/zfkun/sublime-kissy-snippets/master/packages.json",
 		"https://tinkerwell.app/plugins/sublime/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -21,7 +21,6 @@
 		"https://raw.githubusercontent.com/connec/Open-in-ConEmu/master/packages.json",
 		"https://raw.githubusercontent.com/corbinian/GrowlNotifier/master/packages.json",
 		"https://raw.githubusercontent.com/csch0/SublimeText-Packages/master/packages.json",
-		"https://raw.githubusercontent.com/damccull/sublimetext-SolarizedToggle/master/packages.json",
 		"https://raw.githubusercontent.com/danielmagnussons/orgmode/master/packages.json",
 		"https://raw.githubusercontent.com/danielobrien/sublime-DLX-syntax/master/packages.json",
 		"https://raw.githubusercontent.com/enriquein/JavaSetterGetter/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -75,7 +75,6 @@
 		"https://raw.githubusercontent.com/SublimeLinter/package_control_channel/master/packages.json",
 		"https://raw.githubusercontent.com/sublimelsp/repository/main/repository.json",
 		"https://raw.githubusercontent.com/SublimeText/wbond-packages/main/packages.json",
-		"https://raw.githubusercontent.com/tbfisher/sublimetext-Pandoc/master/packages.json",
 		"https://raw.githubusercontent.com/tcrosen/recessify/master/packages.json",
 		"https://raw.githubusercontent.com/Ted-Mohamed/Split/master/packages.json",
 		"https://raw.githubusercontent.com/teddyknox/SublimeChromeRefresh/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -82,7 +82,6 @@
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",
 		"https://raw.githubusercontent.com/wallabyjs/sublime-text-releases/main/packages.json",
 		"https://raw.githubusercontent.com/wallysalami/QuickLook/master/packages.json",
-		"https://raw.githubusercontent.com/weslly/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/wuub/requirementstxt/master/packages.json",
 		"https://raw.githubusercontent.com/wuub/SublimeREPL/master/packages.json",
 		"https://raw.githubusercontent.com/x3ns/x3-alpha-theme/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -79,7 +79,6 @@
 		"https://raw.githubusercontent.com/Ted-Mohamed/Split/master/packages.json",
 		"https://raw.githubusercontent.com/teddyknox/SublimeChromeRefresh/master/packages.json",
 		"https://raw.githubusercontent.com/theadamlt/sublime_packages/master/packages.json",
-		"https://raw.githubusercontent.com/thinkv/sublime-elfinder/master/packages.json",
 		"https://raw.githubusercontent.com/tillig/SublimeMSBuild/master/packages.json",
 		"https://raw.githubusercontent.com/timonwong/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -82,7 +82,6 @@
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",
 		"https://raw.githubusercontent.com/wallabyjs/sublime-text-releases/main/packages.json",
 		"https://raw.githubusercontent.com/wallysalami/QuickLook/master/packages.json",
-		"https://raw.githubusercontent.com/wuub/requirementstxt/master/packages.json",
 		"https://raw.githubusercontent.com/wuub/SublimeREPL/master/packages.json",
 		"https://raw.githubusercontent.com/x3ns/x3-alpha-theme/master/packages.json",
 		"https://raw.githubusercontent.com/xgenvn/InputHelper/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -82,7 +82,6 @@
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",
 		"https://raw.githubusercontent.com/wallabyjs/sublime-text-releases/main/packages.json",
 		"https://raw.githubusercontent.com/wallysalami/QuickLook/master/packages.json",
-		"https://raw.githubusercontent.com/wuub/SublimeREPL/master/packages.json",
 		"https://raw.githubusercontent.com/x3ns/x3-alpha-theme/master/packages.json",
 		"https://raw.githubusercontent.com/xgenvn/InputHelper/master/packages.json",
 		"https://raw.githubusercontent.com/zfkun/sublime-kissy-snippets/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -21,7 +21,6 @@
 		"https://raw.githubusercontent.com/connec/Open-in-ConEmu/master/packages.json",
 		"https://raw.githubusercontent.com/corbinian/GrowlNotifier/master/packages.json",
 		"https://raw.githubusercontent.com/csch0/SublimeText-Packages/master/packages.json",
-		"https://raw.githubusercontent.com/danielmagnussons/orgmode/master/packages.json",
 		"https://raw.githubusercontent.com/danielobrien/sublime-DLX-syntax/master/packages.json",
 		"https://raw.githubusercontent.com/enriquein/JavaSetterGetter/master/packages.json",
 		"https://raw.githubusercontent.com/Exafunction/codeium-sublime/main/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -80,7 +80,6 @@
 		"https://raw.githubusercontent.com/teddyknox/SublimeChromeRefresh/master/packages.json",
 		"https://raw.githubusercontent.com/theadamlt/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",
-		"https://raw.githubusercontent.com/vkocubinsky/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/wallabyjs/sublime-text-releases/main/packages.json",
 		"https://raw.githubusercontent.com/wallysalami/QuickLook/master/packages.json",
 		"https://raw.githubusercontent.com/weslly/sublime_packages/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -79,7 +79,6 @@
 		"https://raw.githubusercontent.com/Ted-Mohamed/Split/master/packages.json",
 		"https://raw.githubusercontent.com/teddyknox/SublimeChromeRefresh/master/packages.json",
 		"https://raw.githubusercontent.com/theadamlt/sublime_packages/master/packages.json",
-		"https://raw.githubusercontent.com/thecotne/subl-protocol/master/package.json",
 		"https://raw.githubusercontent.com/thinkv/sublime-elfinder/master/packages.json",
 		"https://raw.githubusercontent.com/tillig/SublimeMSBuild/master/packages.json",
 		"https://raw.githubusercontent.com/timonwong/sublime_packages/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -79,7 +79,6 @@
 		"https://raw.githubusercontent.com/Ted-Mohamed/Split/master/packages.json",
 		"https://raw.githubusercontent.com/teddyknox/SublimeChromeRefresh/master/packages.json",
 		"https://raw.githubusercontent.com/theadamlt/sublime_packages/master/packages.json",
-		"https://raw.githubusercontent.com/thecotne/smart_less_build/master/package.json",
 		"https://raw.githubusercontent.com/thecotne/subl-protocol/master/package.json",
 		"https://raw.githubusercontent.com/thinkv/sublime-elfinder/master/packages.json",
 		"https://raw.githubusercontent.com/tillig/SublimeMSBuild/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -79,7 +79,6 @@
 		"https://raw.githubusercontent.com/Ted-Mohamed/Split/master/packages.json",
 		"https://raw.githubusercontent.com/teddyknox/SublimeChromeRefresh/master/packages.json",
 		"https://raw.githubusercontent.com/theadamlt/sublime_packages/master/packages.json",
-		"https://raw.githubusercontent.com/tillig/SublimeMSBuild/master/packages.json",
 		"https://raw.githubusercontent.com/timonwong/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",
 		"https://raw.githubusercontent.com/vkocubinsky/sublime_packages/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -7,7 +7,6 @@
 		"https://emmetio.github.io/sublime-text-plugin/registry.json",
 		"https://packages.monokai.pro/packages.json",
 		"https://raw.githubusercontent.com/20Tauri/DoxyDoxygen/master/DoxyDoxygen.json",
-		"https://raw.githubusercontent.com/afterdesign/jshintify/master/packages.json",
 		"https://raw.githubusercontent.com/ajryan/CSharpreter/master/packages.json",
 		"https://raw.githubusercontent.com/amazedkoumei/SublimeKnifeSolo/master/packages.json",
 		"https://raw.githubusercontent.com/Andr3as/Sublime-SurroundWith/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -53,7 +53,6 @@
 		"https://raw.githubusercontent.com/lifted-studios/AutoCopyright/master/packages.json",
 		"https://raw.githubusercontent.com/lucifr/CNPunctuationAutopair/master/packages.json",
 		"https://raw.githubusercontent.com/lyapun/sublime-text-2-python-test-runner/master/packages.json",
-		"https://raw.githubusercontent.com/mekwall/obsidian-color-scheme/master/packages.json",
 		"https://raw.githubusercontent.com/Mendor/sublime-erlyman/master/packages.json",
 		"https://raw.githubusercontent.com/mischah/Console-API-Snippets/master/packages.json",
 		"https://raw.githubusercontent.com/naomichi-y/string_counter/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -53,7 +53,6 @@
 		"https://raw.githubusercontent.com/lifted-studios/AutoCopyright/master/packages.json",
 		"https://raw.githubusercontent.com/lucifr/CNPunctuationAutopair/master/packages.json",
 		"https://raw.githubusercontent.com/lyapun/sublime-text-2-python-test-runner/master/packages.json",
-		"https://raw.githubusercontent.com/mischah/Console-API-Snippets/master/packages.json",
 		"https://raw.githubusercontent.com/naomichi-y/string_counter/master/packages.json",
 		"https://raw.githubusercontent.com/NicholasBuse/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/nLight/Phing/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -53,7 +53,6 @@
 		"https://raw.githubusercontent.com/lifted-studios/AutoCopyright/master/packages.json",
 		"https://raw.githubusercontent.com/lucifr/CNPunctuationAutopair/master/packages.json",
 		"https://raw.githubusercontent.com/lyapun/sublime-text-2-python-test-runner/master/packages.json",
-		"https://raw.githubusercontent.com/MattDMo/Neon-sublime-theme/master/packages.json",
 		"https://raw.githubusercontent.com/mekwall/obsidian-color-scheme/master/packages.json",
 		"https://raw.githubusercontent.com/Mendor/sublime-erlyman/master/packages.json",
 		"https://raw.githubusercontent.com/mischah/Console-API-Snippets/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -29,7 +29,6 @@
 		"https://raw.githubusercontent.com/fnkr/ST-Repository/master/repository.json",
 		"https://raw.githubusercontent.com/francodacosta/sublime-php-getters-setters/master/packages.json",
 		"https://raw.githubusercontent.com/freewizard/sublime_packages/master/package_control.json",
-		"https://raw.githubusercontent.com/gcollazo/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/Harrison-M/indent.txt-sublime/master/packages.json",
 		"https://raw.githubusercontent.com/haru01/EasyOpen/master/packages.json",
 		"https://raw.githubusercontent.com/hellpf/GimpRun/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -40,7 +40,6 @@
 		"https://raw.githubusercontent.com/jadb/st2-search-cakephp-api/master/packages.json",
 		"https://raw.githubusercontent.com/jadb/st2-search-cakephp-book/master/packages.json",
 		"https://raw.githubusercontent.com/jeffturcotte/sublime_packages/master/packages.json",
-		"https://raw.githubusercontent.com/JesseTG/ribosome-sublime/master/packages.json",
 		"https://raw.githubusercontent.com/jfcherng-sublime/ST-my-package-control/master/repository-released.json",
 		"https://raw.githubusercontent.com/jfernandez/SublimeRailsEval/master/packages.json",
 		"https://raw.githubusercontent.com/jfromaniello/sublime-unity-recents/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -45,7 +45,6 @@
 		"https://raw.githubusercontent.com/jfromaniello/sublime-unity-recents/master/packages.json",
 		"https://raw.githubusercontent.com/joacodeviaje/aftersave/master/packages.json",
 		"https://raw.githubusercontent.com/joomlapro/joomla3-sublime-snippets/master/packages.json",
-		"https://raw.githubusercontent.com/kairyou/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/Kaizhi/SublimeUpdater/master/packages.json",
 		"https://raw.githubusercontent.com/kallepersson/Sublime-Finder/master/packages.json",
 		"https://raw.githubusercontent.com/Kasoki/FancyProjects/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -70,7 +70,6 @@
 		"https://raw.githubusercontent.com/seanliang/ConvertToUTF8/master/packages.json",
 		"https://raw.githubusercontent.com/sentience/DokuWiki/master/packages.json",
 		"https://raw.githubusercontent.com/sentience/HyperlinkHelper/master/packages.json",
-		"https://raw.githubusercontent.com/sokolovstas/SublimeWebInspector/master/packages.json",
 		"https://raw.githubusercontent.com/soncy/AutoComments-for-Sublime-Text-2/master/packages.json",
 		"https://raw.githubusercontent.com/spectacles/CodeComplice/master/packages.json",
 		"https://raw.githubusercontent.com/STealthy-and-haSTy/SublimePackages/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -12,7 +12,6 @@
 		"https://raw.githubusercontent.com/BenjaminSchaaf/sbnf/master/package_control/packages.json",
 		"https://raw.githubusercontent.com/blachniet/sublime-mimosa/master/packages.json",
 		"https://raw.githubusercontent.com/blake-regalia/linked-data.syntaxes/master/channels/sublime/package-control.json",
-		"https://raw.githubusercontent.com/bradfeehan/SublimePHPCoverage/master/packages.json",
 		"https://raw.githubusercontent.com/buildersbrewery/sublime-lsl/master/package_control_channel.json",
 		"https://raw.githubusercontent.com/camperdave/EC2Upload/master/packages.json",
 		"https://raw.githubusercontent.com/carlcalderon/ofLang/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -46,7 +46,6 @@
 		"https://raw.githubusercontent.com/joacodeviaje/aftersave/master/packages.json",
 		"https://raw.githubusercontent.com/joomlapro/joomla3-sublime-snippets/master/packages.json",
 		"https://raw.githubusercontent.com/Kaizhi/SublimeUpdater/master/packages.json",
-		"https://raw.githubusercontent.com/kallepersson/Sublime-Finder/master/packages.json",
 		"https://raw.githubusercontent.com/Kasoki/FancyProjects/master/packages.json",
 		"https://raw.githubusercontent.com/keeganstreet/sublime-specificity/master/packages.json",
 		"https://raw.githubusercontent.com/kik0220/sublimetext_japanize/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -16,7 +16,6 @@
 		"https://raw.githubusercontent.com/carlcalderon/ofLang/master/packages.json",
 		"https://raw.githubusercontent.com/ccpalettes/sublime-lorem-text/master/packages.json",
 		"https://raw.githubusercontent.com/chancedai/sublime-cross/master/packages.json",
-		"https://raw.githubusercontent.com/chikatoike/IMESupport/master/packages.json",
 		"https://raw.githubusercontent.com/chriswong/sublime-mootools-snippets/master/packages.json",
 		"https://raw.githubusercontent.com/colinta/sublime_packages/main/packages.json",
 		"https://raw.githubusercontent.com/connec/Open-in-ConEmu/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -48,7 +48,6 @@
 		"https://raw.githubusercontent.com/Kaizhi/SublimeUpdater/master/packages.json",
 		"https://raw.githubusercontent.com/Kasoki/FancyProjects/master/packages.json",
 		"https://raw.githubusercontent.com/keeganstreet/sublime-specificity/master/packages.json",
-		"https://raw.githubusercontent.com/kik0220/sublimetext_japanize/master/packages.json",
 		"https://raw.githubusercontent.com/kylederkacz/lettuce-farmer/master/packages.json",
 		"https://raw.githubusercontent.com/leporo/SublimeYammy/master/packages.json",
 		"https://raw.githubusercontent.com/lifted-studios/AutoCopyright/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -53,7 +53,6 @@
 		"https://raw.githubusercontent.com/lifted-studios/AutoCopyright/master/packages.json",
 		"https://raw.githubusercontent.com/lucifr/CNPunctuationAutopair/master/packages.json",
 		"https://raw.githubusercontent.com/lyapun/sublime-text-2-python-test-runner/master/packages.json",
-		"https://raw.githubusercontent.com/Mendor/sublime-erlyman/master/packages.json",
 		"https://raw.githubusercontent.com/mischah/Console-API-Snippets/master/packages.json",
 		"https://raw.githubusercontent.com/naomichi-y/string_counter/master/packages.json",
 		"https://raw.githubusercontent.com/NicholasBuse/sublime_packages/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -9,7 +9,6 @@
 		"https://raw.githubusercontent.com/20Tauri/DoxyDoxygen/master/DoxyDoxygen.json",
 		"https://raw.githubusercontent.com/ajryan/CSharpreter/master/packages.json",
 		"https://raw.githubusercontent.com/amazedkoumei/SublimeKnifeSolo/master/packages.json",
-		"https://raw.githubusercontent.com/apophys/sublime-packages/master/packages.json",
 		"https://raw.githubusercontent.com/BenjaminSchaaf/sbnf/master/package_control/packages.json",
 		"https://raw.githubusercontent.com/blachniet/sublime-mimosa/master/packages.json",
 		"https://raw.githubusercontent.com/blake-regalia/linked-data.syntaxes/master/channels/sublime/package-control.json",

--- a/channel.json
+++ b/channel.json
@@ -71,7 +71,6 @@
 		"https://raw.githubusercontent.com/sentience/DokuWiki/master/packages.json",
 		"https://raw.githubusercontent.com/sentience/HyperlinkHelper/master/packages.json",
 		"https://raw.githubusercontent.com/soncy/AutoComments-for-Sublime-Text-2/master/packages.json",
-		"https://raw.githubusercontent.com/spectacles/CodeComplice/master/packages.json",
 		"https://raw.githubusercontent.com/STealthy-and-haSTy/SublimePackages/master/packages.json",
 		"https://raw.githubusercontent.com/SublimeLinter/package_control_channel/master/packages.json",
 		"https://raw.githubusercontent.com/sublimelsp/repository/main/repository.json",

--- a/channel.json
+++ b/channel.json
@@ -24,7 +24,6 @@
 		"https://raw.githubusercontent.com/danielobrien/sublime-DLX-syntax/master/packages.json",
 		"https://raw.githubusercontent.com/enriquein/JavaSetterGetter/master/packages.json",
 		"https://raw.githubusercontent.com/Exafunction/codeium-sublime/main/packages.json",
-		"https://raw.githubusercontent.com/FichteFoll/sublime_packages/master/package_control.json",
 		"https://raw.githubusercontent.com/filcab/SublimeLLDB/master/packages.json",
 		"https://raw.githubusercontent.com/fnkr/ST-Repository/master/repository.json",
 		"https://raw.githubusercontent.com/francodacosta/sublime-php-getters-setters/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -82,7 +82,6 @@
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",
 		"https://raw.githubusercontent.com/wallabyjs/sublime-text-releases/main/packages.json",
 		"https://raw.githubusercontent.com/wallysalami/QuickLook/master/packages.json",
-		"https://raw.githubusercontent.com/xgenvn/InputHelper/master/packages.json",
 		"https://raw.githubusercontent.com/zfkun/sublime-kissy-snippets/master/packages.json",
 		"https://tinkerwell.app/plugins/sublime/packages.json",
 		"https://tobygiacometti.com/sublime/packages.json"

--- a/channel.json
+++ b/channel.json
@@ -79,7 +79,6 @@
 		"https://raw.githubusercontent.com/Ted-Mohamed/Split/master/packages.json",
 		"https://raw.githubusercontent.com/teddyknox/SublimeChromeRefresh/master/packages.json",
 		"https://raw.githubusercontent.com/theadamlt/sublime_packages/master/packages.json",
-		"https://raw.githubusercontent.com/timonwong/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/tomascayuelas/coolcodescheme/master/packages.json",
 		"https://raw.githubusercontent.com/vkocubinsky/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/wallabyjs/sublime-text-releases/main/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -12,6 +12,7 @@
 		"https://raw.githubusercontent.com/BenjaminSchaaf/sbnf/master/package_control/packages.json",
 		"https://raw.githubusercontent.com/blachniet/sublime-mimosa/master/packages.json",
 		"https://raw.githubusercontent.com/blake-regalia/linked-data.syntaxes/master/channels/sublime/package-control.json",
+		"https://raw.githubusercontent.com/buildersbrewery/sublime-lsl/master/package_control_channel.json",
 		"https://raw.githubusercontent.com/camperdave/EC2Upload/master/packages.json",
 		"https://raw.githubusercontent.com/carlcalderon/ofLang/master/packages.json",
 		"https://raw.githubusercontent.com/ccpalettes/sublime-lorem-text/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -66,7 +66,6 @@
 		"https://raw.githubusercontent.com/recklesswaltz/Subtoise/master/packages.json",
 		"https://raw.githubusercontent.com/royisme/SublimeOctopressTool/master/packages.json",
 		"https://raw.githubusercontent.com/rpowers/sublime_stata/master/packages.json",
-		"https://raw.githubusercontent.com/rse/sublime-scheme-rse/master/packages.json",
 		"https://raw.githubusercontent.com/sdolard/sublime-jsrevival/master/packages.json",
 		"https://raw.githubusercontent.com/seanliang/ConvertToUTF8/master/packages.json",
 		"https://raw.githubusercontent.com/sentience/DokuWiki/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -45,7 +45,6 @@
 		"https://raw.githubusercontent.com/jfromaniello/sublime-unity-recents/master/packages.json",
 		"https://raw.githubusercontent.com/joacodeviaje/aftersave/master/packages.json",
 		"https://raw.githubusercontent.com/joomlapro/joomla3-sublime-snippets/master/packages.json",
-		"https://raw.githubusercontent.com/jrappen/sublime-packages/master/package_control_channel.json",
 		"https://raw.githubusercontent.com/kairyou/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/Kaizhi/SublimeUpdater/master/packages.json",
 		"https://raw.githubusercontent.com/kallepersson/Sublime-Finder/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -12,7 +12,6 @@
 		"https://raw.githubusercontent.com/BenjaminSchaaf/sbnf/master/package_control/packages.json",
 		"https://raw.githubusercontent.com/blachniet/sublime-mimosa/master/packages.json",
 		"https://raw.githubusercontent.com/blake-regalia/linked-data.syntaxes/master/channels/sublime/package-control.json",
-		"https://raw.githubusercontent.com/buildersbrewery/sublime-lsl/master/package_control_channel.json",
 		"https://raw.githubusercontent.com/camperdave/EC2Upload/master/packages.json",
 		"https://raw.githubusercontent.com/carlcalderon/ofLang/master/packages.json",
 		"https://raw.githubusercontent.com/ccpalettes/sublime-lorem-text/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -12,7 +12,6 @@
 		"https://raw.githubusercontent.com/BenjaminSchaaf/sbnf/master/package_control/packages.json",
 		"https://raw.githubusercontent.com/blachniet/sublime-mimosa/master/packages.json",
 		"https://raw.githubusercontent.com/blake-regalia/linked-data.syntaxes/master/channels/sublime/package-control.json",
-		"https://raw.githubusercontent.com/blueplanet/sublime-text-2-octopress/master/packages.json",
 		"https://raw.githubusercontent.com/bradfeehan/SublimePHPCoverage/master/packages.json",
 		"https://raw.githubusercontent.com/buildersbrewery/sublime-lsl/master/package_control_channel.json",
 		"https://raw.githubusercontent.com/camperdave/EC2Upload/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -9,7 +9,6 @@
 		"https://raw.githubusercontent.com/20Tauri/DoxyDoxygen/master/DoxyDoxygen.json",
 		"https://raw.githubusercontent.com/ajryan/CSharpreter/master/packages.json",
 		"https://raw.githubusercontent.com/amazedkoumei/SublimeKnifeSolo/master/packages.json",
-		"https://raw.githubusercontent.com/Andr3as/Sublime-SurroundWith/master/packages.json",
 		"https://raw.githubusercontent.com/apophys/sublime-packages/master/packages.json",
 		"https://raw.githubusercontent.com/BenjaminSchaaf/sbnf/master/package_control/packages.json",
 		"https://raw.githubusercontent.com/blachniet/sublime-mimosa/master/packages.json",

--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -119,6 +119,28 @@
 					"tags": true
 				}
 			]
+		},
+		{
+			"name": "=BB= LSL",
+			"author": "Builder's Brewery (buildersbrewery)",
+			"details": "https://github.com/buildersbrewery/sublime-lsl",
+			"labels": [
+				"auto-complete",
+				"build system",
+				"code style",
+				"color scheme",
+				"completions",
+				"editor emulation",
+				"language syntax",
+				"linting",
+				"snippets"
+			],
+			"releases": [
+				{
+					"sublime_text": ">=4073",
+					"tags": true
+				}
+			]
 		}
 	]
 }

--- a/repository/0-9.json
+++ b/repository/0-9.json
@@ -119,28 +119,6 @@
 					"tags": true
 				}
 			]
-		},
-		{
-			"name": "=BB= LSL",
-			"author": "Builder's Brewery (buildersbrewery)",
-			"details": "https://github.com/buildersbrewery/sublime-lsl",
-			"labels": [
-				"auto-complete",
-				"build system",
-				"code style",
-				"color scheme",
-				"completions",
-				"editor emulation",
-				"language syntax",
-				"linting",
-				"snippets"
-			],
-			"releases": [
-				{
-					"sublime_text": ">=4073",
-					"tags": true
-				}
-			]
 		}
 	]
 }

--- a/repository/b.json
+++ b/repository/b.json
@@ -1534,6 +1534,17 @@
 			]
 		},
 		{
+			"name": "Browser Refresh",
+			"details": "https://github.com/gcollazo/BrowserRefresh-Sublime",
+			"author": "Giovanni Collazo (@gcollazo)",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Browser Support",
 			"details": "https://github.com/gondo/browsersupport",
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -4599,6 +4599,21 @@
 			]
 		},
 		{
+			"name": "CSScheme",
+			"details": "https://github.com/FichteFoll/CSScheme",
+			"labels": ["color scheme editing"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				},
+				{
+					"sublime_text": "<3000",
+					"tags": "st2-v"
+				}
+			]
+		},
+		{
 			"name": "CSScomb",
 			"details": "https://github.com/csscomb/sublime-csscomb",
 			"previous_names": ["CSScomb.js", "CSScomb JS"],

--- a/repository/c.json
+++ b/repository/c.json
@@ -2912,6 +2912,19 @@
 			]
 		},
 		{
+			"name": "ColorPicker",
+			"details": "https://github.com/weslly/ColorPicker",
+			"homepage": "http://weslly.github.io/ColorPicker/",
+			"author": "Weslly H.",
+			"labels": ["css"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ColorSchemeEditor",
 			"details": "https://github.com/bobef/ColorSchemeEditor",
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -3477,6 +3477,19 @@
 			]
 		},
 		{
+			"name": "Console API Snippets (JavaScript)",
+			"details": "https://github.com/mischah/Console-API-Snippets",
+			"donate": "https://flattr.com/thing/953497/JavaScript-Console-API-Snippets-for-Sublime-Text",
+			"author": "Michael Kühnel",
+			"labels": ["snippets"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Console Exec",
 			"details": "https://github.com/joeyespo/sublimetext-console-exec",
 			"author": "Joe Esposito",

--- a/repository/c.json
+++ b/repository/c.json
@@ -2756,6 +2756,18 @@
 			]
 		},
 		{
+			"name": "Color Scheme - RSE",
+			"details": "https://github.com/rse/sublime-scheme-rse",
+			"author": "Ralf S. Engelschall",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Color Scheme - Sleeplessmind",
 			"details": "https://github.com/godbout/sleeplessmind-color-scheme",
 			"labels": ["color scheme"],

--- a/repository/c.json
+++ b/repository/c.json
@@ -2064,6 +2064,16 @@
 			]
 		},
 		{
+			"name": "CodeComplice",
+			"details": "https://github.com/spectacles/CodeComplice",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CodeDrafts",
 			"details": "https://github.com/subeeshb/codedrafts_sublime_plugin",
 			"labels": ["code sharing", "snippets", "utilities"],

--- a/repository/d.json
+++ b/repository/d.json
@@ -1100,6 +1100,18 @@
 			]
 		},
 		{
+			"name": "distractionless",
+			"details": "https://github.com/jrappen/sublime-distractionless",
+			"donate": "https://paypal.me/jrappen",
+			"labels": ["automation", "distraction-free", "fullscreen"],
+			"releases": [
+				{
+					"sublime_text": ">=4081",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "DistZilla Build",
 			"details": "https://github.com/tmueller/sublime-distzilla-build",
 			"releases": [

--- a/repository/d.json
+++ b/repository/d.json
@@ -256,6 +256,16 @@
 			]
 		},
 		{
+			"name": "DashDoc",
+			"details": "https://github.com/farcaller/DashDoc",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Dashed Comments",
 			"details": "https://github.com/email2vimalraj/DashedComments",
 			"releases": [

--- a/repository/e.json
+++ b/repository/e.json
@@ -594,7 +594,7 @@
 				{
 					"base": "https://github.com/thinkv/sublime-elfinder",
 					"sublime_text": ">=3000",
-					"branch": true
+					"branch": "master"
 				}
 			]
 		},

--- a/repository/e.json
+++ b/repository/e.json
@@ -1218,6 +1218,18 @@
 			]
 		},
 		{
+			"name": "Erlyman",
+			"details": "https://github.com/Mendor/sublime-erlyman",
+			"labels": ["documentation"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ES6-Toolkit",
 			"details": "https://github.com/stephnr/es6-toolkit-for-sublime",
 			"labels": ["snippets", "precompiler", "es2015", "ecmascript6", "javascript"],

--- a/repository/e.json
+++ b/repository/e.json
@@ -585,6 +585,20 @@
 			]
 		},
 		{
+			"name": "Element Finder",
+			"details": "https://github.com/thinkv/sublime-elfinder",
+			"description": "Search HTML files using CSS selectors",
+			"author": ["Keegan Street", "thinkV"],
+			"labels": ["file navigation", "search"],
+			"releases": [
+				{
+					"base": "https://github.com/thinkv/sublime-elfinder",
+					"sublime_text": ">=3000",
+					"branch": true
+				}
+			]
+		},
+		{
 			"name": "Element UI Snippets",
 			"details": "https://github.com/snowffer/Element-UI-Snippets-ST",
 			"labels": ["snippets"],

--- a/repository/f.json
+++ b/repository/f.json
@@ -533,6 +533,18 @@
 			]
 		},
 		{
+			"name": "File History",
+			"details": "https://github.com/FichteFoll/FileHistory",
+			"author": ["FichteFoll", "Josh Bjornson"],
+			"labels": ["file navigation"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "File Rename",
 			"details": "https://github.com/brianlow/FileRename",
 			"labels": ["rename", "file rename"],

--- a/repository/f.json
+++ b/repository/f.json
@@ -1228,6 +1228,18 @@
 			]
 		},
 		{
+			"name": "Floobits",
+			"details": "https://github.com/Floobits/floobits-sublime",
+			"homepage": "https://floobits.com",
+			"labels": ["code sharing", "pair programming", "remote collaboration"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "FloScript",
 			"details": "https://github.com/hadfieldn/sublime-floscript",
 			"labels": ["language syntax"],

--- a/repository/i.json
+++ b/repository/i.json
@@ -317,6 +317,16 @@
 			]
 		},
 		{
+			"name": "IMESupport",
+			"details": "https://github.com/chikatoike/IMESupport",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": "windows"
+				}
+			]
+		},
+		{
 			"name": "img-placeholder",
 			"details": "https://github.com/fisker/img-placeholder",
 			"releases": [

--- a/repository/i.json
+++ b/repository/i.json
@@ -783,6 +783,20 @@
 			]
 		},
 		{
+			"name": "InputHelper",
+			"details": "https://github.com/xgenvn/InputHelper",
+			"author": "Anh Tu Nguyen <xgenvn@gmail.com>",
+			"donate": "https://www.gittip.com/xgenvn/",
+			"labels": ["text input", "input method", "ibus", "linux"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "InQlik-Tools",
 			"details": "https://github.com/inqlik/inqlik-tools",
 			"labels": ["language syntax", "build system"],

--- a/repository/i.json
+++ b/repository/i.json
@@ -322,7 +322,8 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": "windows"
+					"platforms": "windows",
+					"branch": "master"
 				}
 			]
 		},

--- a/repository/i.json
+++ b/repository/i.json
@@ -441,6 +441,18 @@
 			]
 		},
 		{
+			"name": "InactivePanes",
+			"details": "https://github.com/SublimeText/InactivePanes",
+			"author": "FichteFoll",
+			"labels": ["color scheme manipulation"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Inc-Dec-Value",
 			"details": "https://github.com/rmaksim/Sublime-Text-2-Inc-Dec-Value",
 			"author": "Razumenko Maksim",
@@ -850,6 +862,17 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "InsertDate",
+			"details": "https://github.com/FichteFoll/InsertDate",
+			"labels": ["text manipulation"],
+			"releases": [
+				{
+					"sublime_text": "*",
 					"tags": true
 				}
 			]

--- a/repository/j.json
+++ b/repository/j.json
@@ -1066,6 +1066,19 @@
 			]
 		},
 		{
+			"name": "jshintify",
+			"details": "https://github.com/afterdesign/jshintify",
+			"author": "Rafał 'afterdesign' Malinowski",
+			"homepage": "http://afterdesign.github.io/jshintify/",
+			"labels": ["linting"],
+			"releases" : [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "jsimports",
 			"details": "https://github.com/knuthelland/sublime_jsimports",
 			"labels": ["auto-complete"],

--- a/repository/j.json
+++ b/repository/j.json
@@ -132,6 +132,20 @@
 			]
 		},
 		{
+			"name": "Japanize",
+			"details": "https://github.com/kik0220/sublimetext_japanize",
+			"releases": [
+				{
+					"sublime_text": "3000 - 3999",
+					"branch": "3000"
+				},
+				{
+					"sublime_text": ">=4000",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "JapanWordStop",
 			"details": "https://github.com/woodmix/JapanWordStop",
 			"releases": [

--- a/repository/l.json
+++ b/repository/l.json
@@ -33,6 +33,17 @@
 			]
 		},
 		{
+			"name": "Language - French - Français",
+			"details": "https://github.com/superbob/SublimeTextLanguageFrench",
+			"labels": ["spell check", "dictionnary", "french"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Language - Italian - Italiano",
 			"author": ["PLIO", "nixxo"],
 			"details": "https://github.com/nixxo/SublimeTextLanguageItaliano",

--- a/repository/m.json
+++ b/repository/m.json
@@ -2635,6 +2635,17 @@
 			]
 		},
 		{
+			"name": "MSBuild",
+			"details": "https://github.com/tillig/SublimeMSBuild",
+			"labels": ["auto-complete", "build system", "language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MSBuild selector",
 			"details": "https://github.com/JohanBaltie/MSBuildSelector",
 			"author": "Johan Baltié",

--- a/repository/n.json
+++ b/repository/n.json
@@ -469,6 +469,18 @@
 			]
 		},
 		{
+			"name": "Nettuts+ Fetch",
+			"details": "https://github.com/weslly/Nettuts-Fetch",
+			"homepage": "http://net.tutsplus.com/articles/news/introducing-nettuts-fetch/",
+			"author": "Weslly H.",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Network Tech",
 			"details": "https://github.com/heyglen/network_tech",
 			"releases": [

--- a/repository/n.json
+++ b/repository/n.json
@@ -269,6 +269,22 @@
 			]
 		},
 		{
+			"name": "Neon Color Scheme",
+			"details": "https://github.com/MattDMo/Neon-color-scheme",
+			"previous_names": ["Neon Theme"],
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "<3170",
+					"tags": "tmTheme-"
+				},
+				{
+					"sublime_text": ">=3170",
+					"tags": "scs-"
+				}
+			]
+		},
+		{
 			"name": "Neon Intrinsics",
 			"details": "https://github.com/ilya-lavrenov/sublime-neon",
 			"author": "Ilya Lavrenov",

--- a/repository/o.json
+++ b/repository/o.json
@@ -1050,6 +1050,19 @@
 			]
 		},
 		{
+			"name": "orgmode",
+			"details": "https://github.com/danielmagnussons/orgmode",
+			"author": "Daniel Magnusson",
+			"donate": "https://www.gittip.com/danielmagnussons/",
+			"labels": ["text manipulation", "text navigation", "formatting", "todo", "color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/SublimeText/Origami",
 			"releases": [
 				{

--- a/repository/o.json
+++ b/repository/o.json
@@ -181,6 +181,17 @@
 			]
 		},
 		{
+			"name": "Octopress",
+			"details": "https://github.com/blueplanet/sublime-text-octopress",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Octopress Snippets",
 			"details": "https://github.com/yangsu/sublime-octopress",
 			"labels": ["snippets"],

--- a/repository/o.json
+++ b/repository/o.json
@@ -67,6 +67,18 @@
 			]
 		},
 		{
+			"name": "Obsidian Color Scheme",
+			"author": "Marcus Ekwall <marcus.ekwall@gmail.com>",
+			"details": "https://github.com/mekwall/obsidian-color-scheme",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "OCaml Autocompletion",
 			"details": "https://github.com/whitequark/sublime-ocp-index",
 			"releases": [

--- a/repository/o.json
+++ b/repository/o.json
@@ -335,6 +335,18 @@
 			]
 		},
 		{
+			"name": "OmniMarkupPreviewer",
+			"details": "https://github.com/timonwong/OmniMarkupPreviewer",
+			"homepage": "http://timonwong.github.io/OmniMarkupPreviewer/",
+			"author": "timonwong",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "OmniSharp",
 			"details": "https://github.com/OmniSharp/omnisharp-sublime",
 			"labels": ["auto-complete", "language syntax", "c#", ".net"],

--- a/repository/o.json
+++ b/repository/o.json
@@ -487,6 +487,20 @@
 			]
 		},
 		{
+			"name": "Open Finder",
+			"details": "https://github.com/kallepersson/Sublime-Finder",
+			"description": "Provides a command for opening Finder in the current directory",
+			"author": "Kalle Persson",
+			"labels": ["file navigation", "finder"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Open Folder",
 			"details": "https://github.com/mikepfirrmann/openfolder",
 			"labels": ["file navigation"],

--- a/repository/p.json
+++ b/repository/p.json
@@ -199,6 +199,32 @@
 			]
 		},
 		{
+			"name": "Pandoc",
+			"details": "https://github.com/tbfisher/sublimetext-Pandoc",
+			"labels": [
+				"latex",
+				"github flavored markdown",
+				"github markdown",
+				"html",
+				"markdown",
+				"markup",
+				"pandoc",
+				"reStructuredText",
+				"text manipulation",
+				"textile"
+			],
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"branch": "1.x"
+				},
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Pandoc (Markdown)",
 			"details": "https://github.com/jclement/SublimePandoc",
 			"releases": [

--- a/repository/p.json
+++ b/repository/p.json
@@ -1062,6 +1062,16 @@
 			]
 		},
 		{
+			"name": "PHP Code Coverage",
+			"details": "https://github.com/bradfeehan/SublimePHPCoverage",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "PHP Codebeautifier",
 			"details": "https://github.com/Ennosuke/PHP-Codebeautifier",
 			"releases": [

--- a/repository/q.json
+++ b/repository/q.json
@@ -323,6 +323,16 @@
 			]
 		},
 		{
+			"name": "QuickRulers",
+			"details": "https://github.com/FichteFoll/QuickRulers",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "QuickSearchEnhanced",
 			"details": "https://github.com/shagabutdinov/sublime-quick-search-enhanced",
 			"donate": "https://github.com/shagabutdinov/sublime-enhanced/blob/master/readme-donations.md",

--- a/repository/r.json
+++ b/repository/r.json
@@ -1363,6 +1363,20 @@
 			]
 		},
 		{
+			"name": "requirementstxt",
+			"details": "https://github.com/wuub/requirementstxt",
+			"releases": [
+				{
+					"sublime_text": "<3120",
+					"tags": "st2-"
+				},
+				{
+					"sublime_text": ">=3120",
+					"tags": "st3-"
+				}
+			]
+		},
+		{
 			"name": "ReScript",
 			"details": "https://github.com/rescript-lang/rescript-sublime",
 			"releases": [

--- a/repository/r.json
+++ b/repository/r.json
@@ -1597,6 +1597,18 @@
 			]
 		},
 		{
+			"name": "Ribosome",
+			"details": "https://github.com/JesseTG/ribosome-sublime",
+			"labels": ["language syntax"],
+			"previous_names": ["Ribosome Syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "RichTextFormat",
 			"details": "https://github.com/SublimeText/RichTextFormat",
 			"labels": ["language syntax"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -5002,6 +5002,16 @@
 			]
 		},
 		{
+			"name": "SublimeREPL",
+			"details": "https://github.com/wuub/SublimeREPL",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/JulianEberius/SublimeRope",
 			"releases": [
 				{

--- a/repository/s.json
+++ b/repository/s.json
@@ -2856,6 +2856,17 @@
 			]
 		},
 		{
+			"name": "Solarized Toggle",
+			"details": "https://github.com/damccull/sublimetext-SolarizedToggle",
+			"labels": ["color scheme", "theme", "toggle"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Solidity Docstring Generator",
 			"details": "https://github.com/matt-lough/solidity-docstring-generator",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -5424,6 +5424,17 @@
 			]
 		},
 		{
+			"name": "SurroundWith",
+			"details": "https://github.com/Andr3as/Sublime-SurroundWith",
+			"homepage": "http://andrano.de/SurroundWith/",
+			"labels": ["text manipulation"],
+			"releases": [
+				{
+					"sublime_text": "*"
+				}
+			]
+		},
+		{
 			"name": "Susy 2 Snippets",
 			"details": "https://github.com/kyleshevlin/susy-snippets",
 			"labels": ["snippets"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -4342,6 +4342,17 @@
 			]
 		},
 		{
+			"name": "subl protocol",
+			"details": "https://github.com/thecotne/subl-protocol",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["windows", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "sublack",
 			"details": "https://github.com/jgirardet/sublack",
 			"author": "jgirardet",

--- a/repository/s.json
+++ b/repository/s.json
@@ -4993,21 +4993,21 @@
 			]
 		},
 		{
-			"details": "https://github.com/ostinelli/SublimErl",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"branch": "package"
-				}
-			]
-		},
-		{
 			"name": "SublimeREPL",
 			"details": "https://github.com/wuub/SublimeREPL",
 			"releases": [
 				{
 					"sublime_text": "*",
 					"tags": true
+				}
+			]
+		},
+		{
+			"details": "https://github.com/ostinelli/SublimErl",
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"branch": "package"
 				}
 			]
 		},
@@ -5073,18 +5073,6 @@
 			]
 		},
 		{
-			"name": "SublimeTmpl",
-			"details": "https://github.com/kairyou/SublimeTmpl",
-			"donate": "https://www.paypal.me/kairyou",
-			"labels": ["file creation"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "SublimeTextAPICompletions",
 			"details": "https://github.com/gerardroche/sublime-api-completions",
 			"labels": ["auto-complete", "completions"],
@@ -5101,6 +5089,18 @@
 				{
 					"sublime_text": "*",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "SublimeTmpl",
+			"details": "https://github.com/kairyou/SublimeTmpl",
+			"donate": "https://www.paypal.me/kairyou",
+			"labels": ["file creation"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},

--- a/repository/s.json
+++ b/repository/s.json
@@ -348,6 +348,19 @@
 			]
 		},
 		{
+			"name": "ScalaFormat",
+			"details": "https://github.com/timonwong/ScalaFormat",
+			"homepage": "http://timonwong.github.io/ScalaFormat/",
+			"author": "timonwong",
+			"labels": ["formatting", "scala"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ScalaProjectGeneratorFacade",
 			"details": "https://github.com/lgmerek/ScalaProjectGeneratorFacade",
 			"labels": ["scala", "automation"],
@@ -4617,6 +4630,17 @@
 			]
 		},
 		{
+			"name": "SublimeAlternate",
+			"details": "https://github.com/timonwong/SublimeAlternate",
+			"author": "timonwong",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SublimeAnarchy",
 			"details": "https://github.com/AnarchyTools/SublimeAnarchy",
 			"homepage": "http://anarchytools.org",
@@ -4640,6 +4664,19 @@
 				{
 					"platforms": ["osx", "linux"],
 					"sublime_text": ">=3103",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "SublimeAStyleFormatter",
+			"details": "https://github.com/timonwong/SublimeAStyleFormatter",
+			"homepage": "http://timonwong.github.io/SublimeAStyleFormatter/",
+			"author": "timonwong",
+			"labels": ["formatting"],
+			"releases": [
+				{
+					"sublime_text": "*",
 					"tags": true
 				}
 			]

--- a/repository/s.json
+++ b/repository/s.json
@@ -5549,7 +5549,8 @@
 			"labels": ["text manipulation"],
 			"releases": [
 				{
-					"sublime_text": "*"
+					"sublime_text": "*",
+					"branch": "master"
 				}
 			]
 		},

--- a/repository/s.json
+++ b/repository/s.json
@@ -4836,6 +4836,20 @@
 			]
 		},
 		{
+			"name": "SublimeManpage",
+			"details" : "https://github.com/apophys/SublimeManpage",
+			"releases" : [
+				{
+					"sublime_text" : "<3000",
+					"tags": true
+				},
+				{
+					"sublime_text" : ">=3000",
+					"branch": "Sublime-Text-3"
+				}
+			]
+		},
+		{
 			"name": "SublimeNFDToNFCPaste",
 			"details": "https://github.com/astronaughts/SublimeNFDToNFCPaste",
 			"labels": ["multi-byte", "strings"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -2422,6 +2422,18 @@
 			]
 		},
 		{
+			"name": "smart less build",
+			"details": "https://github.com/thecotne/smart_less_build",
+			"labels": ["build system", "css", "less"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["windows"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Smart Match",
 			"details": "https://github.com/ccampbell/sublime-smart-match",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -4971,6 +4971,18 @@
 			]
 		},
 		{
+			"name": "SublimeSimpleSync",
+			"author": ["tnhu", "gfreezy", "kairyou"],
+			"details": "https://github.com/kairyou/SublimeSimpleSync",
+			"donate": "https://www.paypal.me/kairyou",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SublimeSmartBASIC",
 			"details": "https://github.com/eriklins/sublimetext-smartbasic-syntax",
 			"labels": ["language syntax"],
@@ -4987,6 +4999,18 @@
 				{
 					"sublime_text": "<3000",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "SublimeTmpl",
+			"details": "https://github.com/kairyou/SublimeTmpl",
+			"donate": "https://www.paypal.me/kairyou",
+			"labels": ["file creation"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
 				}
 			]
 		},

--- a/repository/t.json
+++ b/repository/t.json
@@ -47,6 +47,23 @@
 			]
 		},
 		{
+			"name": "Table Editor",
+			"details": "https://github.com/vkocubinsky/SublimeTableEditor",
+			"donate": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=CBL373WUKNTZW",
+			"author": "Valery Kocubinsky (vkocubinsky)",
+			"labels": ["text manipulation", "emacs org mode", "markdown", "pandoc", "reStructuredText", "textile"],
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"branch": "st2"
+				},
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Table of comments",
 			"details": "https://github.com/kizza/Table-of-comments",
 			"labels": ["comments", "documentation", "utilities"],

--- a/repository/t.json
+++ b/repository/t.json
@@ -822,6 +822,18 @@
 			]
 		},
 		{
+			"name" : "Test Runner",
+			"author": "André Cerqueira",
+			"details" : "https://github.com/accerqueira/sublime-test-runner",
+			"labels" : ["testing"],
+			"releases" : [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Test Switcher",
 			"details": "https://github.com/davidmreed/test_switcher",
 			"labels": ["testing"],

--- a/repository/w.json
+++ b/repository/w.json
@@ -145,6 +145,21 @@
 			]
 		},
 		{
+			"name": "Web Inspector",
+			"details": "https://github.com/sokolovstas/SublimeWebInspector",
+			"labels": ["debugging", "diagnostics"],
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"tags": "st2-"
+				},
+				{
+					"sublime_text": ">=3000",
+					"tags": "st3-"
+				}
+			]
+		},
+		{
 			"name": "webAgent",
 			"previous_names": ["WebAgent"],
 			"details": "https://github.com/seanfagan/webagent_syntax",

--- a/repository/x.json
+++ b/repository/x.json
@@ -23,6 +23,18 @@
 			]
 		},
 		{
+			"name": "X3-Alpha Color Scheme",
+			"details": "https://github.com/x3ns/x3-alpha-theme",
+			"author": "x3ns <ns@nsyed.com>",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "x86 and x86_64 Assembly",
 			"previous_names": ["X86 and X86_64 assembly"],
 			"details": "https://github.com/13xforever/x86-assembly-textmate-bundle",


### PR DESCRIPTION
This PR moves package registration to internal repository and removes corresponding external repositories from channel to reduce external dependencies.

External repositories remaining are...

1. ST2-only repositories which no longer exist in `four-point-oh` branch
2. repositories pointing to explicit download assets, which can't be migrated without preventing automated package updates
3. trusted repositories with many packages (e.g.: LSP, SublimeLinter, ...)

1 covers 59 repositories

2 and 3 cover 23 repositores

_With ST2-only channels removed and this PR merged, only 23 external repositories remain._




