### PR TITLE
Add Timestamp Sort package

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2479,6 +2479,16 @@
 			]
 		},
 		{
+			"name": "Timestamp Sort",
+			"details": "https://github.com/Daij-Djan/sublime-timestamp-sort",
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},		
+		{
 			"name": "Tinacious Design colour scheme",
 			"details": "https://github.com/tinacious/sublime-tinacious-design-syntax",
 			"labels": ["color scheme"],


### PR DESCRIPTION
A Sublime Text 4 plugin to sort log messages based on their timestamps. Supports multiple timestamp formats, including Unix time.

- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] I have read the [style guide](https://github.com/wbond/package_control_channel/?tab=readme-ov-file#style-guide)
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

There are no packages like it in Package Control.
