### PR TITLE
Remove dead "iTimeTrack" package

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -1302,17 +1302,6 @@
 			]
 		},
 		{
-			"name": "iTimeTrack",
-			"details": "https://github.com/itimetrack/itimetrack-sublime",
-			"labels": ["time tracking", "coding", "utilities"],
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": "itt"
-				}
-			]
-		},
-		{
 			"name": "iTodo",
 			"details": "https://github.com/chagel/itodo",
 			"releases": [


### PR DESCRIPTION
The GitHub URL and the org has been deleted.

https://github.com/itimetrack/itimetrack-sublime
