### PR TITLE
Add ollama-sublime package

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -1056,6 +1056,17 @@
 			]
 		},
 		{
+			"name": "Ollama AI",
+			"details": "https://github.com/KalimeroMK/ollama-sublime",
+			"author": "Zoran Shefot Bogoevski",
+			"releases": [
+				{
+					"sublime_text": ">=4100",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "OrigamiEmacs",
 			"details": "https://github.com/kevincobain2000/Origami-Emacs",
 			"releases": [
@@ -1137,18 +1148,6 @@
 			"releases": [
 				{
 					"sublime_text": ">=3092",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "Ollama AI Sublime",
-			"details": "https://github.com/KalimeroMK/ollama-sublime",
-			"readme": "https://raw.githubusercontent.com/KalimeroMK/ollama-sublime/master/README.md",
-			"author": "Zoran Shefot Bogoevski",
-			"releases": [
-				{
-					"sublime_text": ">=4100",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
# Add ollama-sublime package

## Package Information
- **Package Name**: Ollama AI Sublime
- **Repository**: https://github.com/KalimeroMK/ollama-sublime
- **Author**: Zoran Shefot Bogoevski

## Description
Use local LLMs via Ollama directly in Sublime Text. Works with qwen, codellama, mistral, etc.

## Features
- Right-click to explain or optimize selected code
- Supports Laravel, PHP, JS, CSS
- Works with local Ollama API

## Checklist
- [x] Package name is unique
- [x] Package has a valid GitHub repository
- [x] Package has releases
- [x] Package works with current Sublime Text version
- [x] README exists and is informative
- [x] Package follows Package Control guidelines

## Requirements
- Sublime Text 4+
- Ollama installed and running locally