### PR TITLE
Fix editorconfig typos

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-ident_size = 4
+indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 
@@ -12,4 +12,4 @@ trim_trailing_whitespace = true
 indent_style = tab
 
 [*.py]
-ident_style = space
+indent_style = space


### PR DESCRIPTION
Fixes typos added in #3545 and never changed. I don't use editorconfig, but we should use the right key names if we're going to keep this file.