### PR TITLE
Add RevealInExplorer package

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1516,8 +1516,10 @@
 			"name": "RevealInExplorer",
 			"details": "https://github.com/JohhannasReyn/RevealInExplorer",
 			"releases": [
-				"sublime_text": "*",
-				"tags": true
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
 			]
 		},
 		{

--- a/repository/r.json
+++ b/repository/r.json
@@ -1513,6 +1513,14 @@
 			]
 		},
 		{
+			"name": "RevealInExplorer",
+			"details": "https://github.com/JohhannasReyn/RevealInExplorer",
+			"releases": [
+				"sublime_text": "*",
+				"tags": true
+			]
+		},
+		{
 			"name": "ReverseCharacters",
 			"details": "https://github.com/alfredbez/ReverseCharacters",
 			"releases": [


### PR DESCRIPTION
This PR adds the RevealInExplorer Sublime Text package, which reveals the currently open file in the OS file manager. Cross-platform support for Windows, macOS, Linux.


<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I have read the [style guide](https://github.com/wbond/package_control_channel/?tab=readme-ov-file#style-guide)
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is unique there are no packages like it in Package Control.
