### PR TITLE
Drop "muukii"

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -2876,16 +2876,6 @@
 			]
 		},
 		{
-			"name": "muukii",
-			"details": "https://github.com/muukii/muukii",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "MvtAssign It",
 			"details": "https://github.com/steveosoule/MvtAssignIt",
 			"releases": [


### PR DESCRIPTION
The repo behind just contains a README and doesn't provide any tags.

Given its nonsense content, this commit drops it.
