### PR TITLE
Drop "PHPT Snippets"

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1446,16 +1446,6 @@
 			]
 		},
 		{
-			"name": "PHPT Snippet",
-			"details": "https://github.com/danjesus/phpt-sublime-snippet",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "PhpTidy",
 			"details": "https://github.com/welovewordpress/SublimePhpTidy",
 			"releases": [


### PR DESCRIPTION
This package never surfaced on packagecontrol.io because it doesn't provide any tags. The package has been archived.

Given its age and it never being public, this commit proposes to drop it.