### PR TITLE
Drop "Linux System Administration Snippets"

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1253,16 +1253,6 @@
 			]
 		},
 		{
-			"name": "Linux System Administration Snippets",
-			"details": "https://github.com/YuniorGlez/LinuxSystemAdministration",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags" : true
-				}
-			]
-		},
-		{
 			"name": "lioshiTheme",
 			"details": "https://github.com/lioshi/lioshiScheme",
 			"labels": ["theme", "color scheme"],


### PR DESCRIPTION
This package never surfaced on packagecontrol.io because it provides a malformed tag, only.

Given its age and it never being public, this commit proposes to drop it.
