### PR TITLE
add ColorConverter

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2849,7 +2849,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=4151",
+					"sublime_text": ">=4143",
 					"tags": true
 				}
 			]

--- a/repository/c.json
+++ b/repository/c.json
@@ -2849,7 +2849,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=4189",
+					"sublime_text": ">=4151",
 					"tags": true
 				}
 			]

--- a/repository/c.json
+++ b/repository/c.json
@@ -2558,16 +2558,6 @@
 			]
 		},
 		{
-			"name": "Color Convert",
-			"details": "https://github.com/zhouyuexie/ColorConvert",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Color Highlight",
 			"labels": ["color", "highlight", "highlighter", "hex", "rgb", "hsl"],
 			"details": "https://github.com/Kronuz/ColorHighlight",
@@ -2847,6 +2837,24 @@
 			]
 		},
 		{
+			"details": "https://github.com/braver/ColorConverter",
+			"donate": "https://paypal.me/koenlageveen",
+			"labels": ["css", "colors", "utilities"],
+			"previous_names": [
+				"Color Convert",
+				"CSS Color Converter",
+				"Hex to HSL Color Converter",
+				"Hex to RGB Converter",
+				"Hex-to-RGBA"
+			],
+			"releases": [
+				{
+					"sublime_text": ">=4189",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Colored Comments",
 			"details": "https://github.com/TheSecEng/ColoredComments",
 			"author": "Terminal / TheSecEng",
@@ -2873,6 +2881,8 @@
 		},
 		{
 			"details": "https://github.com/braver/ColorHints",
+			"donate": "https://paypal.me/koenlageveen",
+			"labels": ["css", "colors", "utilities"],
 			"releases": [
 				{
 					"sublime_text": ">=3200",
@@ -4340,16 +4350,6 @@
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"branch": "master"
-				}
-			]
-		},
-		{
-			"name": "CSS Color Converter",
-			"details": "https://github.com/TheDutchCoder/ColorConvert",
-			"releases": [
-				{
-					"sublime_text": "*",
 					"branch": "master"
 				}
 			]

--- a/repository/h.json
+++ b/repository/h.json
@@ -450,16 +450,6 @@
 			]
 		},
 		{
-			"name": "Hex to HSL Color Converter",
-			"details": "https://github.com/atadams/Hex-to-HSL-Color",
-			"releases": [
-				{
-					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "Hex to Int Preview",
 			"details": "https://github.com/unknownuser88/hex2int",
 			"author": "David Bekoyan",
@@ -472,31 +462,12 @@
 			]
 		},
 		{
-			"name": "Hex to RGB Converter",
-			"details": "https://github.com/vitorleal/hex-2-rgb",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"branch": "master"
-				}
-			]
-		},
-		{
 			"name": "Hex-Bin System",
 			"details": "https://github.com/ALLZ/hex-bin_system",
 			"labels": ["text manipulation", "hexadecimal", "binary", "decimal", "base converter"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
-				}
-			]
-		},
-		{
-			"details": "https://github.com/aroscoe/Hex-to-RGBA",
-			"releases": [
-				{
-					"sublime_text": "<3000",
 					"branch": "master"
 				}
 			]


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I have read the [style guide](https://github.com/wbond/package_control_channel/?tab=readme-ov-file#style-guide)
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is [ColorConverter](https://github.com/braver/ColorConverter). It is a modern converter of (CSS) colors, supporting the most commonly used formats, including relatively new ones like `lab()` and `color()`, and uses the current recommended notation for familiar formats like `rgb()`. Under the hood it uses the [coloraide](https://facelessuser.github.io/coloraide/) library by @facelessuser.

This new package intends to consolidate several legacy packages currently available in Package Control. All of them attempt to implement similar feature sets. However, they are roughly between 7 and 12 years old and don't support modern formats. Furthermore they all lack either a feature ("convert all"), don't support a certain format, have outstanding bugs, and/or simply no longer install or work correctly in recent versions of ST4/py3.8. As it stands, there currently is no reliably working and future-proof alternative out there (excluding some larger packages like ColorHelper of course, but their scope and complexity is in many cases unnecessary), which led me to build something new to replace them all.  
This is also why the package comes with a context menu, as that's convenient and will be expected by users of the replaced packages. There is a section in the README about how to customize or completely remove the menu.  
Since upgrading to this package will break key bindings anyway, the package does not ship with any enabled. But there is an example in place that can serve as a template for users to set up their own.

~The version requirement is relatively steep because at least some API features are used that were introduced in 4181, and I don't want to go back and test against older versions. You'll need a "this year" version of ST to use this. I assume this means that users of old versions of ST, with existing versions of the replaced packages, get to keep those.~
Edit: I was able to drop the version requirement to 4143, from 3 years ago. Should be good for pretty much anyone who still actually uses ST.

Pinging authors of existing packages for approval of the replacement: @obetame, @TheDutchCoder, @vitorleal, @aroscoe, @atadams.

@FichteFoll or @kaste perhaps one of you can serve as reviewers in this instance 😄 
