### PR TITLE
Add Tmux 3 syntax hightlight

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -2655,12 +2655,12 @@
 		},
 		{
 			"name": "Tmux Syntax Highlight",
-			"details": "https://github.com/kei-q/sublime-tmux-syntax-highlight",
+			"details": "https://github.com/Edditoria/tmux-sublime",
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": "*",
-					"branch": "master"
+					"sublime_text": ">=3000",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I have read the [style guide](https://github.com/wbond/package_control_channel/?tab=readme-ov-file#style-guide)
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is Tmux 3 Syntax Highlight. It supports Tmux v3.

My package is similar to "Tmux Syntax Highlight". However I still decided to submit my own one because:

1. My package uses `.sublime-syntax` rather than `.tmLanguage` (ST3+).
2. My package follows the official Tmux man-page, and deprecates v2 syntax.
3. I will maintain my own repo anyway because I need to share it in my dotfiles using MIT license.
4. I would like to control releases (tags) myself.

I understand the instruction about package name. However I still decided to use the name "Tmux 3 Syntax Highlight" because:

- There is an existing package named "Tmux" (but not related to syntax).
- There is an existing package named "Tmux Syntax Highlight". Adding "3" behind Tmux is better than adding "ST3+" (confusing).

Thank you for your review.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
