### PR TITLE
add RAScript package

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -57,6 +57,7 @@
 		"https://raw.githubusercontent.com/jfromaniello/sublime-unity-recents/master/packages.json",
 		"https://raw.githubusercontent.com/joacodeviaje/aftersave/master/packages.json",
 		"https://raw.githubusercontent.com/joomlapro/joomla3-sublime-snippets/master/packages.json",
+		"https://raw.githubusercontent.com/joshraphael/sublime-rascript/main/packages.json",
 		"https://raw.githubusercontent.com/jrappen/sublime-packages/master/package_control_channel.json",
 		"https://raw.githubusercontent.com/kairyou/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/Kaizhi/SublimeUpdater/master/packages.json",

--- a/channel.json
+++ b/channel.json
@@ -57,7 +57,6 @@
 		"https://raw.githubusercontent.com/jfromaniello/sublime-unity-recents/master/packages.json",
 		"https://raw.githubusercontent.com/joacodeviaje/aftersave/master/packages.json",
 		"https://raw.githubusercontent.com/joomlapro/joomla3-sublime-snippets/master/packages.json",
-		"https://raw.githubusercontent.com/joshraphael/sublime-rascript/main/packages.json",
 		"https://raw.githubusercontent.com/jrappen/sublime-packages/master/package_control_channel.json",
 		"https://raw.githubusercontent.com/kairyou/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/Kaizhi/SublimeUpdater/master/packages.json",

--- a/repository/r.json
+++ b/repository/r.json
@@ -407,6 +407,17 @@
 			]
 		},
 		{
+			"name": "RAScript",
+			"details": "https://github.com/joshraphael/sublime-rascript",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/facelessuser/RawLineEdit",
 			"releases": [
 				{


### PR DESCRIPTION
<!--
The manual review may take several days or weeks,
depending on the reviewer's availability and workload.
Patience padawan!

You can request a review from @packagecontrol-bot.
Please ensure the reviews pass and follow any instructions.

Please provide some information via this checklist,
feel free to remove what't not applicable.
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I have read the [style guide](https://github.com/wbond/package_control_channel/?tab=readme-ov-file#style-guide)
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a syntax highlighter for RAScript, which is a DSL language for RetroAchievements.org to make achievement logic

There are no packages like it in Package Control.

[1]: https://packagecontrol.io/docs/submitting_a_package
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
