### PR TITLE
Add FluxUI package

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -1352,6 +1352,20 @@
 				}
 			]
 		},
+		"FluxUI": {
+		    "description": "Complete FluxUI component library for Sublime Text with intelligent autocomplete and snippets for Laravel Livewire development",
+		    "author": "Claudio Daud",
+		    "homepage": "https://github.com/claudiodaud/fluxui-sublime-package",
+		    "last_modified": "2025-01-08 12:00:00",
+		    "platforms": {
+		        "*": [
+		            {
+		                "version": "1.0.0",
+		                "url": "https://github.com/claudiodaud/fluxui-sublime-package/archive/refs/tags/v1.0.0.zip"
+		            }
+		        ]
+		    }
+		},
 		{
 			"name": "Fmt",
 			"details": "https://github.com/mitranim/sublime-fmt",


### PR DESCRIPTION
Adding FluxUI Sublime Text package for Laravel Livewire development

Adding FluxUI package for Sublime Text

Package provides:
- 94+ FluxUI components with autocomplete
- Blade template support  
- Laravel Livewire integration
- Professional snippets for rapid development

Repository: https://github.com/tu-usuario/fluxui-sublime-package
License: MIT