### PR TITLE
Index the color scheme "Hypeon"

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -1567,7 +1567,7 @@
 			]
 		},
 		{
-			"name": "Hypeon Theme",
+			"name": "Hypeon Color Scheme",
 			"details": "https://github.com/apehex/sublime-hypeon-scheme",
 			"labels": ["color scheme"],
 			"releases": [

--- a/repository/h.json
+++ b/repository/h.json
@@ -1567,6 +1567,17 @@
 			]
 		},
 		{
+			"name": "Hypeon Theme",
+			"details": "https://github.com/apehex/sublime-hypeon-scheme",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "HyperClick",
 			"details": "https://github.com/aziz/SublimeHyperClick",
 			"labels": ["file navigation", "code navigation", "file open"],


### PR DESCRIPTION
Hi! :space_invader: 

I love Sublime Text and I made a [dark synthwave color theme, Hypeon][github-hypeon].

From what I saw there are no other dark color theme to my taste, so here.

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

[github-hypeon]: https://github.com/apehex/sublime-hypeon-scheme