### PR TITLE
Add ShareToS3 package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1384,6 +1384,17 @@
 			]
 		},
 		{
+			"name": "ShareToS3",
+			"details": "https://github.com/jamesacklin/ShareToS3",
+			"labels": ["share", "snippets", "S3", "upload"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Shebang",
 			"details": "https://github.com/samizdatco/sublime-text-shebang",
 			"releases": [


### PR DESCRIPTION
Adds a Sublime Text package which allows the user to upload whatever is in their current buffer to a .txt file in an S3 bucket, then copy the resulting URL to their clipboard.

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is similar to the following packages:

- https://github.com/benanders/Rust-Share
- https://github.com/devdinu/ShareFile
- https://github.com/geekpradd/sublime-sourcesharer-plugin
- https://packagecontrol.io/packages/Cloudup
- https://packagecontrol.io/packages/Just%20Paste
- https://github.com/jonasdp/Snipplr
- https://github.com/camperdave/EC2Upload
- https://src.grytoyr.io/kim/npaste (404)

However, it should still be added because these packages all interact with proprietary or single-party file uploading/sharing services. My plugin uses any S3-compatible endpoint (MinIO, AWS S3, DigitalOcean storage, etc).
