### PR TITLE
Adopt "Color Highlight" into the SublimeText org

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2572,7 +2572,7 @@
 		{
 			"name": "Color Highlight",
 			"labels": ["color", "highlight", "highlighter", "hex", "rgb", "hsl"],
-			"details": "https://github.com/Kronuz/ColorHighlight",
+			"details": "https://github.com/SublimeText/ColorHighlight",
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
This is a takeover attempt for the Color Highlight package by @Kronuz, fixing a bug that (supposedly) prevents it from functioning on ST4.

The package has not seen any activity by the author since 2018, neither in commits not in pull requests or issues. After it was brought up in our discord server, I offerred to create a fork and submit a takeover request so that some form of basic maintenance is possible. However, I want to make it clear that no maintainer has been found for this package yet.

@Kronuz, if you are still interested in maintaining this package, you have 2 weeks of time to object to this takeover request.

cc @ykqmain