### PR TITLE
Add MikroTik RouterOS Syntax Highlighting

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1595,6 +1595,17 @@
 			]
 		},
 		{
+			"name": "MikroTik RouterOS",
+			"details": "https://github.com/ReK42/sublime-mikrotik-routeros",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MikrotikScript",
 			"details": "https://github.com/Kentzo/MikrotikScript",
 			"labels": ["language syntax"],


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package adds syntax highlighting for MikroTik RouterOS configuration files.

There is an existing package [MikrotikScript](https://github.com/Kentzo/MikrotikScript) which adds support for the MikroTik scripting language. This is a separate syntax and the two packages do not overlap.