### PR TITLE
Add XmlTransformer v1.0.0

### DIFF
--- a/repository/x.json
+++ b/repository/x.json
@@ -172,15 +172,6 @@
 			]
 		},
 		{
-			"details": "https://github.com/haloway13/XmlTransformer",
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "XmlDocs",
 			"details": "https://github.com/irrationalistic/sublime-xmldocs",
 			"labels": ["documentation", "c-sharp"],
@@ -192,13 +183,13 @@
 			]
 		},
 		{
-		    "details": "https://github.com/haloway13/XmlTransformer",
-		    "releases": [
-		        {
-		            "sublime_text": ">=3000",
-		            "tags": true
-		        }
-		    ]
+			"details": "https://github.com/haloway13/XmlTransformer",
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
 		},
 		{
 			"name": "XMPFilter",


### PR DESCRIPTION
Adds XmlTransformer v1.0.0 to the main Sublime Text package channel

- [x] I'm the package's author and maintainer (haloway13).
- [x] I have read https://docs.sublimetext.io/guide/package-control/submitting.html.
- [x] Tagged release v1.0.0 with semantic versioning (https://semver.org).
- [x] Repo (https://github.com/haloway13/XmlTransformer) has a description and README.md detailing usage, installation, and features.
- [x] No context menu entries; uses build command (Cmd+B/Ctrl+B).
- [x] No custom key bindings; relies on default build key.
- [x] Commands (XmlTransformer: Build) available via command palette.
- [x] Settings (XmlTransformer.sublime-settings) accessible via command palette/menu, opens in split view.
- [x] Not a syntax package; no color scheme included.
- [x] Added .gitattributes to exclude test_xslt/, *.sublime-project, *.sublime-workspace from ZIP.

**Uniqueness**: No existing XSLT transformation plugins with Saxon-HE integration in Package Control.

**Details**:
Tested on Windows, Linux, and macOS with Sublime Text 3/4. MIT License. No bundled dependencies (external via setup scripts).

Features:
- XSLT transformations using Saxon-HE 12.9 and xmlresolver 6.0.6.
- Quick panel for XSL and parameter file selection.
- Manual parameter entry or XML files with validation.
- Cross-platform setup scripts and error handling.

Repo: https://github.com/haloway13/XmlTransformer
Tag: v1.0.0
ZIP: https://github.com/haloway13/XmlTransformer/archive/v1.0.0.zip (verified)
