### PR TITLE
Update minimal Sublime version for Dhall

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -834,7 +834,7 @@
 			"labels": ["language syntax", "dhall"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
The Dhall package (syntax highlighting for the Dhall configuration language) does not provide a fallback `.tmLanguage` file and I'm not planning add it, at least in the nearest future.