### PR TITLE
add Auto Open Notes package

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2248,6 +2248,17 @@
 			]
 		},
 		{
+			"name": "Auto Open Notes",
+			"details": "https://github.com/noahcoad/SublimeAutoOpenNotes",
+			"labels": ["notes.txt", "readme.txt", "readme.md", "readme"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Auto Refresh",
 			"details": "https://github.com/Wouterdek/AutoRefresh",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is ...

There are no packages like it in Package Control.