### PR TITLE
add Insert Markdown Hyperlink package

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -825,6 +825,17 @@
 			]
 		},
 		{
+			"name": "Insert Markdown Hyperlink",
+			"details": "https://github.com/noahcoad/SublimeInsertMarkdownHyperlink",
+			"labels": ["markdown", "hyperlink", "url", "link"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Insert Nums",
 			"author": ["jbrooksuk", "FichteFoll"],
 			"details": "https://github.com/SublimeText/InsertNums",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is similar to ... a few other Markdown packages that also have a command to insert a hyperlink

However it should still be added because ... Those other markdown packages insert just the '[]()' base template, as they do with any other markdown shortcut, like '![]()' for images, '#' for headers etc. This package inserts hyperlinks much more intelligently by using the selected text/url placing it the right spot, or using a url in the clipboard, then grabs the title from the url if available, and sets the selected text and cursor in the spot most needed (title or url).
