### PR TITLE
Add package: Vue Tools Kit

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -851,6 +851,17 @@
 			]
 		},
 		{
+            "name": "Vue Tools Kit",
+            "details": "https://github.com/Maung90/vue-toolkit",
+            "labels": ["vue", "javascript", "theme", "snippets", "syntax"],
+            "releases": [
+                {
+                    "sublime_text": "*",
+                    "tags": true
+                }
+            ]
+        },
+		{
 			"name": "Vuln",
 			"details": "https://github.com/Shimmy/vuln",
 			"author": "Shimmy",


### PR DESCRIPTION
- [✅] I'm the package's author and/or maintainer.
- [✅] I have have read [the docs][1].
- [✅] I have tagged a release with a [semver][2] version number.
- [✅] My package repo has a description and a README describing what it's for and how to use it.
- [✅] My package doesn't add context menu entries. *
- [✅] My package doesn't add key bindings. **
- [✅] Any commands are available via the command palette.
- [✅] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [✅] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is **Vue Tools Kit**, an all-in-one toolkit for Vue 3 development in Sublime Text. It bundles a custom syntax, a vibrant neon color scheme, essential snippets, and a command to create new components, providing a complete and modern development environment.

My package is similar to other Vue syntax packages, but it should still be added because it provides an integrated "out-of-the-box" experience with a matching theme and time-saving tools specifically tailored for the Vue 3 Composition API and `<script setup>` workflow.