### PR TITLE
Add LSP-Roslyn, a language server for C# with roslyn

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1868,6 +1868,17 @@
 			]
 		},
 		{
+			"name": "LSP-Roslyn",
+			"details": "https://github.com/ownself/LSP-Roslyn",
+			"labels": ["language server"],
+			"releases": [
+				{
+					"sublime_text": ">4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Lua Dev",
 			"details": "https://github.com/rorydriscoll/LuaSublime",
 			"labels": ["language syntax", "lua"],


### PR DESCRIPTION

- [✔] I'm the package's author and/or maintainer.
- [✔] I have have read [the docs][1].
- [✔] I have tagged a release with a [semver][2] version number.
- [✔] My package repo has a description and a README describing what it's for and how to use it.
- [✔] My package doesn't add context menu entries. *
- [✔] My package doesn't add key bindings. **
- [✔] Any commands are available via the command palette.
- [✔] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [✔] If my package is a syntax it doesn't also add a color scheme. ***
- [✔] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is C# language server with roslyn as backend

My package is similar to LSP-OmniSharp However it should still be added because with official Microsoft Roslyn(Which VSCode uses it as LSP backend) as backend, it would provide better performance and functionality than old school omnisharp.
