### PR TITLE
Update Jinja2 package

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -713,11 +713,11 @@
 					"tags": "4107-"
 				},
 				{
-					"sublime_text": "4152 - 4199",
+					"sublime_text": "4152 - 4198",
 					"tags": "4152-"
 				},
 				{
-					"sublime_text": ">=4200",
+					"sublime_text": ">=4199",
 					"tags": "4200-"
 				}
 			]


### PR DESCRIPTION
This commit changes st4200 release branch to include 4199 dev build and treat it equal to 4200 stable build to fix an issue with mixed syntax versions of SQL for those who keep going with dev channel.

Jinja2 st4200 release branch expects new SQL syntax which has actually been introduced with ST4193.
