### PR TITLE
Add JenkinsDoc package

### DIFF
--- a/repository/j.json
+++ b/repository/j.json
@@ -646,6 +646,20 @@
 			]
 		},
 		{
+			"name": "JenkinsDoc",
+			"description": "Comprehensive Jenkins Pipeline documentation and autocompletion for Sublime Text",
+			"author": "Tsahi Elkayam",
+			"homepage": "https://github.com/Tsahi-Elkayam/JenkinsDoc",
+            "issues": "https://github.com/Tsahi-Elkayam/JenkinsDoc/issues",
+            "donate": "https://github.com/sponsors/Tsahi-Elkayam",
+            "labels": ["jenkins", "groovy", "pipeline", "automation", "auto-complete", "documentation"],
+			"releases": [
+				{
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Jenkinsfile",
 			"details": "https://github.com/june07/sublime-Jenkinsfile",
 			"releases": [


### PR DESCRIPTION
  Title:
  Add JenkinsDoc

  Description:
  ## Add JenkinsDoc

  Jenkins Pipeline documentation and autocompletion plugin for Sublime Text.

  ### Features
  - 🔍 Rich hover documentation for 1700+ Jenkins Pipeline steps
  - 🔤 Intelligent autocompletion with parameter support
  - 🔗 Go to definition for Groovy functions
  - 🌍 Environment variables completion
  - 📝 Smart snippets with context awareness
  - 📊 Post-condition completions
  - ✅ 100% feature parity with VS Code extension

  ### Package Details
  - **Repository:** https://github.com/Tsahi-Elkayam/JenkinsDoc
  - **Author:** Tsahi Elkayam
  - **License:** GPL-3.0
  - **First Release:** v1.0.0
  - **Sublime Text Compatibility:** 3 & 4