### PR TITLE
Add Breadcrumb Panel (ST4+, GitHub tags)

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -1456,6 +1456,17 @@
 			]
 		},
 		{
+			"name": "Breadcrumb Panel",
+			"details": "https://github.com/sarev/sublime-breadcrumb-panel",
+			"labels": ["utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "BreakLines",
 			"details": "https://github.com/Moojuiceman/BreakLines",
 			"labels": ["break", "group", "split", "separate", "lines"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read the docs.
- [x] I have tagged a release with a semver version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [n/a] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use .gitattributes to exclude files from the package: images, test files, sublime-project/workspace.

My package is similar to the Breadcrumbs package except it is a cleanroom implementation that outputs to a (semi-persistent) panel, similar to how the linters often work, meaning you can always have a view of your breadcrumb context for the active view while you're editing. I've taken steps to ensure it isn't too much of a performance drain and been very generous with the comments to hopefully help other plugin developers to understand how it works.