### PR TITLE
Add labels to PowerShell

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2155,7 +2155,7 @@
 		{
 			"name": "PowerShell",
 			"details": "https://github.com/SublimeText/PowerShell",
-			"labels": ["language syntax", "powershell"],
+			"labels": ["language syntax", "build system", "snippets", "powershell"],
 			"releases": [
 				{
 					"sublime_text": "<4000",


### PR DESCRIPTION
I missed some elements of the PowerShell package the last time I added labels.

The package also technically contains a color scheme to make ST look like the default client, but I don't think we want to advertise that on PC.
