### PR TITLE
Add Markdown Table of Contents package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1224,6 +1224,19 @@
 			]
 		},
 		{
+			"name": "Markdown Table of Contents",
+			"details": "https://github.com/codeleventh/mdtoc",
+			"readme": "https://github.com/codeleventh/mdtoc/blob/master/README.md",
+			"labels": ["markdown", "table of contents", "text navigation"],
+			"author": "codeleventh",
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MDX",
 			"details": "https://github.com/SublimeText/MDX",
 			"labels": ["jsx", "language syntax", "markdown", "mdx"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is prepending Markdown files with inline Table of Contents 

It adds own keybinding (Ctrl+Shift+M)

There are no packages like it in Package Control (that's why I did it, lol).
