### PR TITLE
Add hyprlang syntax

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -1645,6 +1645,7 @@
 		{
 			"name": "Hyprlang",
 			"details": "https://github.com/0x000C0A71/hyprlang-sublime-syntax",
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a syntax definition for the hyprlang config language.

There are no packages like it in Package Control.

