### PR TITLE
Add autoTOC entry with details and releases

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2626,6 +2626,16 @@
 			]
 		},
 		{
+		    "name": "autoTOC",
+		    "details": "https://github.com/mynl/autoTOC",
+		    "releases": [
+		        {
+		            "sublime_text": ">=4000",
+		            "tags": true
+		        }
+		    ]
+		},		
+		{
 			"name": "Autotools",
 			"details": "https://github.com/ptomato/sublime_autotools",
 			"labels": ["language syntax"],


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is autoTOC. It creates a new tab with a table of contents for the doc. Works for 
py, md, qmd, tex, css, and yaml files. 

There are no packages like it in Package Control.
<!-- OR -->
My package is similar to an old ST3 toc (that I used all the time), but that never 
got updated for ST4.  

<!-- 
*)   If you do need a context menu, make sure the menu applies to the cursor
     context, and the commands are conditional. Space in this menu is limited!
**)  There aren't enough keys for all packages, so you risk overriding those
     of other packages. You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) Syntaxes should work in any color scheme the user chooses.

For bonus points also consider how the review guidelines apply to your package:
https://docs.sublimetext.io/reference/package-control/reviewing.html
-->
