### PR TITLE
Add new plugin 'Save All New Tabs to One File'

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -298,15 +298,15 @@
 			]
 		},
 		{
-            "name": "Save All New Tabs to One File",
-            "details": "https://github.com/Thamulabs/SaveAllNewTabsInOneDocument",
-            "releases": [
-                {
-                    "sublime_text": "*",
-                    "tags": true
-                }
-            ]
-        },
+			"name": "Save All New Tabs to One File",
+			"details": "https://github.com/Thamulabs/SaveAllNewTabsInOneDocument",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
 		{
 			"name": "Save Copy As",
 			"details": "https://github.com/NickHatBoecker/SaveCopyAs",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a utility to help users clean up their workspace by saving all open, unsaved tabs (scratch buffers) into a single file and closing them automatically. It concatenates the content of all "new" tabs (those without a file path) and prompts the user to save the result.

There are no packages like it in Package Control.