### PR TITLE
Add CiscoSyntax BadWifi package (Alt to existing) 

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1205,6 +1205,16 @@
 			]
 		},
 		{
+			"name": "CiscoSyntax BadWifi",
+			"details": "https://github.com/badwifi/CiscoSyntax-Badwifi-Sublime-syntax",
+			"releases": [
+				{
+				"sublime_text": ">=3000",
+				"tags": true
+				}
+			]
+		},
+		{
 			"name": "CiteBibtex",
 			"details": "https://github.com/sjpfenninger/citebibtex",
 			"releases": [


### PR DESCRIPTION
- [YES ] I'm the package's author and/or maintainer.
- [YES ] I have have read [the docs][1].
- [ YES, though it's the first] I have tagged a release with a [semver][2] version number.
- [ YES] My package repo has a description and a README describing what it's for and how to use it.
- [ YES] My package doesn't add context menu entries. *
- [ YES] My package doesn't add key bindings. **
- [N/A] Any commands are available via the command palette.
- [N/A] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ TRUE ] If my package is a syntax it doesn't also add a color scheme. ***
- [ DONE IN PATCH 1.0.1, I didn't know this was a thing! thx.] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is an alternative to the existing "Cisco Syntax Highlighter". The existing one has not been updated in 7 years, and really doesn't do anything so I have never used it as a CCIE Cisco Engineer and over my career been frustrated by the lack of Cisco Syntax in Sublime

Mine will be active and I'll address recomendations from users. 


<!-- 
*)   If you do need a context menu, make sure the menu applies to the cursor
     context, and the commands are conditional. Space in this menu is limited!
**)  There aren't enough keys for all packages, so you risk overriding those
     of other packages. You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) Syntaxes should work in any color scheme the user chooses.

Correct, mine just uses default colors. 

For bonus points also consider how the review guidelines apply to your package:
https://docs.sublimetext.io/reference/package-control/reviewing.html
-->
