### PR TITLE
Post review report as PR comment

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,13 +5,6 @@ on:
   issue_comment:
     types: [created]  # run when comment added with "📦"
 
-env:
-  GITHUB_TOKEN: ${{ github.token }}
-
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   # run package test on pull request event (but not on drafts)
   package:
@@ -22,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@7dd94a9f77ab03d7a7a412ae88132076c66cf5ff
+        uses: kaste/st_package_reviewer/gh_action@c31b4581d84e7481c38ba0552cf9b7bfb4178b87
         with:
           pr: ${{ github.event.pull_request.html_url }}
           file: repository.json
@@ -36,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@7dd94a9f77ab03d7a7a412ae88132076c66cf5ff
+        uses: kaste/st_package_reviewer/gh_action@c31b4581d84e7481c38ba0552cf9b7bfb4178b87
         with:
           pr: ${{ github.event.issue.pull_request.html_url }}
           file: repository.json

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -1,0 +1,26 @@
+name: Post Review Comment
+on:
+  workflow_run:
+    workflows: ["Package test"] # must match the phase-1 workflow name
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+        type: string
+
+jobs:
+  post-review:
+    if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      actions: read
+      contents: read
+    steps:
+      - name: Post PR comment from artifact
+        uses: kaste/st_package_reviewer/gh_action@c31b4581d84e7481c38ba0552cf9b7bfb4178b87
+        with:
+          phase: report
+          run_id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
Using kaste/st_package_reviewer/gh_action we can now post PR comments like a pro.  We need two workflows, the first one basically does the review as before, a second workflow ("phase-2") is then used to publish the outcome of the first one.

This is done solely for security reasons.  "phase-1" runs with few privileges, and "phase-2" requests write permissions but doesn't even check out the users code.


