### PR TITLE
Update Cisco syntax highlighter details and name

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1183,13 +1183,14 @@
 			]
 		},
 		{
-			"name": "Cisco Syntax Highlighter",
-			"details": "https://github.com/tunnelsup/sublime-cisco-syntax",
+			"name": "Cisco",
+			"details": "https://github.com/mburknoe/CiscoSyntax-Badwifi-Sublime-syntax",
+			"previous_names": ["Cisco Syntax Highlighter"],
 			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
See #9264

@mburknoe let me know when you've added the message to your package and tagged the latest version. Note this also renames the package to align with our guidelines (syntax packages should simply have the name of the language). 