### PR TITLE
Add sublime-run-command package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -6175,6 +6175,17 @@
 					"tags": "st3-"
 				}
 			]
+		},
+		{
+		    "name": "sublime-run-command",
+		    "details": "https://github.com/randolph555/sublime-run-command",
+		    "labels": ["shell", "terminal", "command", "execute", "run"],
+		    "releases": [
+		        {
+		            "sublime_text": ">=4000",
+		            "platforms": ["osx", "linux"]
+		        }
+		    ]
 		}
 	]
 }


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read the docs.
- [x] I have tagged a release with a semver version number. (v1.0.0)
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use .gitattributes to exclude files from the package.

*Context menu: Only adds one "Execute Command" entry for running selected text as shell command.

**Key bindings: 
- macOS: `Cmd+Enter` (run command), `Ctrl+Tab` (history complete)
- Linux: `Ctrl+Enter` (run command), `Ctrl+Tab` (history complete)

---

My package is similar to **Terminus**, however it should still be added because:

1. **Lightweight** - No terminal panel, executes commands directly in the editor
2. **Inline output** - Command output appears right below the command line
3. **Streaming output** - Real-time output display, doesn't block the editor
4. **Pipe support** - Select text + `|command` to pipe content to shell commands
5. **History autocomplete** - Auto-complete from command history
6. **Dangerous command protection** - Confirms before running `rm -rf`, `sudo rm`, etc.

This is useful for quick command execution without leaving the editor context.
