### PR TITLE
Add Android Syntax Package (#9270)

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1013,6 +1013,17 @@
 			]
 		},
 		{
+			"name": "Android Syntax",
+			"details": "https://github.com/google/sublime-text-android-syntax",
+			"labels": ["android", "language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "AndroidImport",
 			"details": "https://github.com/ribot/SublimeAndroidImport",
 			"labels": ["auto-complete", "android", "java", "imports"],


### PR DESCRIPTION
This CL adds the Android Syntax package.

<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [X] I'm the package's author and/or maintainer.
- [X] I have have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [N/A] Any commands are available via the command palette.
- [N/A] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is [Android Syntax](https://github.com/google/sublime-text-android-syntax)

There are no packages like it in Package Control.


<!-- 
*)   If you do need a context menu, make sure the menu applies to the cursor
     context, and the commands are conditional. Space in this menu is limited!
**)  There aren't enough keys for all packages, so you risk overriding those
     of other packages. You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) Syntaxes should work in any color scheme the user chooses.

For bonus points also consider how the review guidelines apply to your package:
https://docs.sublimetext.io/reference/package-control/reviewing.html
-->
