### PR TITLE
Move Zxx packages to GitLab

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -71,8 +71,8 @@
 		},
 		{
 			"name": "ABNF-sublime-syntax",
-			"details": "https://github.com/ZxxLang/ABNF-sublime-syntax",
-			"labels": ["abnf", "language syntax"],
+			"details": "https://gitlab.com/zxxlang/ABNF-sublime-syntax",
+			"labels": ["language syntax", "abnf", "bnf"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/z.json
+++ b/repository/z.json
@@ -331,7 +331,7 @@
 		},
 		{
 			"name": "Zxx",
-			"details": "https://github.com/ZxxLang/ZxxSublime",
+			"details": "https://gitlab.com/zxxlang/ZxxSublime",
 			"labels": ["language syntax", "zxx"],
 			"releases": [
 				{


### PR DESCRIPTION
The two packages owned by ZxxLang are marked as "archived" in GitHub and have a "moved to GitLab" message in their repo descriptions. They don't appear to have any changes in the GitLab version, but it will drop the MIA tag.