### PR TITLE
Add LiveScript package

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1405,6 +1405,7 @@
 		{
 			"name": "LiveScript",
 			"details": "https://github.com/SublimeText/LiveScript",
+			"labels": ["language syntax", "build system", "snippets"],
 			"releases": [
 				{
 					"sublime_text": ">=4107",


### PR DESCRIPTION
This commit adds a rewritten LiveScript package for Sublime Text 4.

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

There are no packages like it in Package Control.
