### PR TITLE
Update package reviewer

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -11,11 +11,8 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@c31b4581d84e7481c38ba0552cf9b7bfb4178b87
+        uses: kaste/st_package_reviewer/gh_action@463ce04e289b5b4158230802c5c867d8719daefa
         with:
           pr: ${{ github.event.pull_request.html_url }}
           file: repository.json
@@ -25,11 +22,8 @@ jobs:
     if: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request != null && contains(github.event.comment.body, '📦') }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@c31b4581d84e7481c38ba0552cf9b7bfb4178b87
+        uses: kaste/st_package_reviewer/gh_action@463ce04e289b5b4158230802c5c867d8719daefa
         with:
           pr: ${{ github.event.issue.pull_request.html_url }}
           file: repository.json


### PR DESCRIPTION
The reviewer now resolves the merge base to compare the PR with.

Remove the checkout step which is not necessary.

See https://github.com/sublimehq/package_control_channel/pull/9279 which lists several packages as being removed for the bug.
