### PR TITLE
Move AsciiDoc to tagged releases and add labels

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -1902,11 +1902,15 @@
 		},
 		{
 			"details": "https://github.com/SublimeText/AsciiDoc",
-			"labels": ["language syntax"],
+			"labels": ["language syntax", "snippets", "asciidoc"],
 			"releases": [
 				{
-					"sublime_text": "*",
-					"branch": "master"
+					"sublime_text": ">=4174",
+					"tags": "version/st4174/"
+				},
+				{
+					"sublime_text": "<4174",
+					"tags": "version/st3000/"
 				}
 			]
 		},


### PR DESCRIPTION

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] **New!** I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add *any __more__* key bindings *than before*.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax, it doesn't also add a color scheme.
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is already on PCC.

There are one or two similar ones, but everybody suffers from bad syntax highlighting. I just picked the community-owned one to start a better syntax.

`.gitattributes` not uploaded yet, but will be.