### PR TITLE
Add ESPHome package

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -1350,7 +1350,7 @@
 		{
 			"name": "ESPHome",
 			"details": "https://github.com/SublimeText/ESPHome",
-			"labels":["language syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=4143",


### PR DESCRIPTION
- [ ] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package provides syntax definition for ESPHome configuration files.

There are no packages like it in Package Control.
