### PR TITLE
Restrict TOML

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -3069,7 +3069,7 @@
 			"labels": ["language syntax", "toml"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<4198",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This commit restricts external TOML package to ST builds before 4198.

Installing it on later builds overrides bundled TOML syntax and causes compatibility issues with syntaxes extending it. At least Python throws errors due to different sublime-syntax versions. Jinja2 and other packages may also be affected.
