### PR TITLE
Add InlineShell package

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -765,6 +765,18 @@
 			]
 		},
 		{
+			"name": "InlineShell",
+			"details": "https://github.com/randolph555/sublime-run-command",
+			"labels": ["shell", "terminal", "command", "execute", "run"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"platforms": ["osx", "linux"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Inno Setup",
 			"details": "https://github.com/idleberg/sublime-innosetup",
 			"labels": ["language syntax", "build system", "inno setup", "innosetup"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -6151,17 +6151,6 @@
 					"tags": "st3-"
 				}
 			]
-		},
-		{
-		    "name": "sublime-run-command",
-		    "details": "https://github.com/randolph555/sublime-run-command",
-		    "labels": ["shell", "terminal", "command", "execute", "run"],
-		    "releases": [
-		        {
-		            "sublime_text": ">=4000",
-		            "platforms": ["osx", "linux"]
-		        }
-		    ]
 		}
 	]
 }


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read the docs.
- [x] I have tagged a release with a semver version number. (v1.0.2)
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add key bindings. Any commands are available via the command palette. Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use .gitattributes to exclude files from the package.

Context menu: Adds one entry "Inline Shell: Run Command" for running selected text as a shell command.

Package name: InlineShell (renamed from sublime-run-command). Entry moved to repository/i.json.

Summary:
- Lightweight inline shell runner (no terminal panel)
- Inline/streaming output
- Pipe support (selection + |command)
- History autocomplete
- Dangerous command confirmation
- macOS/Linux only