### PR TITLE
Add BeancountAutocomplete package

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -335,16 +335,16 @@
 			]
 		},
 		{
-		    "name": "BeancountAutocomplete",
-		    "details": "https://github.com/rhydlewis/BeancountAutocomplete",
-		    "labels": ["autocomplete", "beancount", "finance"],
-		    "releases": [
+			"name": "BeancountAutocomplete",
+			"details": "https://github.com/rhydlewis/BeancountAutocomplete",
+			"labels": ["autocomplete", "beancount", "finance"],
+			"releases": [
 				{
 					"sublime_text": ">=3000",
 					"tags": true
 				}
-		    ]
-	    },
+			]
+		},
 		{
 			"name": "Beanstalk Tools",
 			"details": "https://github.com/temochka/sublime-text-2-beanstalk",


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette (plugin has no commands - it's an autocomplete listener only)
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is ...

There are no packages like it in Package Control (that I'm aware of!)

<!-- 
*)   If you do need a context menu, make sure the menu applies to the cursor
     context, and the commands are conditional. Space in this menu is limited!
**)  There aren't enough keys for all packages, so you risk overriding those
     of other packages. You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) Syntaxes should work in any color scheme the user chooses.

For bonus points also consider how the review guidelines apply to your package:
https://docs.sublimetext.io/reference/package-control/reviewing.html
-->
