### PR TITLE
Added EXIF Syntax Highlighting

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -1601,6 +1601,17 @@
 			]
 		},
 		{
+			"name": "EXIF Syntax",
+			"details": "https://github.com/alberti42/EXIF-Syntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Expand and Edit",
 			"details": "https://github.com/aafulei/sublime-expand-and-edit",
 			"author": "Aaron Fu Lei",


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read the docs.
- [x] I have tagged a release with a semver version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use .gitattributes to exclude files from the package.

My package is **EXIF Syntax**, a Sublime Text syntax definition for highlighting `exiftool` output.

It provides readable highlighting for EXIF metadata key/value output (including grouped output such as `-G`), without adding commands, key bindings, menus, or color schemes.

There are no existing packages in Package Control that provide a dedicated syntax for `exiftool` / EXIF metadata output.