### PR TITLE
added mpytool

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -2683,6 +2683,18 @@
 			]
 		},
 		{
+			"name": "MpyTool",
+			"author": "Pavel Revak",
+			"details": "https://github.com/pavelrevak/mpytool-sublime",
+			"labels": ["micropython", "mpytool", "embedded", "iot", "esp32", "esp8266", "rp2"],
+			"releases": [
+				{
+					"sublime_text": ">=4081",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Mreq Color Scheme",
 			"details": "https://github.com/mreq/mreq-theme",
 			"labels": ["color scheme"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. *** (N/A - not a syntax package)
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

**My package is** a MicroPython development tool that integrates with the [mpytool](https://github.com/pavelrevak/mpytool) CLI to upload, run, backup, and manage code on
MicroPython devices (ESP32, ESP8266, RP2, etc.) directly from Sublime Text.

**Similar packages:** "MicroPython Tools" exists in Package Control. However, mpytool should be added because:
- It uses a different backend CLI (mpytool) with different features
- Project-based workflow with `.mpyproject` configuration
- Supports multi-device setups and project switching
- Includes backup/restore functionality
- MicroPython Tools hasn't been updated in 8+ years and is not very functional

**Regarding context menu:** Adds a "MicroPython" submenu to the sidebar for project-specific actions (Copy to Device, Add to Deploy, etc.). These are contextual and only visible
when relevant.

**Regarding key bindings:** Adds 3 optional shortcuts (`Ctrl+Alt+U/M`) that don't conflict with Sublime defaults. Users can override in their keymap.