### PR TITLE
feat: add Pain package

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -200,6 +200,17 @@
 			]
 		},
 		{
+			"name": "Pain",
+			"details": "https://github.com/ilyaZar/Pain",
+			"labels": ["utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "PaletteFile",
 			"details": "https://github.com/vshotarov/PaletteFile",
 			"labels": ["file creation", "file navigation", "directory creation", "directory navigation"],


### PR DESCRIPTION
Hi all,

- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

To the core:

Pain is a minimlasit keyboard-driven pane-resizing plugin with two resize modes, I call directional and growth. 

I added my research of older/defunct packages to the README/docs at the very bottom section; Origami is full featured but sometimes overkill (and I find it cumbersome to use for just resizing; also there seems to be a note indicating that there is interal conflict with built in ST stuff regarding resizing); the older ones dont do exactly what I need, i.e. resize in more complicated multi-pane layouts precisely even for outer boundary panes; and without strange behavior when I add more and more panes ...

It took me a while to figure out what the resizing differences are at edge cases for larger multi-pane layouts, and how to express this conceptually. This lead to the modes of growth vs. directional resizing, with the corresponding examples, that I think is quite useful more generally. The package, however, is easier to use in practice, than to wrap the head around the two modes, but a nice thought experiment anyway!

Would be happy if you could add !
