### PR TITLE
Add Mercurial Color Scheme

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1735,7 +1735,9 @@
 					"sublime_text": ">=3149",
 					"tags": true
 				}
-			]
+			],
+			"homepage": "https://renzojohnson.com",
+			"donate": "https://renzojohnson.com/support"
 		},
 		{
 			"name": "Merge Variables",


### PR DESCRIPTION
Add **Mercurial Color Scheme** — a dark color scheme for Sublime Text based on Warp Terminal's default palette.

- **Repository**: https://github.com/renzojohnson/mercurial-color-scheme
- **Label**: color scheme
- **Sublime Text**: >=3149
- **Versioning**: semver tags (v1.0.0)
- **License**: MIT

52 scope rules covering standard TextMate scopes for PHP, JavaScript, CSS, HTML, JSON, YAML, Markdown, SQL, and more.