### PR TITLE
Add Mercurial Color Scheme

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1376,7 +1376,7 @@
 		},
 		{
 			"name": "Mercurial Color Scheme",
-			"homepage": "https://github.com/renzojohnson/mercurial-color-scheme",
+			"details": "https://github.com/renzojohnson/mercurial-color-scheme",
 			"donate": "https://github.com/sponsors/renzojohnson",
 			"labels": ["color scheme"],
 			"releases": [


### PR DESCRIPTION
Dark color scheme for Sublime Text inspired by Warp Terminal's default palette.

- 52 scope rules with carefully tuned colors
- Supports ST3 (build 3149+) and ST4
- Repository: https://github.com/renzojohnson/mercurial-color-scheme

Preview:
![Mercurial Color Scheme](https://raw.githubusercontent.com/renzojohnson/mercurial-color-scheme/main/preview.png)