### PR TITLE
Fix sublime_lib registration

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -1218,7 +1218,7 @@
 					"base": "https://github.com/SublimeText/sublime_lib",
 					"platforms": ["*"],
 					"sublime_text": ">=3000",
-					"tags": true
+					"tags": "st3-"
 				}
 			]
 		},


### PR DESCRIPTION
This commit fixes an issue, which caused PC3.4.1 to pull python 3.8+ specific variant of sublime_lib, which is also not of valid legacy dependency format anymore.

As a result installed library doesn't work on ST3 and cannot be migrated to library format when upgrading to PC4 afterwards.
