### PR TITLE
Fix sublime_lib registration part 2

### DIFF
--- a/repository/dependencies.json
+++ b/repository/dependencies.json
@@ -1218,7 +1218,7 @@
 					"base": "https://github.com/SublimeText/sublime_lib",
 					"platforms": ["*"],
 					"sublime_text": ">=3000",
-					"tags": "st3-"
+					"tags": "st3-v"
 				}
 			]
 		},


### PR DESCRIPTION
This followup of #9309 adds missing `v` to tag prefix.