### PR TITLE
Rename "Close All without Confirmation" to "Force Close All Files"

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1590,17 +1590,6 @@
 			]
 		},
 		{
-			"name": "Close All without Confirmation",
-			"details": "https://github.com/ddbln/CloseAllNoConfirm",
-			"labels": ["file navigation", "files", "close files", "file close", "commands", "productivity", "utilities", "refactoring"],
-			"releases": [
-				{
-					"sublime_text": ">=3092",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Close Oldest File",
 			"details": "https://github.com/jturcotte/SublimeCloseOldestFile",
 			"releases": [

--- a/repository/f.json
+++ b/repository/f.json
@@ -1584,6 +1584,19 @@
 			]
 		},
 		{
+			"name": "Force Close All Files",
+			"previous_names": ["Close All without Confirmation"],
+			"details": "https://github.com/ddbln/CloseAllNoConfirm",
+			"author": "Dirk Dassow",
+			"labels": ["force close", "close files", "close all", "discard", "commands", "productivity", "utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ForceMoveToGroup",
 			"details": "https://github.com/tkotosz/SublimeForceMoveToGroup",
 			"releases": [


### PR DESCRIPTION
Renaming my package from **Close All without Confirmation** to **Force Close All Files**.

## Changes

- Removed entry from `repository/c.json`
- Added entry in `repository/f.json` (alphabetically under "F")
- Added `previous_names` for seamless upgrade path
- Added `author` field

## Package repo

https://github.com/ddbln/CloseAllNoConfirm

The plugin code, command palette caption, menu entries, and README have already been updated in [v1.6.0](https://github.com/ddbln/CloseAllNoConfirm/releases/tag/v1.6.0).