### PR TITLE
Add RailsClassToPath

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -207,6 +207,18 @@
 			]
 		},
 		{
+			"name": "RailsClassToPath",
+			"details": "https://github.com/Zlatov/RailsClassToPath",
+			"labels": ["rails", "ruby", "navigation"],
+			"author": "Zlatov",
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "RailsGoToSass",
 			"details": "https://github.com/xijo/sublime_rails_go_to_sass",
 			"releases": [


### PR DESCRIPTION
- [+] I'm the package's author.
- [+] I have have read [the docs][1].
- [+] I have tagged a release with a [semver][2] version number.
- [+] My package repo has a description and a README describing what it's for and how to use it.
- [+] My package doesn't add context menu entries. *
- [+] My package doesn't add key bindings (I use `edit_settings` for this). **
- [+] Any commands are available via the command palette.
- [+] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [no syntax] If my package is a syntax it doesn't also add a color scheme. ***
- [+] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is similar to one of the functions in the String Utilities package. But String Utilities doesn't and shouldn't do what my highly specialized package does.

A Sublime Text plugin that converts Ruby/Rails class names to file paths and back.

Repository:
https://github.com/Zlatov/RailsClassToPath

Package Control compliance fixes: 1.0.1