### PR TITLE
Add WooCommerce package

### DIFF
--- a/repository/w.json
+++ b/repository/w.json
@@ -717,7 +717,7 @@
 		{
 			"name": "WooCommerce",
 			"details": "https://github.com/renzojohnson/woocommerce",
-			"labels": ["snippets", "completions", "woocommerce", "wordpress", "php"],
+			"labels": ["snippets", "woocommerce", "wordpress", "php"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs](https://docs.sublimetext.io/guide/package-control/submitting.html).
- [x] I have tagged a release with a [semver](https://semver.org) version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes](https://www.git-scm.com/docs/gitattributes#_export_ignore) to exclude files from the package: images, test files, sublime-project/workspace.

My package is a collection of 172 curated WooCommerce code snippets for Sublime Text, covering hooks, CRUD, REST API, HPOS, Block Checkout, Store API, Action Scheduler, shipping, emails, and more.

There are no packages like it in Package Control.