### PR TITLE
Rename Django package

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -1144,6 +1144,20 @@
 			]
 		},
 		{
+			"name": "Django Snippets",
+			"details": "https://github.com/mattseymour/sublime-django",
+			"labels": ["snippets", "django"],
+			"previous_names": [
+				"Django"
+			],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Django Starter",
 			"details": "https://github.com/geekpradd/Sublime-Django-Starter",
 			"releases": [
@@ -1203,20 +1217,6 @@
 				{
 					"sublime_text": "*",
 					"platforms": "*",
-					"tags": true
-				}
-			]
-		},
-		{
-			"name": "Django Snippets",
-			"details": "https://github.com/mattseymour/sublime-django",
-			"labels": ["snippets", "django"],
-			"previous_names": [
-				"Django"
-			],
-			"releases": [
-				{
-					"sublime_text": "*",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This commit renames "Django" package to "Django Snippets" and fixes labels to reflect its purpose more accurately. It actually just provides snippets.

The package doesn't include package name related resources such as settings or commands. Hence renaming is transparent for end users.