### PR TITLE
Add HostSettings package

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -858,17 +858,6 @@
 			]
 		},
 		{
-			"name": "HostSettings",
-			"details": "https://github.com/Taffer/HostSettings",
-			"labels": ["utilities"],
-			"releases": [
-				{
-					"sublime_text": ">=4050",
-					"tags": true
-				}
-			]
-		},
-		{
 			"details": "https://github.com/samueljohn/Homebrew-formula-syntax",
 			"labels": ["language syntax"],
 			"releases": [
@@ -985,6 +974,17 @@
 			"releases": [
 				{
 					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "HostSettings",
+			"details": "https://github.com/Taffer/HostSettings",
+			"labels": ["utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=4050",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] **N/A** My package doesn't add context menu entries. *
- [x] **N/A** My package doesn't add key bindings. **
- [x] **N/A** Any commands are available via the command palette.
- [x] **N/A** Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] **N/A** If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is for adding specific settings overrides based on the computer it's running on, keyed by the computer's host name. This is useful if you have system-specific settings that can't be controlled by platform (for example, I'm running on multiple Linux platforms, and need to tweak `font_size` different on my laptop than on the system with a 4k monitor).

My package is similar to various other Settings control packages. However it should still be added because none of them allow per-system settings changes, and they generally don't let you change settings without changing the on-disk `.sublime-settings` file(s), which will cause unnecessary churn for people keeping their Sublime setup in version control.

**Note:** I wasn't able to test this change; I couldn't get ChannelRepositoryTools to stop telling me to open the `package_control_channel` folder, even when it was open as the only folder. :shrug: It's valid JSON at least:

```py
>>> with open("repository/h.json") as fp:
...     j = json.load(fp)
...
>>> j
{'schema_version': '3.0.0', 'packages': [{'name': 'Hacker News Reader', 'details': 'https://github.com/Dimillian/Sublime-Hacker-News-Reader',
```
