### PR TITLE
Pin package review CI to latest st_package_reviewer action

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@44d95b6af4fa16bd17dddfeba809ca166c73895f
+        uses: kaste/st_package_reviewer/gh_action@418eee2d016d896a9302fd514232b8672615e7d2
         with:
           pr: ${{ github.event.pull_request.html_url }}
           file: repository.json
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@44d95b6af4fa16bd17dddfeba809ca166c73895f
+        uses: kaste/st_package_reviewer/gh_action@418eee2d016d896a9302fd514232b8672615e7d2
         with:
           pr: ${{ github.event.issue.pull_request.html_url }}
           file: repository.json

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -15,6 +15,6 @@ jobs:
       contents: read
     steps:
       - name: Post PR comment from artifact
-        uses: kaste/st_package_reviewer/gh_action@44d95b6af4fa16bd17dddfeba809ca166c73895f
+        uses: kaste/st_package_reviewer/gh_action@418eee2d016d896a9302fd514232b8672615e7d2
         with:
           phase: report


### PR DESCRIPTION
Update the Package test workflow to use
kaste/st_package_reviewer/gh_action@9e6455798b06b34ab846c5b1d2e3d4468814d57c.

This picks up the change to review only the newest crawled release from workspace data instead of iterating over all recent tags.


