### PR TITLE
Add Spartan Color Scheme package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3245,7 +3245,7 @@
 		{
 			"name": "Spartan Color Scheme",
 			"details": "https://github.com/renzojohnson/spartan-color-scheme",
-			"labels": ["color scheme", "theme", "dark"],
+			"labels": ["color scheme", "dark"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs](https://docs.sublimetext.io/guide/package-control/submitting.html).
- [x] I have tagged a release with a [semver](https://semver.org) version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes](https://www.git-scm.com/docs/gitattributes#_export_ignore) to exclude files from the package: images, test files, sublime-project/workspace.

My package is a dark color scheme for Sublime Text featuring a deep purple-black background with vivid syntax highlighting, designed for extended coding sessions.

There are no packages like it in Package Control.