### PR TITLE
Update Zig Language to Codeberg

### DIFF
--- a/repository/z.json
+++ b/repository/z.json
@@ -149,7 +149,7 @@
 		},
 		{
 			"name": "Zig Language",
-			"details": "https://github.com/ziglang/sublime-zig-language",
+			"details": "https://codeberg.org/ziglang/sublime-zig-language",
 			"labels": ["language syntax", "zig"],
 			"releases": [
 				{


### PR DESCRIPTION
Everything Zig was migrated to codeberg
https://ziglang.org/news/migrating-from-github-to-codeberg/
