### PR TITLE
Resurrect Modelines package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -2090,6 +2090,10 @@
 				{
 					"sublime_text": "<3000",
 					"tags": "st2/"
+				},
+				{
+					"sublime_text": ">=4135",
+					"tags": "st4135/"
 				}
 			]
 		},


### PR DESCRIPTION
- [x] I ~~am~~ _[represent]_ the package's author and/or maintainer. cc @Frizlab
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

This package is back from the dead! Credit to Frizlab.

I can't merge https://github.com/SublimeText/Modelines/pull/9 to master without this change.[^1] Some of the checkmarks above are dependent on that merge. I'll tag an ST4 release when things are settled.[^2]

[^1]: That's based on the very unlikely assumption that someone is using ST2, has this package installed, and has automatic updates from Package Control. :laughing: But we'll pretend.
[^2]: **Edit:** I've tagged a prerelease for ST4. I'd *like* to save the big 2.0.0 tag for the merge commit or a `messages.json` update, but I can tag it now if it's necessary for the automated tests.