### PR TITLE
Add MCPServer package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -580,7 +580,7 @@
 			"labels": ["markdown", "table of contents", "text navigation"],
 			"releases": [
 				{
-					"sublime_text": ">=4171",
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]
@@ -1222,7 +1222,7 @@
 			"labels": ["mcp", "ai", "productivity"],
 			"releases": [
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=4171",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have have read the docs.
- [x] I have tagged a release with a semver version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use .gitattributes to exclude files from the package: images, test files, sublime-project/workspace.

My package is a Sublime Text package that runs a local MCP server for open unsaved buffers, so AI tools can read scratch tabs and close them after they are consumed.

There are no packages like it in Package Control.

My package is similar to MCPHelper. However it should still be added because MCPHelper is an MCP client for connecting Sublime to external LLM backends, while MCPServer turns Sublime itself into an MCP server that exposes unsaved editor buffers to other AI tools.

## Package
- Name: MCPServer
- Details: https://github.com/benyue1978/sublime-mcp
- Latest tag: 0.2.7
- Release: https://github.com/benyue1978/sublime-mcp/releases/tag/0.2.7