### PR TITLE
Add MarkdownJiraConverter package

### DIFF
--- a/repository/markdownjiraconverter.json
+++ b/repository/markdownjiraconverter.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "4.0.0",
+  "packages": [
+    {
+      "name": "MarkdownJiraConverter",
+      "details": "https://github.com/crqcastro/markdown_to_jira",
+      "description": "Convert Markdown to Jira format and Jira format back to Markdown directly in Sublime Text.",
+      "author": "crqcastro",
+      "labels": ["markdown", "jira", "converter", "formatting", "productivity"],
+      "releases": [
+        {
+          "sublime_text": ">=4000",
+          "tags": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a Markdown ↔ Jira converter for Sublime Text.

It allows developers to quickly convert between Markdown and Jira text formatting, supporting common elements such as headings, lists (including nested), code blocks, inline code, tables, links, images and blockquotes.

There are similar tools available outside Sublime Text or limited to one-way conversion. However, this package provides:

- bidirectional conversion (Markdown → Jira and Jira → Markdown)
- support for selection or entire file
- clipboard-only conversion commands
- configurable behavior via settings
- integration with the command palette and Tools menu

This makes it particularly useful for developers who frequently work between documentation (Markdown) and issue tracking (Jira), improving productivity and reducing manual formatting work.