### PR TITLE
Change Modelines packages to tagged releases

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -2085,10 +2085,11 @@
 		},
 		{
 			"details": "https://github.com/SublimeText/Modelines",
+			"labels": ["formatting", "syntax", "indention", "modeline"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
-					"branch": "master"
+					"tags": "st2/"
 				}
 			]
 		},


### PR DESCRIPTION
This is an administrative change to move Modelines from branch-based releases to tags.

It prepares for #9333 and an ST4 version.