### PR TITLE
bump schema test

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: packagecontrol/st-schema-reviewer-action@f0ed8819bd9058dfa9921e4a061a6a1b643339a2
+      - uses: packagecontrol/st-schema-reviewer-action@a1bdfafb7e7b834226052dac79f23730ba09ef26
         with:
           test_repositories: true

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: packagecontrol/st-schema-reviewer-action@a1bdfafb7e7b834226052dac79f23730ba09ef26
+      - uses: packagecontrol/st-schema-reviewer-action@b0634964a486096628fbe9da5cbc0f6f91773c6a
         with:
-          test_repositories: false
+          test_repositories: true

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v5
       - uses: packagecontrol/st-schema-reviewer-action@a1bdfafb7e7b834226052dac79f23730ba09ef26
         with:
-          test_repositories: true
+          test_repositories: false


### PR DESCRIPTION
to skip codexns repo from the tests, since it's certificate expired