### PR TITLE
Update Spartan Color Scheme metadata

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1377,8 +1377,10 @@
 		{
 			"name": "Mercurial Color Scheme",
 			"details": "https://github.com/renzojohnson/mercurial-color-scheme",
-			"donate": "https://github.com/sponsors/renzojohnson",
-			"labels": ["color scheme"],
+			"homepage": "https://renzojohnson.com",
+			"issues": "https://renzojohnson.com/contact",
+			"donate": "https://www.paypal.com/paypalme/renzojohnson",
+			"labels": ["color scheme", "theme", "dark", "light"],
 			"releases": [
 				{
 					"sublime_text": ">=3149",

--- a/repository/m.json
+++ b/repository/m.json
@@ -1377,10 +1377,8 @@
 		{
 			"name": "Mercurial Color Scheme",
 			"details": "https://github.com/renzojohnson/mercurial-color-scheme",
-			"homepage": "https://renzojohnson.com",
-			"issues": "https://renzojohnson.com/contact",
-			"donate": "https://www.paypal.com/paypalme/renzojohnson",
-			"labels": ["color scheme", "theme", "dark", "light"],
+			"donate": "https://github.com/sponsors/renzojohnson",
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": ">=3149",

--- a/repository/s.json
+++ b/repository/s.json
@@ -3245,7 +3245,10 @@
 		{
 			"name": "Spartan Color Scheme",
 			"details": "https://github.com/renzojohnson/spartan-color-scheme",
-			"labels": ["color scheme", "dark"],
+			"homepage": "https://renzojohnson.com",
+			"issues": "https://renzojohnson.com/contact",
+			"donate": "https://www.paypal.com/paypalme/renzojohnson",
+			"labels": ["color scheme", "theme", "dark", "light"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
Add homepage, issues, and donate links for Spartan Color Scheme.
Update labels to include `theme` and `light` for the new light variant in v1.1.0.

**Changes:**
- `homepage`: https://renzojohnson.com
- `issues`: https://renzojohnson.com/contact
- `donate`: https://www.paypal.com/paypalme/renzojohnson
- `labels`: added `theme`, `light`