### PR TITLE
Add Godot Dialogue Manager Syntax

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1302,6 +1302,21 @@
 			]
 		},
 		{
+      		"name": "Godot Dialogue Manager",
+      		"details": "https://github.com/hobbesjaap/sublime-dialogue-manager",
+      		"labels": [
+        		"godot",
+        		"dialogue",
+        		"syntax highlighting"
+      			],
+      		"releases": [
+        		{
+          			"sublime_text": "*",
+          			"tags": true
+        		}
+      		]
+    	},
+		{
 			"name": "GoEscape",
 			"details": "https://bitbucket.org/shellzen/goescape",
 			"labels": ["go"],

--- a/repository/g.json
+++ b/repository/g.json
@@ -1302,20 +1302,16 @@
 			]
 		},
 		{
-      		"name": "Godot Dialogue Manager",
-      		"details": "https://github.com/hobbesjaap/sublime-dialogue-manager",
-      		"labels": [
-        		"godot",
-        		"dialogue",
-        		"syntax highlighting"
-      			],
-      		"releases": [
-        		{
-          			"sublime_text": "*",
-          			"tags": true
-        		}
-      		]
-    	},
+			"name": "Godot Dialogue Manager",
+			"details": "https://github.com/hobbesjaap/sublime-dialogue-manager",
+			"labels": ["godot", "dialogue", "syntax highlighting"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
 		{
 			"name": "GoEscape",
 			"details": "https://bitbucket.org/shellzen/goescape",


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is "Godot Dialogue Manager Syntax"

There are no packages like it in Package Control. It is a syntax highlighting package only.