### PR TITLE
Add MarkdownImagePaste

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -520,6 +520,17 @@
 			]
 		},
 		{
+			"name": "MarkdownImagePaste",
+			"details": "https://github.com/ricetim/MarkdownImagePaste",
+			"labels": ["markdown", "image", "clipboard", "paste"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Markdown Numbered Headers",
 			"details": "https://github.com/weituotian/md_numbered_headers",
 			"labels": ["markdown", "headers", "numbered headers"],


### PR DESCRIPTION
## Package Information

- **Package name:** MarkdownImagePaste
- **Repository:** https://github.com/ricetim/MarkdownImagePaste
- **Latest release:** v1.0.0

## Description

Sublime Text 4 plugin (Windows only) that intercepts `Ctrl+V` in Markdown files. When the clipboard contains an image, it saves the image to a `.images/` subdirectory next to the open file and inserts `![](.images/image_<timestamp>.png)` at the cursor. Falls through to normal text paste when no image is present.

- No external dependencies — pure Python stdlib + ctypes
- No subprocess spawning
- Configurable `image_dir` and `prompt_alt_text` settings
- Multi-cursor support

## Checklist

- [x] Package name is spelled correctly and follows naming conventions
- [x] Repository is public
- [x] `v1.0.0` semver tag exists on the repository
- [x] Plugin loads under ST4 Python 3.8 runtime (`.python-version` present)
- [x] Entry is in alphabetical order in `repository/m.json`