### PR TITLE
Debian Syntax: add ST4 release channel with unprefixed tags

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -417,7 +417,7 @@
 				},
 				{
 					"sublime_text": ">=4000",
-					"tags": "st4-"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

Adds a separate release entry for Sublime Text 4+ using unprefixed tags, while preserving the existing ST3 release channel with `st3-` prefixed tags.

This allows [Debian Syntax](https://github.com/barnumbirr/sublime-debian) v2.0.0+ (which uses ST4-only features like `set:`) to be served to ST4+ users, while ST3 users continue to receive v1.4.2.

There are no packages like it in Package Control.