### PR TITLE
Add MLIR TOC

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1998,6 +1998,17 @@
 			]
 		},
 		{
+			"name": "MLIR TOC",
+			"details": "https://github.com/hockyy/mlir-toc",
+			"labels": ["mlir", "navigation", "text manipulation"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Moai Debugger",
 			"details": "https://github.com/DJHoltkamp/Sublime-Moai-Debugger",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

**My package is** [MLIR TOC](https://github.com/hockyy/mlir-toc): a Sublime Text 4 plugin for [MLIR](https://mlir.llvm.org/) sources. It parses section banners of the form `// ----- // Title // ----- //`, opens a three-pane layout (source, TOC list, focused section), jumps the cursor when you move in the TOC, refreshes on save, and assigns MLIR syntax in the section pane when a syntax named `MLIR` is installed.

**There are no packages like it in Package Control.** Existing MLIR-related entries are syntax (or unrelated tooling); none provide this TOC + section workspace.

**Release:** `v1.0.0` (semver tag).

**Note:** N/A items — the package has no settings file, preferences menu, or default key bindings (users can bind `mlir_toc_section_workspace` / `mlir_toc_section_refresh` themselves; README documents Command Palette use only). Not a syntax package.
