### PR TITLE
Add ATASCII and PETSCII packages

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2119,6 +2119,17 @@
 			]
 		},
 		{
+			"name": "ATASCII",
+			"details": "https://github.com/thinkyhead/ATASCII",
+			"labels": ["text manipulation", "unicode", "atari", "basic"],
+			"releases": [
+				{
+					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ATG(CocoR C#) Syntax",
 			"details": "https://github.com/nolanar/ATG-Syntax-Sublime",
 			"labels": ["language syntax"],

--- a/repository/p.json
+++ b/repository/p.json
@@ -979,6 +979,17 @@
 			]
 		},
 		{
+			"name": "PETSCII",
+			"details": "https://github.com/thinkyhead/PETSCII",
+			"labels": ["text manipulation", "unicode", "commodore 64", "c64"],
+			"releases": [
+				{
+					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "PgcliSublime",
 			"details": "https://github.com/darikg/PgcliSublime",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My packages are ATASCII and PETSCII, adding support for "Atari Classic" and "Pet Me 64" Unicode fonts. Providing commands to open popup palettes to insert Unicode characters, and a command to invert ATASCII / PETSCII text. These packages may be used on their own with the appropriate fonts in any text file, but are best used with "Atari 800" and "Commodore 64" themes, and with "Atari BASIC" and "Commodore BASIC" syntaxes (also pending).

There are no packages like these in Package Control.
