### PR TITLE
Add Atari800 and Commodore64 color schemes

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2119,6 +2119,17 @@
 			]
 		},
 		{
+			"name": "Atari800 Color Scheme",
+			"details": "https://github.com/thinkyhead/Atari800",
+			"labels": ["color scheme", "atari", "basic"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ATG(CocoR C#) Syntax",
 			"details": "https://github.com/nolanar/ATG-Syntax-Sublime",
 			"labels": ["language syntax"],

--- a/repository/c.json
+++ b/repository/c.json
@@ -3255,6 +3255,17 @@
 			]
 		},
 		{
+			"name": "Commodore64 Color Scheme",
+			"details": "https://github.com/thinkyhead/Commodore64",
+			"labels": ["color scheme", "commodore 64", "c64", "basic"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/TooBug/CompactExpandCss",
 			"releases": [
 				{


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

There are no packages like it in Package Control.

These eyedropper-accurate color schemes are great for editing AtariBASIC or Commodore BASIC, especially with the appropriate Unicode fonts, "Atari Classic" and "Pet Me 64," and syntax/build capabilities of AtariTools and C64Tools (also pending).