### PR TITLE
Add Search All Windows

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -813,6 +813,17 @@
 			]
 		},
 		{
+			"name": "Search All Windows",
+			"details": "https://github.com/nathanshipley/SublimeSearchAllWindows",
+			"labels": ["search"],
+			"releases": [
+				{
+					"sublime_text": ">=4050",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Search Anywhere",
 			"details": "https://github.com/ericmartel/Sublime-Text-2-Search-Anywhere-Plugin",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. *(N/A — not a syntax package)*
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a Sublime Text plugin that searches the live buffer contents of every open tab across every open window, including unsaved documents. Sublime Text's built-in Find only searches the current file, and Find in Files only searches files on disk — this fills the gap.

There are no packages like it in Package Control.