### PR TITLE
Add RPG syntax highlighter package

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1968,6 +1968,16 @@
 			]
 		},
 		{
+			"name": "RPG Syntax Highlighting",
+			"details": "https://github.com/tegansnyder/Sublime-Text-3-RPG-Syntax-Highlighting",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "RPGMaker MV Add-On Snippets",
 			"details": "https://github.com/jomarcenter-mjm/RMMVSublimeSnippet",
 			"labels": ["snippets", "rpgmaker mv", "javascript", "rpg maker", "rpgmaker", "rpg"],


### PR DESCRIPTION
  - [x] I'm the package's author and/or maintainer.
  - [x] I have read [the docs][1].
  - [x] I have tagged a release with a [semver][2] version number.
  - [x] My package repo has a description and a README describing what it's for and how to use it.
  - [x] My package doesn't add context menu entries. *
  - [x] My package doesn't add key bindings. **
  - [x] Any commands are available via the command palette.
  - [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
  - [x] If my package is a syntax it doesn't also add a color scheme. ***
  - [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is an RPG/ILE RPG syntax highlighting package for Sublime Text 3, covering both free-format and fixed-format RPG, plus embedded SQL highlighting and RPG-specific completions/snippets.

My package is similar to the original RPG package by Niels Liisberg. However it should still be added because this package is updated for Sublime Text 3 with a native `.sublime-syntax` grammar, improved RPG token coverage, fixed-format and free-format support refinements, embedded SQL handling, and active maintenance.