### PR TITLE
Add Bulk Renamer package

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -1085,7 +1085,7 @@
 					"tags": true
 				}
 			]
-		},		
+		},
 		{
 			"name": "Block Cursor Everywhere",
 			"details": "https://github.com/karlhorky/BlockCursorEverywhere",
@@ -1753,6 +1753,19 @@
 			"releases": [
 				{
 					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "Bulk Renamer",
+			"details": "https://github.com/guille/sublime-bulk-renamer",
+			"labels": [
+				"utilities"
+			],
+			"releases": [
+				{
+					"sublime_text": "*",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package **does** add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

Repo link: https://github.com/guille/sublime-bulk-renamer

I do add one context menu entry but it is scoped to directories only and I think it is justified given the package's aim.

My package is a bulk renamer of files using Sublime Text itself. If you're familiar with oil.nvim, it's similar to that. Otherwise, there's a video in the README that probably explains it better than I can.

There are no packages like it in Package Control as far as I can see.
