### PR TITLE
Adjust RSpec package branch for ST3

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -2046,7 +2046,11 @@
 					"branch": "st2"
 				},
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": "3000 - 3999",
+					"branch": "st3"
+				},
+				{
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have read [the docs][1].
- [ ] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

I'm updating the definition of the RSpec package. I've been added as maintainer, so I've frozen the last state in `st3` and will only target ST4 from now on.