### PR TITLE
Add Base64AutoCharset package

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -230,6 +230,17 @@
 			]
 		},
 		{
+			"name": "Base64AutoCharset",
+			"details": "https://github.com/emotion/base64-decode-autocharset",
+			"labels": ["base64", "encoding", "charset", "gb18030", "decode", "cjk"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"branch": "main"
+				}
+			]
+		},
+		{
 			"name": "Bash Build System",
 			"details": "https://github.com/macite/sublimebashbuildsystem",
 			"labels": ["build system"],

--- a/repository/b.json
+++ b/repository/b.json
@@ -232,7 +232,7 @@
 		{
 			"name": "Base64AutoCharset",
 			"details": "https://github.com/emotion/base64-decode-autocharset",
-			"labels": ["base64", "encoding", "charset", "gb18030", "decode", "cjk"],
+			"labels": ["utilities", "base64", "encoding", "charset", "gb18030", "decode", "cjk"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/b.json
+++ b/repository/b.json
@@ -236,7 +236,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"branch": "main"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. *** (N/A - not a syntax)
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a Base64 encode/decode tool with automatic charset detection. It supports decoding Base64 with automatic detection of the original charset (UTF-8, GB18030/GBK/GB2312, Big5, EUC-JP, Shift_JIS, EUC-KR, etc.), and encoding text to Base64 with either GB18030 or UTF-8. This is particularly useful for debugging CJK email content (MIME headers often use Base64 with non-UTF-8 encodings) and API data inspection.

There are no packages like it in Package Control. Existing Base64 packages (e.g. `Base64 Fold`) only handle raw byte encode/decode and do not perform charset detection, which makes them unusable for GB18030/GBK encoded content common in Chinese enterprise email systems.

**Repository**: https://github.com/emotion/base64-decode-autocharset
**Latest release**: [1.0.2](https://github.com/emotion/base64-decode-autocharset/releases/tag/1.0.2) (uses `"tags": true` so Package Control tracks all semver tags automatically)

Verified with `st_package_reviewer`: 0 failures, 0 warnings across all 19 checkers.
