### PR TITLE
Add AL language syntax package

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -583,6 +583,17 @@
 			]
 		},
 		{
+			"name": "AL",
+			"details": "https://github.com/SShadowS/sublime-al",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Alabaster Color Scheme",
 			"details": "https://github.com/tonsky/sublime-scheme-alabaster",
 			"donate": "https://www.patreon.com/tonsky",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a syntax definition for AL (Application Language) used in Microsoft Dynamics 365 Business Central. It provides syntax highlighting, completions (228 keywords/types), comment toggling, and symbol indexing.

There are no packages like it in Package Control.