### PR TITLE
fix(MarkerStack):  fix required sublime version

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -759,7 +759,7 @@
 			"donate": "https://buymeacoffee.com/vwheeler63",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"sublime_text": ">=4050",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
This PR fixes an erroneous ST version requirement in my previous `MarkerStack` Package submission.

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
