### PR TITLE
Add Viv (DSL for games and simulations)

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -88,6 +88,7 @@
 		"https://raw.githubusercontent.com/seanliang/ConvertToUTF8/master/packages.json",
 		"https://raw.githubusercontent.com/sentience/DokuWiki/master/packages.json",
 		"https://raw.githubusercontent.com/sentience/HyperlinkHelper/master/packages.json",
+		"https://raw.githubusercontent.com/siftystudio/viv/main/plugins/sublime/repository.json",
 		"https://raw.githubusercontent.com/sokolovstas/SublimeWebInspector/master/packages.json",
 		"https://raw.githubusercontent.com/soncy/AutoComments-for-Sublime-Text-2/master/packages.json",
 		"https://raw.githubusercontent.com/spectacles/CodeComplice/master/packages.json",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read the docs.
- [x] I have tagged a release with a semver version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme.
- [ ] I use .gitattributes to exclude files from the package: images, test files, sublime-project/workspace.

My package is a syntax definition and compiler integration for [Viv](https://viv.sifty.studio), a domain-specific language (DSL) for emergent narrative in games and simulations. It provides syntax highlighting, six optional color themes, autocompletion, and integration with the Viv DSL compiler via the Sublime build system.

There are no packages for Viv in Package Control.

Notes on unchecked items:
- **Preferences/split view:** The package has no user-facing preferences or keybindings.
- **Color schemes:** The six bundled Viv themes are optional, and the syntax works with any color scheme. The themes provide finer-grained semantic distinctions specific to the Viv language.
- **gitattributes:** The package is self-hosted. The CD workflow builds the `.sublime-package` zip with an explicit file list, so `.gitattributes` export–ignore is not applicable.

Notes with regard to the reviewer guidelines:

* **`.no-sublime-package`:** Present in the zip. The package's build system invokes a Python bridge script (`bridge/compiler_bridge.py`) via the host system's Python, which requires the file to be on disk. This falls under "running scripts."
* **`repository.json` includes a custom `compilerVersion` field:** This is read by the bridge script at runtime to check compiler compatibility. Package Control ignores it.
* **No online services or data transmission.** The Viv compiler runs locally.
* **Tests:** `ChannelRepositoryTools` would not recognize the cloned repo (`"Please open the package_control_channel folder"`), so I couldn't run the tests. But I have confirmed that the package installs and functions correctly via the self-hosted `repository.json`.