### PR TITLE
Add LSP-Path-Scoping package

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1856,6 +1856,17 @@
 			]
 		},
 		{
+			"name": "LSP-Path-Scoping",
+			"details": "https://github.com/skovsboll/Sublime-LSP-Path-Scoping",
+			"labels": ["lsp"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Lua Dev",
 			"details": "https://github.com/rorydriscoll/LuaSublime",
 			"labels": ["language syntax", "lua"],


### PR DESCRIPTION
Adds [LSP-Path-Scoping](https://github.com/skovsboll/Sublime-LSP-Path-Scoping), a Sublime Text 4 package that enables directory-based LSP server scoping.

This allows routing different LSP servers to different project directories — for example, directing LSP-Deno to `backend/` and LSP-typescript to `frontend/` in a mixed Deno/Node monorepo.

- **Repository:** https://github.com/skovsboll/Sublime-LSP-Path-Scoping
- **Tag:** 1.0.0
- **License:** MIT
- **Requires:** Sublime Text >= 4000, LSP package