### PR TITLE
Add ISF

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -1305,6 +1305,17 @@
 			]
 		},
 		{
+			"name": "ISF",
+			"details": "https://github.com/newrosesystems/isf-syntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4075",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ISML",
 			"details": "https://github.com/aearly/isml-tmlanguage",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package adds syntax highlighting for [Interactive Shader Format (ISF)](https://isf.video) files. ISF is a GLSL-based format for describing GPU shaders, widely used in VJ tools, creative-coding environments, and video-effects hosts such as VDMX, ISF editors on the web, and similar applications. Fragment shaders are typically saved as `.fs`, vertex shaders as `.vs`, and combined documents as `.isf`; all three extensions are registered.

The package is a pure syntax contribution — no commands, menus, key bindings, color schemes, or settings UI. It extends standard GLSL highlighting with ISF-specific awareness: the JSON metadata block in the leading `/* { ... } */` header, ISF uniforms (`PASSINDEX`, `RENDERSIZE`, `isf_FragNormCoord`, `TIME`, `TIMEDELTA`, `DATE`, `FRAMEINDEX`), ISF image-sampling macros (`IMG_PIXEL`, `IMG_NORM_PIXEL`, `IMG_SIZE`, `IMG_THIS_PIXEL`, `IMG_THIS_NORM_PIXEL`, `isf_vertShaderInit`), and ISF input types (`event`, `bool`, `long`, `float`, `point2D`, `color`, `image`, `audio`, `audioFFT`).

It is forked from [euler0/sublime-glsl](https://github.com/euler0/sublime-glsl), which provides only plain GLSL highlighting and has no ISF awareness. There are no packages like it in Package Control.