### PR TITLE
Add VS Code 2026 Color Scheme

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -742,6 +742,17 @@
 				}
 			]
 		},
+ 		{
+			"name": "VS Code 2026 Dark",
+			"details": "https://github.com/vector-foundry-dev/sublime-vscode-2026-dark",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+ 		},
 		{
 			"name": "VSCMT",
 			"details": "https://github.com/drew-wallace/VSCMT",

--- a/repository/v.json
+++ b/repository/v.json
@@ -742,17 +742,17 @@
 				}
 			]
 		},
- 		{
-			"name": "VS Code 2026",
+		{
+			"name": "VS Code 2026 Color Scheme",
 			"details": "https://github.com/vector-foundry-dev/sublime-vscode-2026-color-scheme",
 			"labels": ["color scheme"],
 			"releases": [
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=4171",
 					"tags": true
 				}
 			]
- 		},
+		},
 		{
 			"name": "VSCMT",
 			"details": "https://github.com/drew-wallace/VSCMT",

--- a/repository/v.json
+++ b/repository/v.json
@@ -744,7 +744,7 @@
 		},
  		{
 			"name": "VS Code 2026 Dark",
-			"details": "https://github.com/vector-foundry-dev/sublime-vscode-2026-dark",
+			"details": "https://github.com/vector-foundry-dev/sublime-vscode-2026-dark-color-scheme",
 			"labels": ["color scheme"],
 			"releases": [
 				{

--- a/repository/v.json
+++ b/repository/v.json
@@ -743,8 +743,8 @@
 			]
 		},
  		{
-			"name": "VS Code 2026 Dark",
-			"details": "https://github.com/vector-foundry-dev/sublime-vscode-2026-dark-color-scheme",
+			"name": "VS Code 2026",
+			"details": "https://github.com/vector-foundry-dev/sublime-vscode-2026-color-scheme",
 			"labels": ["color scheme"],
 			"releases": [
 				{


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a color scheme designed to provide modern VS Code syntax highlighting.

My package is similar to other VS Code ports currently available. However it should still be added because this [vscode dark 2026](https://github.com/microsoft/vscode/blob/01152bb3689f0e1980ce46ed01257a29feba7338/extensions/theme-defaults/themes/2026-dark.json#L4).