### PR TITLE
add Kamailio syntax support

### DIFF
--- a/repository/k.json
+++ b/repository/k.json
@@ -36,6 +36,17 @@
 			]
 		},
 		{
+			"name": "Kamailio Config",
+			"details": "https://github.com/igorolhovskiy/kamailio-sublime",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "KanaKana",
 			"details": "https://github.com/mitsu-ksgr/KanaKana",
 			"labels": ["japanese", "text manipulation"],


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is ...
Adding Kamailio/SER SIP Proxy family config files syntax support.

There are no packages like it in Package Control.
