### PR TITLE
Update tag series for PowerShell

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2188,11 +2188,15 @@
 			"labels": ["language syntax", "build system", "snippets", "powershell"],
 			"releases": [
 				{
-					"sublime_text": "<4000",
+					"sublime_text": "<4107",
 					"tags": "st2-"
 				},
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": "4107 - 4203",
+					"tags": "st4107-"
+				},
+				{
+					"sublime_text": ">=4204",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
With the forthcoming updates to C# in upstream, this sets tag prefixes for new releases. https://github.com/SublimeText/PowerShell/pull/220

It also corrects a previous error in specific version support for earlier tags.