### PR TITLE
Update tag series for HTML (C#)

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -1106,8 +1106,12 @@
 					"tags": "version/st4157/"
 				},
 				{
-					"sublime_text": ">=4201",
+					"sublime_text": "4201 - 4203",
 					"tags": "version/st4201/"
+				},
+				{
+					"sublime_text": ">=4204",
+					"tags": "version/st4204/"
 				}
 			]
 		},


### PR DESCRIPTION
Upstream C# package is now `version: 2`, requiring a new tag series.

https://github.com/michaelblyons/SublimeSyntax-HTML-CSharp/pull/13
