### PR TITLE
Add MarkdownPrettyPreview

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -732,6 +732,17 @@
 			]
 		},
 		{
+			"name": "MarkdownPrettyPreview",
+			"details": "https://github.com/neverbot/MarkdownPrettyPreview",
+			"labels": ["markdown", "preview"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/naokazuterada/MarkdownTOC",
 			"labels": ["markdown", "toc", "table of contents"],
 			"releases": [


### PR DESCRIPTION
Adds MarkdownPrettyPreview, a Sublime Text 4 plugin that opens a read-only, prettified Markdown preview in a sibling view with live debounced updates, Unicode box tables, banner-framed fenced code blocks with per-language syntax highlighting, task list / blockquote / heading styling.

- Repo: https://github.com/neverbot/MarkdownPrettyPreview
- License: MIT
- Release tag: v0.1.0
- ST4 only (`>=4000`), tag-based releases.