### PR TITLE
Tag Umbral as language syntax

### DIFF
--- a/repository/u.json
+++ b/repository/u.json
@@ -146,6 +146,7 @@
 		{
 			"name": "Umbral",
 			"details": "https://github.com/hersac/umbral-sublime",
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=4000",


### PR DESCRIPTION
It's not my package. I'm just running another scan of https://github.com/packagecontrol/thecrawl/issues/40, and this package showed up as an untagged language. I checked, and it does seem to be a language. No snippets, build system, or other features needing tags.