### PR TITLE
Add Better Go To File package

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -614,6 +614,17 @@
 			]
 		},
 		{
+			"name": "Better Go To File",
+			"details": "https://github.com/Suor/GoToFile",
+			"labels": ["file open", "code navigation"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Better JavaScript",
 			"details": "https://github.com/int3h/sublime-better-javascript",
 			"labels": ["language syntax"],

--- a/repository/b.json
+++ b/repository/b.json
@@ -614,17 +614,6 @@
 			]
 		},
 		{
-			"name": "BetterGoToFile",
-			"details": "https://github.com/Suor/GoToFile",
-			"labels": ["file open", "code navigation"],
-			"releases": [
-				{
-					"sublime_text": ">=3000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Better JavaScript",
 			"details": "https://github.com/int3h/sublime-better-javascript",
 			"labels": ["language syntax"],
@@ -686,6 +675,17 @@
 			"releases": [
 				{
 					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "BetterGoToFile",
+			"details": "https://github.com/Suor/GoToFile",
+			"labels": ["file open", "code navigation"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]

--- a/repository/b.json
+++ b/repository/b.json
@@ -614,7 +614,7 @@
 			]
 		},
 		{
-			"name": "Better Go To File",
+			"name": "BetterGoToFile",
 			"details": "https://github.com/Suor/GoToFile",
 			"labels": ["file open", "code navigation"],
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read the docs.
- [x] I have tagged a release with a semver version number. Latest tag: 1.0.2.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [ ] I use .gitattributes to exclude files from the package: images, test files, sublime-project/workspace.

My package is a small command that opens a file path under the cursor. It supports project-relative paths, absolute paths, line numbers, multiple matches via a quick panel, and falls back to goto_definition when no path resolves.

It is similar to GoToFile. However it should still be added because that package is ST2-only in Package Control, uses a broad regex search over project files, and exposes a different command. Better Go To File is a separate ST3+ implementation focused on deterministic path-under-cursor resolution.