### PR TITLE
Add RememberSyntax package

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1091,6 +1091,17 @@
 			]
 		},
 		{
+			"name": "RememberSyntax",
+			"details": "https://github.com/Suor/RememberSyntax",
+			"labels": ["utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Remify",
 			"details": "https://github.com/brousalis/remify",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read the docs.
- [x] I have tagged a release with a semver version number. Latest tag: 1.0.0.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [ ] I use .gitattributes to exclude files from the package: images, test files, sublime-project/workspace.

My package remembers manually selected syntax for files and restores it when those files are opened again. It also supports basename glob rules for files with generic names or no extensions.

There are no packages like it in Package Control that I am aware of.