### PR TITLE
Add RemoteSync package

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1162,6 +1162,16 @@
 			]
 		},
 		{
+			"name": "RemoteSync",
+			"details": "https://github.com/NeloGH/RemoteSync",
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "RemoteTree",
 			"details": "https://github.com/deNULL/RemoteTree",
 			"releases": [

--- a/repository/r.json
+++ b/repository/r.json
@@ -1164,6 +1164,7 @@
 		{
 			"name": "RemoteSync",
 			"details": "https://github.com/NeloGH/RemoteSync",
+			"labels": ["ftp", "sftp", "sync", "remote"],
 			"releases": [
 				{
 					"sublime_text": ">=4000",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries.
- [ ] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a Sublime Text 4 plugin for syncing files to remote servers via SFTP, FTP, FTPS, and SCP. It features upload-on-save, parallel batch folder operations, an interactive remote file browser, local vs remote diff, per-subfolder configs, connection pooling with keepalive, and support for pre/post upload commands.

There are no packages like it in Package Control.