### PR TITLE
Move Kotlin package

### DIFF
--- a/repository/k.json
+++ b/repository/k.json
@@ -484,7 +484,12 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": "<4075",
+					"base": "https://github.com/vkostyukov/kotlin-sublime-package",
+					"branch": "master"
+				},
+				{
+					"sublime_text": ">=4075",
 					"tags": true
 				}
 			]

--- a/repository/k.json
+++ b/repository/k.json
@@ -480,12 +480,12 @@
 		},
 		{
 			"name": "Kotlin",
-			"details": "https://github.com/vkostyukov/kotlin-sublime-package",
+			"details": "https://github.com/guille/sublime-kotlin",
 			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

Repo: https://github.com/guille/sublime-kotlin

My package is a Kotlin syntax. Rather than have a "Better Kotlin" package I figured this made more sense.

Two disclaimers:
- The syntax is AI generated. It does fix every open issue I saw on the old package's (and then some) but it is probably not perfect. I am not good at writing syntaxes so any maintaining will also be done with this approach, although syntax tests seem to make it output decent stuff.
- I have not tried to submit patches [the old package](https://github.com/vkostyukov/kotlin-sublime-package). The last commit was 8 years ago, there have been open issues for longer, and I don't feel comfortable dumping a 1000-line syntax file on someone else.

I would understand if the change is rejected. I initially wasn't going to submit it because I don't think a lot of people use ST for Kotlin but it's been pointed out that Sublime Merge would also benefit from a better syntax.

The only "breaking" change beyond better highlighting is the scope name changes from `source.Kotlin` to `source.kotlin`. The only places I can imagine that would cause issues is in [LSP-Kotlin](https://github.com/search?q=repo%3Asublimelsp%2FLSP-kotlin%20source.kotlin&type=code) and [AFileIcon](https://github.com/search?q=repo%3ASublimeText%2FAFileIcon%20source.kotlin&type=code). If this is accepted I'd submit patches there too.

## Comparison

**Before**

<img width="1010" height="939" alt="2026-04-24-15:52:33" src="https://github.com/user-attachments/assets/f51fbebe-79da-41d5-9fbc-3fb653a2ea22" />

---

**After:**
<img width="1002" height="964" alt="2026-04-24-15:53:00" src="https://github.com/user-attachments/assets/188913aa-fce5-494b-bf4b-14d8231aa9e9" />
