### PR TITLE
Add A6s

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -14,6 +14,17 @@
 			]
 		},
 		{
+			"name": "A6s",
+			"details": "https://github.com/The-Autonoma/a6s-sublime",
+			"labels": ["ai", "tools", "code", "websocket"],
+			"releases": [
+				{
+					"sublime_text": ">=3211",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ABAP",
 			"details": "https://github.com/flaiker/abap-st3",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs](https://docs.sublimetext.io/guide/package-control/submitting.html).
- [x] I have tagged a release with a [semver](https://semver.org) version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes](https://www.git-scm.com/docs/gitattributes#_export_ignore) to exclude files from the package: images, test files, sublime-project/workspace.

My package is **A6s** — a Sublime Text client for the local A6s CLI daemon. It provides intelligent multi-agent orchestration inside Sublime: invoke AI agents, stream RIGOR-phase progress, and review/apply generated refactors and tests. All traffic flows over `ws://localhost:9876/ws` to a locally-installed daemon (`a6s` Homebrew formula); the package itself never holds API credentials or speaks to a remote orchestrator.

There are no packages like it in Package Control today — most AI-assist plugins target a single hosted vendor; A6s is a thin client over a local daemon that owns the upstream call. Sibling clients exist for VS Code, JetBrains, Neovim, and Emacs.

Notes on the checklist:
- **Context menu**: A6s adds a single nested submenu under right-click ("A6s") with selection-conditional commands (`selection_empty == false`), so it only surfaces when the user has highlighted code.
- **Key bindings**: A6s ships **no default key bindings**. `Default.sublime-keymap` contains commented-out suggestions only — users copy what they want into their own keymap.

Repo: https://github.com/The-Autonoma/a6s-sublime
Latest release: v2.0.1