### PR TITLE
Add D2 Package

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -13,6 +13,17 @@
 			]
 		},
 		{
+			"name": "D2",
+			"details": "https://gitlab.com/sotilrac/d2-syntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "D3.js Snippets",
 			"details": "https://github.com/fabriciotav/d3-snippets-for-sublime-text-2",
 			"labels": ["snippets"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a Sublime Text syntax highlighter for the [D2 diagram language](https://d2lang.com). It highlights `.d2` files: keywords, shapes, edge operators (`->`, `--`, `<->`, `<-`), strings, block strings with embedded language hints (`|md`, `|sh`, `|js`, `|go`, `|d2`), comments (`#` and `"""..."""`), numbers, booleans, substitutions (`${...}`), and imports (`@...`). It also ships a `Comments.tmPreferences` for line/block comment toggling and a `D2.sublime-settings` file with sensible per-syntax defaults.

There are no packages like it in Package Control.

Repo: https://gitlab.com/sotilrac/d2-syntax
