### PR TITLE
Add StyleTokenHighlighter

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -4297,7 +4297,6 @@
 			]
 		},
 		{
-			"name": "StyleTokenHighlighter",
 			"details": "https://github.com/leoshome/StyleTokenHighlighter",
 			"releases": [
 				{

--- a/repository/s.json
+++ b/repository/s.json
@@ -4297,6 +4297,16 @@
 			]
 		},
 		{
+			"name": "StyleTokenHighlighter",
+			"details": "https://github.com/leoshome/StyleTokenHighlighter",
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "StylishHaskell",
 			"details": "https://github.com/hairyhum/SublimeStylishHaskell",
 			"releases": [


### PR DESCRIPTION

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is similar to **StyleToken** and **TextMarker**, both of which are years old and no longer maintained. However it should still be added because:

1. It combines the features of them, one is right-click context menu of **StyleToken** and one is easy mark selected text feature of **TextMarker**.
2. It is designed to mimic **Notepad++'s "Style all occurrences of token"** via the right-click context menu, which is more intuitive and familiar for users coming from Notepad++.
