### PR TITLE
Add syntax highlighting for the Praia language

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2234,9 +2234,8 @@
 			]
 		},
 		{
-			"name": "Praia Syntax Highlighting",
 			"details": "https://github.com/praia-lang/praia-sublime",
-			"labels": ["praia", "language syntax"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/p.json
+++ b/repository/p.json
@@ -2234,6 +2234,7 @@
 			]
 		},
 		{
+			"name": "Praia Syntax Highlighting",
 			"details": "https://github.com/praia-lang/praia-sublime",
 			"labels": ["language syntax"],
 			"releases": [

--- a/repository/p.json
+++ b/repository/p.json
@@ -2234,6 +2234,17 @@
 			]
 		},
 		{
+			"name": "Praia Syntax Highlighting",
+			"details": "https://github.com/praia-lang/praia-sublime",
+			"labels": ["praia", "language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Pre language syntax highlighting",
 			"details": "https://github.com/jonschlinkert/pre-sublime",
 			"labels": ["language syntax"],

--- a/repository/p.json
+++ b/repository/p.json
@@ -2234,7 +2234,7 @@
 			]
 		},
 		{
-			"name": "Praia Syntax Highlighting",
+			"name": "Praia",
 			"details": "https://github.com/praia-lang/praia-sublime",
 			"labels": ["language syntax"],
 			"releases": [


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is syntax highlighting for the Praia programming language.

There are no packages like it in Package Control.

