### PR TITLE
Add syntax highlighting for the Rux language

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -2577,6 +2577,17 @@
 					"branch": "master"
 				}
 			]
+		},
+		{
+			"name": "Rux",
+			"details": "https://github.com/rux-lang/SublimeText",
+			"labels": ["language syntax", "rux"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
 		}
 	]
 }

--- a/repository/r.json
+++ b/repository/r.json
@@ -2567,17 +2567,7 @@
 					"tags": true
 				}
 			]
-		},
-		{
-			"name": "RVM",
-			"details": "https://github.com/jinze/sublime-rvm",
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"branch": "master"
-				}
-			]
-		},
+		},		
 		{
 			"name": "Rux",
 			"details": "https://github.com/rux-lang/SublimeText",
@@ -2586,6 +2576,16 @@
 				{
 					"sublime_text": ">=4000",
 					"tags": true
+				}
+			]
+		},
+		{
+			"name": "RVM",
+			"details": "https://github.com/jinze/sublime-rvm",
+			"releases": [
+				{
+					"sublime_text": "<3000",
+					"branch": "master"
 				}
 			]
 		}


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is syntax highlighting for the Rux programming language.

There are no packages like it in Package Control.