### PR TITLE
Add Ai Bridge plugin information to a.json

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -561,6 +561,19 @@
 			]
 		},
 		{
+			"name": "Ai Bridge",
+			"description": "An MCP (Model Context Protocol) server, hosted inside Sublime Text as a plugin, that lets an LLM read and edit code through Sublime's own APIs — symbol index, syntax-aware definition extraction and project search. The LLM gets the same 'go to definition' and 'find references' power that Sublime gives you, plus the ability to read and rewrite whole functions.",
+			"author": "Jonathan Heintzeman",
+			"details": "https://github.com/MNU-497/Sublime-AI-Bridge",
+			"labels": ["text manipulation", "mcp", "ai"],
+			"releases": [
+				{
+					"sublime_text": ">=4081",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "AiComplete",
 			"description": "Auto code completion using Gemini API",
 			"author": "Chinmay Agarwal",

--- a/repository/a.json
+++ b/repository/a.json
@@ -561,7 +561,7 @@
 			]
 		},
 		{
-			"name": "Ai Bridge",
+			"name": "AI Bridge",
 			"description": "An MCP (Model Context Protocol) server, hosted inside Sublime Text as a plugin, that lets an LLM read and edit code through Sublime's own APIs — symbol index, syntax-aware definition extraction and project search. The LLM gets the same 'go to definition' and 'find references' power that Sublime gives you, plus the ability to read and rewrite whole functions.",
 			"author": "Jonathan Heintzeman",
 			"details": "https://github.com/MNU-497/Sublime-AI-Bridge",

--- a/repository/a.json
+++ b/repository/a.json
@@ -562,7 +562,6 @@
 		},
 		{
 			"name": "AI Bridge",
-			"description": "An MCP (Model Context Protocol) server, hosted inside Sublime Text as a plugin, that lets an LLM read and edit code through Sublime's own APIs — symbol index, syntax-aware definition extraction and project search. The LLM gets the same 'go to definition' and 'find references' power that Sublime gives you, plus the ability to read and rewrite whole functions.",
 			"author": "Jonathan Heintzeman",
 			"details": "https://github.com/MNU-497/Sublime-AI-Bridge",
 			"labels": ["text manipulation", "mcp", "ai"],


### PR DESCRIPTION
Added Ai Bridge plugin details including name, description, author, and release information.

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is similar to MCPServer, however, it should still be added because it has many more features, optimized workflow, better usability and includes intelligence for business level editing.

<img width="1147" height="806" alt="image" src="https://github.com/user-attachments/assets/58e599a5-6b01-4918-a70d-f0dce1ec6e62" />

<img width="984" height="501" alt="image" src="https://github.com/user-attachments/assets/aa646e98-2a13-48cf-a7cc-bae88e19cab0" />

<img width="1001" height="727" alt="image" src="https://github.com/user-attachments/assets/d4056c27-90a2-42f0-a089-832c8f2fcd5d" />

<img width="990" height="484" alt="image" src="https://github.com/user-attachments/assets/994d1829-cb83-4274-9b0e-f7513b861a47" />


Regards.