### PR TITLE
Add ToptalMinifier

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -3113,6 +3113,19 @@
 			]
 		},
 		{
+			"name": "ToptalMinifier",
+			"author": "Kader Bouyakoub",
+			"description": "Minify CSS and JavaScript using Toptal's online minifier APIs.",
+		    "details": "https://github.com/bkader/ToptalMinifier",
+		    "labels": ["css", "javascript", "minifier"],
+		    "releases": [
+		        {
+		            "sublime_text": ">=4000",
+		            "tags": true
+		        }
+		    ]
+		},
+		{
 			"name": "Tornado",
 			"description": "Template syntax for Python's Tornado web framework.",
 			"details": "https://github.com/nickbaum/sublime-tornado/",

--- a/repository/t.json
+++ b/repository/t.json
@@ -3116,14 +3116,14 @@
 			"name": "ToptalMinifier",
 			"author": "Kader Bouyakoub",
 			"description": "Minify CSS and JavaScript using Toptal's online minifier APIs.",
-		    "details": "https://github.com/bkader/ToptalMinifier",
-		    "labels": ["css", "javascript", "minifier"],
-		    "releases": [
-		        {
-		            "sublime_text": ">=4000",
-		            "tags": true
-		        }
-		    ]
+			"details": "https://github.com/bkader/ToptalMinifier",
+			"labels": ["css", "javascript", "minifier"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
 		},
 		{
 			"name": "Tornado",


### PR DESCRIPTION
Added ToptalMinifier plugin details including author, description, and release information.

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. *** N/A, this package is not a syntax package.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a small utility package for Sublime Text 4 that minifies CSS and JavaScript using Toptal's online minifier APIs.

There are no packages like it in Package Control that specifically integrate the Toptal CSS Minifier and Toptal JavaScript Minifier APIs.

It has been tested by installing through Package Control's "Add Repository" flow, restarting Sublime Text 4, and verifying:

- Command Palette commands
- Tools menu entries
- Package settings menu
- Split-view settings editing via `edit_settings`
- CSS minification
- JavaScript minification