### PR TITLE
Add ST3 tag for Modelines package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -2117,6 +2117,10 @@
 					"tags": "st2/"
 				},
 				{
+					"sublime_text": "3000 - 4134",
+					"tags": "st3/"
+				},
+				{
 					"sublime_text": ">=4135",
 					"tags": "st4135/"
 				}


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

This PR only adds the ST3 release series of the Modelines package which has been recently resurrected.