### PR TITLE
Add InlineGitBlame to Package Control

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -757,15 +757,15 @@
 		},
 		{
 			"name": "InlineGitBlame",
-		    "details": "https://github.com/akostoth02/ST-InlineGitBlame",
-		  	"labels": ["git", "blame", "inline", "annotation"],
-	  		"releases": [
-		  		{
-			  		"sublime_text": ">=4000",
-			  		"tags": true
-			  	}
-	  		]
-	  	},
+			"details": "https://github.com/akostoth02/ST-InlineGitBlame",
+			"labels": ["git", "blame", "inline", "annotation"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
 		{
 			"name": "InlineOutline",
 			"details": "https://github.com/kaste/InlineOutline",

--- a/repository/i.json
+++ b/repository/i.json
@@ -756,6 +756,17 @@
 			]
 		},
 		{
+			"name": "InlineGitBlame",
+		    "details": "https://github.com/akostoth02/ST-InlineGitBlame",
+		  	"labels": ["git", "blame", "inline", "annotation"],
+	  		"releases": [
+		  		{
+			  		"sublime_text": ">=4000",
+			  		"tags": true
+			  	}
+	  		]
+	  	},
+		{
 			"name": "InlineOutline",
 			"details": "https://github.com/kaste/InlineOutline",
 			"releases": [


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is similar to Git Blame, however I would like to add it, because it shows the blame inline without any direct trigger. It works just like in VS Code for example. Similar, but still different :)
Also planning to add more useful features, maybe the exact change made for the line with the last commit. However i will try to keep it lean, as all things should be.