### PR TITLE
Add ST4 Word Count package

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3741,6 +3741,18 @@
 			]
 		},
 		{
+			"name": "ST4 Word Count",
+			"description": "Live word count in the status bar, with selection count when text is selected",
+			"details": "https://github.com/dgdiddy/st4-wordcount",
+			"labels": ["word count"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ST_AWK",
 			"details": "https://github.com/qiuxiafei/st_awk",
 			"releases": [


### PR DESCRIPTION
Adds **ST4 Word Count**, a simple Sublime Text 4 plugin that shows a live word count in the status bar.

- Shows total word count of the document at all times
- When text is selected, also shows the word count of just the selection
- Works correctly with split panes
- ST4 only (`>=4000`)

Repository: https://github.com/dgdiddy/st4-wordcount