### PR TITLE
Take over Indent XML

### DIFF
--- a/repository/i.json
+++ b/repository/i.json
@@ -580,12 +580,12 @@
 		},
 		{
 			"name": "Indent XML",
-			"details": "https://github.com/alek-sys/sublimetext_indentxml",
+			"details": "https://github.com/braver/IndentXML",
 			"labels": ["indentation", "xml"],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "master"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. (It already had a few in previous versions, they stay)
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

This points Indent XML to my fork at https://github.com/braver/IndentXML. The original repo hasn't been updated in 8 years, has several issues and PR's without responses, including mine to make it compatible with ST's upcoming move to python 3.14: https://github.com/alek-sys/sublimetext_indentxml/pull/131. 