### PR TITLE
Add Structurizr DSL package - a language syntax for Structurizr DSL

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -4236,6 +4236,17 @@
 			]
 		},
 		{
+		  "name": "Structurizr Syntax",
+		  "details": "https://github.com/agehrke/structurizr-syntax",
+		  "labels": ["language syntax"],
+		  "releases": [
+		    {
+		      "sublime_text": ">=4000",
+		      "tags": true
+		    }
+		  ]
+		},
+		{
 			"name": "Stupid Indent",
 			"details": "https://github.com/tzvetkoff/sublime_stupid_indent",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -4240,10 +4240,10 @@
 		  "details": "https://github.com/agehrke/structurizr-syntax",
 		  "labels": ["language syntax"],
 		  "releases": [
-		    {
-		      "sublime_text": ">=4000",
-		      "tags": true
-		    }
+		  		{
+		      		"sublime_text": ">=4000",
+		      		"tags": true
+		    	}
 		  ]
 		},
 		{

--- a/repository/s.json
+++ b/repository/s.json
@@ -4236,15 +4236,15 @@
 			]
 		},
 		{
-		  "name": "Structurizr Syntax",
-		  "details": "https://github.com/agehrke/structurizr-syntax",
-		  "labels": ["language syntax"],
-		  "releases": [
-		  		{
-		      		"sublime_text": ">=4000",
-		      		"tags": true
-		    	}
-		  ]
+			"name": "Structurizr DSL",
+			"details": "https://github.com/agehrke/structurizr-syntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
 		},
 		{
 			"name": "Stupid Indent",


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package "Structurizr DSL" is language syntax for the [Structurizr DSL](https://docs.structurizr.com/dsl/language).

There are no packages like it in Package Control.

<!-- 
*)   If you do need a context menu, make sure the menu applies to the cursor
     context, and the commands are conditional. Space in this menu is limited!
**)  There aren't enough keys for all packages, so you risk overriding those
     of other packages. You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) Syntaxes should work in any color scheme the user chooses.

For bonus points also consider how the review guidelines apply to your package:
https://docs.sublimetext.io/reference/package-control/reviewing.html
-->
