### PR TITLE
Add CodeShot package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2305,17 +2305,17 @@
 			]
 		},
 		{
-		    "name": "CodeShot",
-		    "details": "https://github.com/yasinahmed/CodeShot",
-		    "author": "Yasin Jagral",
-		    "labels": ["code", "screenshot", "clipboard", "windows"],
-		    "releases": [
-		        {
-		            "sublime_text": ">=4107",
-		            "platforms": ["windows"],
-		            "tags": true
-		        }
-		    ]
+			"name": "CodeShot",
+			"details": "https://github.com/yasinahmed/CodeShot",
+			"author": "Yasin Jagral",
+			"labels": ["code", "screenshot", "clipboard", "windows"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"platforms": ["windows"],
+					"tags": true
+				}
+			]
 		},		
 		{
 			"name": "CodeStats",

--- a/repository/c.json
+++ b/repository/c.json
@@ -1959,6 +1959,19 @@
 			]
 		},
 		{
+		    "name": "CodeShot",
+		    "details": "https://github.com/yasinahmed/CodeShot",
+		    "author": "Yasin Jagral",
+		    "labels": ["code", "screenshot", "clipboard", "windows"],
+		    "releases": [
+		        {
+		            "sublime_text": ">=4107",
+		            "platforms": ["windows"],
+		            "tags": true
+		        }
+		    ]
+		},
+		{
 			"name": "Code Cast",
 			"details": "https://github.com/mraiur/CodeCast",
 			"labels": ["code", "cast", "share", "codecast"],

--- a/repository/c.json
+++ b/repository/c.json
@@ -1959,19 +1959,6 @@
 			]
 		},
 		{
-		    "name": "CodeShot",
-		    "details": "https://github.com/yasinahmed/CodeShot",
-		    "author": "Yasin Jagral",
-		    "labels": ["code", "screenshot", "clipboard", "windows"],
-		    "releases": [
-		        {
-		            "sublime_text": ">=4107",
-		            "platforms": ["windows"],
-		            "tags": true
-		        }
-		    ]
-		},
-		{
 			"name": "Code Cast",
 			"details": "https://github.com/mraiur/CodeCast",
 			"labels": ["code", "cast", "share", "codecast"],
@@ -2317,6 +2304,19 @@
 				}
 			]
 		},
+		{
+		    "name": "CodeShot",
+		    "details": "https://github.com/yasinahmed/CodeShot",
+		    "author": "Yasin Jagral",
+		    "labels": ["code", "screenshot", "clipboard", "windows"],
+		    "releases": [
+		        {
+		            "sublime_text": ">=4107",
+		            "platforms": ["windows"],
+		            "tags": true
+		        }
+		    ]
+		},		
 		{
 			"name": "CodeStats",
 			"details": "https://github.com/code-stats/code-stats-sublime",


### PR DESCRIPTION
Adds CodeShot, a Windows-only Sublime Text plugin for creating clean code screenshots.

Developer: Yasin Jagral

Repository:
https://github.com/yasinahmed/CodeShot

Notes:
- Windows only
- Requires Chrome or Edge installed locally
- Uses PowerShell for clipboard copy
- Works offline
- First release tag: 1.0.0