### PR TITLE
Add Makinda Icons and Makinda Themes

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -325,6 +325,28 @@
 			]
 		},
 		{
+			"name": "Makinda Color Scheme",
+			"details": "https://github.com/makinda-jackson/makinda-sublime",
+			"labels": ["color scheme", "theme", "light", "dark", "orange"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "Makinda Icons",
+			"details": "https://github.com/makinda-jackson/makinda-icons-sublime",
+			"labels": ["theme", "icons", "file icons"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Mako",
 			"details": "https://github.com/marconi/mako-tmbundle",
 			"labels": ["language syntax"],


### PR DESCRIPTION
Adds two related packages from the Makinda design system as a single PR:

- **Makinda Icons** — a file-icon theme. Repo: https://github.com/makinda-jackson/makinda-icons-sublime — tag `v1.0.13`, MIT.
- **Makinda Themes** — a pair of color schemes (Makinda Light + Makinda Dark). Repo: https://github.com/makinda-jackson/makinda-sublime — tag `v1.0.4`, MIT.

Each is added as a separate commit; the combined diff is two 12-line inserts into `repository/m.json` (24 lines total, no other changes).

---

### Checklist — Makinda Icons

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette. (n/a — no commands)
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view. (n/a — none)
- [x] If my package is a syntax it doesn't also add a color scheme. (n/a — not a syntax)
- [x] I use [.gitattributes][3] to exclude non-runtime files from the package.

It ships 16/32/48 px PNG icons and `.tmPreferences` files that bind TextMate scopes (e.g. `source.js`, `source.python`) to those icons so files get the right glyph in the sidebar and tabs.

Similar to A File Icon, but follows a different visual language — warm, single-fill, optimized for legibility at 16 px — and is the icon half of the Makinda design system.

### Checklist — Makinda Themes

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette. (n/a — no commands)
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view. (n/a — none)
- [x] If my package is a syntax it doesn't also add a color scheme. (n/a — this package *is* color schemes, not a syntax)
- [x] I use [.gitattributes][3] to exclude non-runtime files from the package.

A pair of color schemes for Sublime Text 3 / 4 with warm orange accents and a focus on contrast and readability. Similar to many existing schemes in Package Control; included because it's the canonical Sublime distribution of the Makinda design system and pairs with Makinda Icons above.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

---

Replaces the earlier #9408 and #9409 (both auto-closed after an erroneous force-push left orphan commits). This branch is built directly on top of `sublimehq:master`, packages combined into one PR per request, two clean commits. Earlier mistakes (full-file reformat, missing LICENSE, broken README references) are all corrected in the linked package repos. I'll be handling responses on this PR personally.