### PR TITLE
Update reviewer action ref

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@4129d541dbed77fb6afc86b762a306266a4bdc45
+        uses: kaste/st_package_reviewer/gh_action@e4e205ded09a710aab7d35bf603b3f10bfd763eb
         with:
           pr: ${{ github.event.pull_request.html_url }}
           file: repository.json
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@4129d541dbed77fb6afc86b762a306266a4bdc45
+        uses: kaste/st_package_reviewer/gh_action@e4e205ded09a710aab7d35bf603b3f10bfd763eb
         with:
           pr: ${{ github.event.issue.pull_request.html_url }}
           file: repository.json

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@573b332e25687618809f6ed33c40d7f0949b1c9c
+        uses: kaste/st_package_reviewer/gh_action@4129d541dbed77fb6afc86b762a306266a4bdc45
         with:
           pr: ${{ github.event.pull_request.html_url }}
           file: repository.json
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@573b332e25687618809f6ed33c40d7f0949b1c9c
+        uses: kaste/st_package_reviewer/gh_action@4129d541dbed77fb6afc86b762a306266a4bdc45
         with:
           pr: ${{ github.event.issue.pull_request.html_url }}
           file: repository.json

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@ad89510c574e97d92cfd4d9e0f5c9029394f5c94
+        uses: kaste/st_package_reviewer/gh_action@573b332e25687618809f6ed33c40d7f0949b1c9c
         with:
           pr: ${{ github.event.pull_request.html_url }}
           file: repository.json
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@ad89510c574e97d92cfd4d9e0f5c9029394f5c94
+        uses: kaste/st_package_reviewer/gh_action@573b332e25687618809f6ed33c40d7f0949b1c9c
         with:
           pr: ${{ github.event.issue.pull_request.html_url }}
           file: repository.json

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -15,6 +15,6 @@ jobs:
       contents: read
     steps:
       - name: Post PR comment from artifact
-        uses: kaste/st_package_reviewer/gh_action@ad89510c574e97d92cfd4d9e0f5c9029394f5c94
+        uses: kaste/st_package_reviewer/gh_action@573b332e25687618809f6ed33c40d7f0949b1c9c
         with:
           phase: report

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -15,6 +15,6 @@ jobs:
       contents: read
     steps:
       - name: Post PR comment from artifact
-        uses: kaste/st_package_reviewer/gh_action@573b332e25687618809f6ed33c40d7f0949b1c9c
+        uses: kaste/st_package_reviewer/gh_action@4129d541dbed77fb6afc86b762a306266a4bdc45
         with:
           phase: report

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -15,6 +15,6 @@ jobs:
       contents: read
     steps:
       - name: Post PR comment from artifact
-        uses: kaste/st_package_reviewer/gh_action@4129d541dbed77fb6afc86b762a306266a4bdc45
+        uses: kaste/st_package_reviewer/gh_action@e4e205ded09a710aab7d35bf603b3f10bfd763eb
         with:
           phase: report


### PR DESCRIPTION
Point package review workflows at the latest st_package_reviewer commit, which fixes the composite action project context used by uv.


