### PR TITLE
Remove unreachable 'kallepersson' repository

### DIFF
--- a/channel.json
+++ b/channel.json
@@ -57,7 +57,6 @@
 		"https://raw.githubusercontent.com/jrappen/sublime-packages/master/package_control_channel.json",
 		"https://raw.githubusercontent.com/kairyou/sublime_packages/master/packages.json",
 		"https://raw.githubusercontent.com/Kaizhi/SublimeUpdater/master/packages.json",
-		"https://raw.githubusercontent.com/kallepersson/Sublime-Finder/master/packages.json",
 		"https://raw.githubusercontent.com/Kasoki/FancyProjects/master/packages.json",
 		"https://raw.githubusercontent.com/keeganstreet/sublime-specificity/master/packages.json",
 		"https://raw.githubusercontent.com/kik0220/sublimetext_japanize/master/packages.json",


### PR DESCRIPTION
See e.g. https://packages.sublimetext.io/status?run_id=26086529021

The repository (not a single package) is 404ing since [May 9th](https://packages.sublimetext.io/status?run_id=25582921002).   