### PR TITLE
Bump reviewer action ref

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@81e964270472dae33e904a15a354976b99d7b2f2
+        uses: kaste/st_package_reviewer/gh_action@6eaccd35d3032f7293e0024c5cf8260c65a3d2ce
         with:
           pr: ${{ github.event.pull_request.html_url }}
           file: repository.json
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Diff and review changed/added packages
-        uses: kaste/st_package_reviewer/gh_action@81e964270472dae33e904a15a354976b99d7b2f2
+        uses: kaste/st_package_reviewer/gh_action@6eaccd35d3032f7293e0024c5cf8260c65a3d2ce
         with:
           pr: ${{ github.event.issue.pull_request.html_url }}
           file: repository.json

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -15,6 +15,6 @@ jobs:
       contents: read
     steps:
       - name: Post PR comment from artifact
-        uses: kaste/st_package_reviewer/gh_action@81e964270472dae33e904a15a354976b99d7b2f2
+        uses: kaste/st_package_reviewer/gh_action@6eaccd35d3032f7293e0024c5cf8260c65a3d2ce
         with:
           phase: report


### PR DESCRIPTION
Point the package review workflows at the reviewer commit that sets a setuptools-scm fallback version before uv builds the action checkout.


