### PR TITLE
Add Tahcia package

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -282,6 +282,17 @@
 			]
 		},
 		{
+			"name": "Tahcia Script Sync",
+			"details": "https://github.com/tahcia/sublime_text",
+			"labels": ["automation", "scripting", "json", "remote execution"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Tailwind CSS",
 			"details": "https://github.com/SublimeText/TailwindCSS",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ It Does  Have It] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [na] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is ...

Tahcia.com  Script Downloader & Uploader

There are no packages like it in Package Control.


