### PR TITLE
Add Abrase Syntax Highlight

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -81,6 +81,17 @@
 			]
 		},
 		{
+			"name": "Abrase",
+			"details": "https://github.com/KHN190/Abrase-sublime",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Abstract Markup Language",
 			"details": "https://github.com/abstractmarkup/sublimetext",
 			"labels": ["build system", "language syntax", "snippets"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a syntax definition for Abrase, a typed effect-handler language (`.abe` files) I author at https://github.com/KHN190/Abrase.

The submitted package is at https://github.com/KHN190/Abrase-sublime

There are no packages like it in Package Control.