### PR TITLE
Add Serendipity and Sequoia color schemes

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1215,8 +1215,7 @@
 			]
 		},
 		{
-			"name": "Sequoia Theme",
-			"description": "Sequoia color schemes for Sublime Text — Moonlight, Monochrome, and Retro (dark and light).",
+			"name": "Sequoia Color Scheme",
 			"details": "https://github.com/Sequoia-Theme/sublime-text",
 			"labels": ["color scheme"],
 			"releases": [
@@ -1227,8 +1226,7 @@
 			]
 		},
 		{
-			"name": "Serendipity Theme",
-			"description": "Serendipity color schemes for Sublime Text — Midnight, Morning, and Sunset.",
+			"name": "Serendipity Color Scheme",
 			"details": "https://github.com/Serendipity-Theme/sublime-text",
 			"labels": ["color scheme"],
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -1215,6 +1215,30 @@
 			]
 		},
 		{
+			"name": "Sequoia Theme",
+			"description": "Sequoia color schemes for Sublime Text — Moonlight, Monochrome, and Retro (dark and light).",
+			"details": "https://github.com/Sequoia-Theme/sublime-text",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "Serendipity Theme",
+			"description": "Serendipity color schemes for Sublime Text — Midnight, Morning, and Sunset.",
+			"details": "https://github.com/Serendipity-Theme/sublime-text",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/facelessuser/SerializedDataConverter",
 			"releases": [
 				{


### PR DESCRIPTION
## Summary

- **Serendipity Theme** — https://github.com/Serendipity-Theme/sublime-text (Midnight, Morning, Sunset)
- **Sequoia Theme** — https://github.com/Sequoia-Theme/sublime-text (Moonlight, Monochrome, Retro — dark and light)

Both repos have tagged release **v1.0.0** and `.gitattributes` excluding README/LICENSE from the package archive.

## Checklist

- [x] I'm the package's author and/or maintainer.
- [x] I have read the docs.
- [x] I have tagged a release with a semver version number.
- [x] My package repo has a description and a README.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use `.gitattributes` to exclude files from the package.

My package is a color scheme collection ported from the Serendipity / Sequoia VS Code theme families.

There are no packages like it in Package Control under these names.

Made with [Cursor](https://cursor.com)