### PR TITLE
Update b.json : New dark color scheme Borliana.

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -1338,6 +1338,17 @@
 			]
 		},
 		{
+            "name": "Borliana Color Scheme",
+            "details": "https://github.com/Avijit-1234/Borliana-Theme",
+            "labels": ["color scheme", "dark", "minimalist"],
+            "releases": [
+                {
+                    "sublime_text": "*",
+                    "tags": true
+                }
+            ]
+        },
+		{
 			"name": "Bottle",
 			"details": "https://github.com/eric-wieser/sublime-bottle",
 			"labels": ["language syntax", "snippets", "python"],

--- a/repository/b.json
+++ b/repository/b.json
@@ -1339,7 +1339,7 @@
 		},
 		{
             "name": "Borliana Color Scheme",
-            "details": "https://github.com/Avijit-1234/Borliana-Theme",
+            "details": "https://github.com/Avijit-1234/Borliana-Color-Scheme",
             "labels": ["color scheme", "dark", "minimalist"],
             "releases": [
                 {

--- a/repository/b.json
+++ b/repository/b.json
@@ -1338,16 +1338,16 @@
 			]
 		},
 		{
-            "name": "Borliana Color Scheme",
-            "details": "https://github.com/Avijit-1234/Borliana-Color-Scheme",
-            "labels": ["color scheme", "dark", "minimalist"],
-            "releases": [
-                {
-                    "sublime_text": "*",
-                    "tags": true
-                }
-            ]
-        },
+			"name": "Borliana Color Scheme",
+			"details": "https://github.com/Avijit-1234/Borliana-Color-Scheme",
+			"labels": ["color scheme", "dark", "minimalist"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
 		{
 			"name": "Bottle",
 			"details": "https://github.com/eric-wieser/sublime-bottle",


### PR DESCRIPTION
Added a new dark color scheme - Borliana.

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a dark color scheme named Borliana. It is designed specifically for high readability and minimal eye strain.

My package is similar to Mariana and the classic Borland themes. However it should still be added because it provides a unique hybrid: it maintains the heavy, bold visual weight and contrast of classic Borland, but utilizes the softer, pastel color science of Mariana to prevent retina burn.