### PR TITLE
Add sublime-llm

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1423,6 +1423,17 @@
 			]
 		},
 		{
+			"name": "LLM",
+			"details": "https://github.com/tonylchang/sublime-llm",
+			"labels": ["ai", "llm", "chat"],
+			"releases": [
+				{
+					"sublime_text": ">=4050",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LLVM",
 			"details": "https://github.com/whitequark/llvm.tmbundle",
 			"labels": ["language syntax"],

--- a/repository/s.json
+++ b/repository/s.json
@@ -4639,6 +4639,17 @@
 			]
 		},
 		{
+			"name": "sublime-llm",
+			"details": "https://github.com/tonylchang/sublime-llm",
+			"labels": ["ai", "llm", "chat"],
+			"releases": [
+				{
+					"sublime_text": ">=4050",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/ccreutzig/sublime-MuPAD",
 			"labels": ["language syntax"],
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -4639,17 +4639,6 @@
 			]
 		},
 		{
-			"name": "sublime-llm",
-			"details": "https://github.com/tonylchang/sublime-llm",
-			"labels": ["ai", "llm", "chat"],
-			"releases": [
-				{
-					"sublime_text": ">=4050",
-					"tags": true
-				}
-			]
-		},
-		{
 			"details": "https://github.com/ccreutzig/sublime-MuPAD",
 			"labels": ["language syntax"],
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is **sublime-llm**, an in-editor Markdown chat view that talks to local Ollama (default, private-by-default) or hosted providers — OpenAI, Anthropic, OpenRouter, DeepSeek — and any OpenAI-compatible endpoint (LM Studio, llama.cpp, vLLM, Groq, …). API keys come from environment variables or an external `~/.config/sublime-llm/config.json` (mode 0600), never the synced settings file. MIT licensed; uses the Python 3.8 plugin host (`.python-version`), Sublime Text build 4050+.

Notes on the two unchecked items — both are intentional and minimal:

- **Context menu**: two conditional entries — `sublime-llm: Send Selection to Chat` (right-click; only visible when the selection is non-empty, via `is_visible`) and `sublime-llm: Send File to Chat` (Side Bar). Both apply to the cursor/click context.
- **Key bindings**: only two, both scoped to the plugin's own chat view via `setting.sublime_llm_chat_view` — `ctrl/super+enter` (submit) and `escape` (cancel a stream). No global bindings: the previous `ctrl+shift+l` for Send Selection was removed in v1.0.1 because it shadowed the built-in "Split selection into lines"; a commented rebind example ships in `Default.sublime-keymap` and is documented in the README.

There are no packages like it in Package Control — none provide an in-editor, multi-provider LLM chat view.

I'm the author and will maintain it long term.