### PR TITLE
Add MarkdownImagePaste

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -685,6 +685,18 @@
 			]
 		},
 		{
+			"name": "MarkdownImagePaste",
+			"details": "https://github.com/vjeantet/sublime-image-paste",
+			"labels": ["markdown", "image", "clipboard", "paste"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/sekogan/MarkdownLight",
 			"labels": ["language syntax", "markdown"],
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. ** (my package overide Cmd+V and it is its purpose)
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

With my package, in a markdown view, Cmd+V saves a clipboard image next to the current .md file and inserts a `![](path)` reference; otherwise it falls back to a normal paste.

My package is similar to [Image​Paste](https://packagecontrol.io/packages/ImagePaste) However it should still be added because it works on ST4, macOS and will work on LINUX and WIN.


- Repository: https://github.com/vjeantet/sublime-image-paste
- One package, repository root.
- Semver tag `1.0.0` is published (`tags: true`).
- Sublime Text 4 only (`>=4000`); the package runs under the Python 3.8 plugin host.
- macOS only (`platforms: ["osx"]`): it ships a universal arm64+x86_64 helper binary that reads images from NSPasteboard. A `.no-sublime-package` file forces on-disk extraction so the helper is runnable.

