### PR TITLE
Adding an up-to-date Cypher syntax package

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -5121,17 +5121,6 @@
 		},
 		{
 			"name": "Cypher",
-			"details": "https://github.com/kollhof/sublime-cypher",
-			"labels": ["language syntax"],
-			"releases": [
-				{
-					"sublime_text": "<3000",
-					"branch": "master"
-				}
-			]
-		},
-		{
-			"name": "Cypher ST3+",
 			"details": "https://github.com/fulguritude/cypher-sublime-syntax",
 			"labels": ["language syntax"],
 			"description": "Syntax highlighting for the Neo4j Cypher query language for ST3 and above.",

--- a/repository/c.json
+++ b/repository/c.json
@@ -5131,6 +5131,18 @@
 			]
 		},
 		{
+			"name": "Cypher ST3+",
+			"details": "https://github.com/fulguritude/cypher-sublime-syntax",
+			"labels": ["language syntax"],
+			"description": "Syntax highlighting for the Neo4j Cypher query language for ST3 and above.",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Cython",
 			"details": "https://github.com/NotSqrt/sublime-cython",
 			"labels": ["language syntax"],

--- a/repository/c.json
+++ b/repository/c.json
@@ -5123,7 +5123,6 @@
 			"name": "Cypher",
 			"details": "https://github.com/fulguritude/cypher-sublime-syntax",
 			"labels": ["language syntax"],
-			"description": "Syntax highlighting for the Neo4j Cypher query language for ST3 and above.",
 			"releases": [
 				{
 					"sublime_text": ">=3092",


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is [Cypher ST3+](https://github.com/Fulguritude/cypher-sublime-syntax). It is a syntax coloring package for the Neo4J Cypher query language.

My package is similar to [Cypher](https://github.com/kollhof/sublime-cypher). However it should still be added because the repo has been archived for almost a decade, and the plugin only works for ST versions `<3000`.

Concerning the name of the package, since mine is set to versions `>=3092`, there shouldn't be a conflict if it was just named `Cypher`, but I named it this way to avoid any conflict. Feel free to change it if so desired.

I'm available to discuss, improve or fix anything you'd like.

The syntax coloring in action:
<img width="980" height="554" alt="image" src="https://github.com/user-attachments/assets/28f08818-749a-4a81-ad2d-3c0c992f3c4d" />
