### PR TITLE
Add ES|QL syntax highlighting package

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -1335,6 +1335,17 @@
 			]
 		},
 		{
+			"name": "ES|QL",
+			"details": "https://github.com/elastic/esql-syntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "main"
+				}
+			]
+		},
+		{
 			"name": "Estomato",
 			"details": "https://github.com/rakibulhaq/Estomato",
 			"labels": ["text manipulation", "text selection", "aggregation"],

--- a/repository/e.json
+++ b/repository/e.json
@@ -1335,7 +1335,7 @@
 			]
 		},
 		{
-			"name": "ES|QL",
+			"name": "ESQL",
 			"details": "https://github.com/elastic/esql-syntax",
 			"labels": ["language syntax"],
 			"releases": [

--- a/repository/e.json
+++ b/repository/e.json
@@ -1341,7 +1341,7 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"branch": "main"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [X] I'm the package's author and/or maintainer.
- [X] I have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is a TextMate grammar (.tmLanguage) that adds syntax highlighting for ES|QL, Elasticsearch Query Language — Elastic's query language for the Elasticsearch platform.

There are no packages like it in Package Control.