### PR TITLE
Add sublime-mcp

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1204,6 +1204,17 @@
 			]
 		},
 		{
+			"name": "MCP Commander",
+			"details": "https://github.com/dpc00/sublime-mcp",
+			"labels": ["ai", "mcp"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MCPHelper",
 			"description": "Connects to a local Model Context Protocol (MCP) server for AI-powered code generation, review, refactoring, and translation using OpenAI or Gemini.",
 			"author": "David Donohue",

--- a/repository/s.json
+++ b/repository/s.json
@@ -4661,6 +4661,17 @@
 			]
 		},
 		{
+			"name": "sublime-mcp",
+			"details": "https://github.com/dpc00/sublime-mcp",
+			"labels": ["ai", "mcp"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/ccreutzig/sublime-MuPAD",
 			"labels": ["language syntax"],
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -4661,17 +4661,6 @@
 			]
 		},
 		{
-			"name": "sublime-mcp",
-			"details": "https://github.com/dpc00/sublime-mcp",
-			"labels": ["ai", "mcp"],
-			"releases": [
-				{
-					"sublime_text": ">=4000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"details": "https://github.com/ccreutzig/sublime-MuPAD",
 			"labels": ["language syntax"],
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is similar to MCPHelper and MCPServer. However it should still be added because the direction is inverted: sublime-mcp turns Sublime Text into an MCP *server* that an external AI agent (e.g. Claude Code CLI) can directly control. The agent reads cursor context, makes edits, navigates files, runs builds, and evaluates Python in ST's runtime — while the user watches the changes appear in real time. The AI is the client; ST is the controlled environment. Neither MCPHelper nor MCPServer expose ST's internal API at this level of granularity to an external agent.

I built this to solve my own workflow and have been using it daily. I intend to maintain it.