### PR TITLE
Add Paste Markdown

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -504,6 +504,18 @@
 			]
 		},
 		{
+			"name": "Paste Markdown",
+			"details": "https://github.com/Wuvist/subl_paste_md",
+			"labels": ["text manipulation", "clipboard", "paste", "markdown"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"platforms": ["osx"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Paste PDF Text Block",
 			"details": "https://github.com/compleatang/sublimetext-pastepdf",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs](https://docs.sublimetext.io/guide/package-control/submitting.html).
- [x] I have tagged a release with a [semver](https://semver.org) version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings are listed in the menu and the command palette, and open in split view.
- [x] This package is not a syntax and does not add a color scheme.
- [x] I use [.gitattributes](https://www.git-scm.com/docs/gitattributes#_export_ignore) to exclude test and repository-only files from the package.

Paste Markdown converts rich HTML copied from Chrome into Markdown when pasted into Sublime Text on macOS. It supports headings, links, images, lists, blockquotes, code blocks, and tables, with plain-text fallback.

There are no packages like it in Package Control. The existing Markdown to Clipboard package handles the opposite direction.