### PR TITLE
Add KeyBindingReport package

### DIFF
--- a/repository/k.json
+++ b/repository/k.json
@@ -190,6 +190,17 @@
 			]
 		},
 		{
+			"details": "https://github.com/vwheeler63/KeyBindingReport",
+			"labels": ["key", "binding", "key binding", "utilities"],
+			"donate": "https://buymeacoffee.com/vwheeler63",
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "KeyboardNavigation",
 			"details": "https://github.com/robertcollier4/KeyboardNavigation",
 			"releases": [

--- a/repository/k.json
+++ b/repository/k.json
@@ -190,7 +190,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/vwheeler63/KeyBindingReport",
+			"details" : "https://github.com/vwheeler63/KeyBindingReport",
 			"labels": ["key", "binding", "key binding", "utilities"],
 			"donate": "https://buymeacoffee.com/vwheeler63",
 			"releases": [

--- a/repository/k.json
+++ b/repository/k.json
@@ -195,7 +195,7 @@
 			"donate": "https://buymeacoffee.com/vwheeler63",
 			"releases": [
 				{
-					"sublime_text": ">=4171",
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]

--- a/repository/k.json
+++ b/repository/k.json
@@ -190,7 +190,7 @@
 			]
 		},
 		{
-			"details" : "https://github.com/vwheeler63/KeyBindingReport",
+			"details": "https://github.com/vwheeler63/KeyBindingReport",
 			"labels": ["key", "binding", "key binding", "utilities"],
 			"donate": "https://buymeacoffee.com/vwheeler63",
 			"releases": [

--- a/repository/k.json
+++ b/repository/k.json
@@ -195,7 +195,7 @@
 			"donate": "https://buymeacoffee.com/vwheeler63",
 			"releases": [
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=4171",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] (n/a)  If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

## KeyBindingReport

...is a Sublime Text Package that produces a wide variety of reports about the current state of Sublime Text key bindings on the system it is running on, and has the capacity to simulate running on other platforms for the sake of reporting Key Binding information for that platform.

### Comparison to Other Packages

There are no packages like it in Package Control.  2 built-in reports begin with the name "Key Binding Overrides", which sounds a lot like the "FindKeyConflicts" Package.  The difference between the two is:

- Only 2 of the built-in reports deal with "key conflicts".

- "FindKeyConflicts" only reports on when it finds the same keypresses used in 2 or more key bindings in all packages on a system, and importantly, *it has no consideration for the "context" entries of these key bindings* thus making it report key bindings that are normal to have many of (e.g. for `"`, `'`, `enter`, `tab` and other keys that mean different things at different times), and it tends to cause *real key conflicts* to hide among the large amount of data reported.

- The 2 "Key Binding Overrides" reports DO take the key-bindings' "context" entries into account, and thus are far more effective at isolating real binding overrides.

- KeyBindingReport has 57 other reports that have nothing to do with "key conflicts".

Other than the above, it is different than any other Package managed under PackageControl.
 
### Note:

**st_package_reviewer** produces a warning on this Package:

    It looks like you're using platform-dependent code ...

due to platform-specific code in `platform.py`.  Indeed, this module detects the platform it is running on, and normally reports about *that platform*.  However, it also provides facilities (optional argument for all reports) to "simulate" being on platforms other than the one it is running on.  In any case, the Package is indeed designed to run on all three platforms:  Windows, Linux and OSX.
