### PR TITLE
feat: add harpoon package

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -300,6 +300,17 @@
 			]
 		},
 		{
+			"name": "Harpoon",
+			"details": "Faster Navigate inside Sublime Text with your favourite list of file",
+			"labels": ["file navigation", "utilities"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"branch": "master"
+				}
+			]
+		},
+		{
 			"name": "Harvey",
 			"details": "https://github.com/rayje/harvey-sublime",
 			"labels": ["language syntax"],

--- a/repository/h.json
+++ b/repository/h.json
@@ -301,7 +301,7 @@
 		},
 		{
 			"name": "Harpoon",
-			"details": "Faster Navigate inside Sublime Text with your favourite list of file",
+			"details": "https://github.com/huyhoang8398/harpoon",
 			"labels": ["file navigation", "utilities"],
 			"releases": [
 				{


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

There are no packages like it in Package Control.
A Sublime Text plugin for marking files and jumping back to them instantly.
Marks are scoped per project, stored inside your .sublime-project file, so each project keeps its own independent list.

Features
- Mark/unmark the current file with one hotkey
- Jump to any mark directly by slot number (1, 2, 3, 4...)
- Browse all marks in a quick panel
- Cycle forward/backward through marks
- Marks persist across restarts (saved in the .sublime-project file)
- Dead marks (deleted or moved files) are pruned automatically
- Remember the line 

**NOTE**: dependency: `AutoProject` plugin or save folder as project