### PR TITLE
Remove MCP Commander

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1204,17 +1204,6 @@
 			]
 		},
 		{
-			"name": "MCP Commander",
-			"details": "https://github.com/dpc00/sublime-mcp",
-			"labels": ["ai", "mcp"],
-			"releases": [
-				{
-					"sublime_text": ">=4000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "MCPHelper",
 			"description": "Connects to a local Model Context Protocol (MCP) server for AI-powered code generation, review, refactoring, and translation using OpenAI or Gemini.",
 			"author": "David Donohue",


### PR DESCRIPTION
Removing MCP Commander at the author's request. The package will no longer be maintained.