### PR TITLE
Add labels to PCR's "Remarkable" packages

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -1447,6 +1447,7 @@
 		},
 		{
 			"details": "https://github.com/facelessuser/BracketHighlighter",
+			"labels": ["brackets"],
 			"releases": [
 				{
 					"sublime_text": "3000 - 4200",

--- a/repository/c.json
+++ b/repository/c.json
@@ -457,7 +457,7 @@
 			"name": "Catppuccin color schemes",
 			"details": "https://github.com/catppuccin/sublime-text",
 			"author": ["Catppuccin"],
-			"labels": ["color scheme"],
+			"labels": ["color scheme", "dark", "light"],
 			"releases": [
 				{
 					"sublime_text": ">=3100",
@@ -2924,6 +2924,7 @@
 		},
 		{
 			"details": "https://github.com/facelessuser/ColorHelper",
+			"labels": ["color"],
 			"releases": [
 				{
 					"sublime_text": "3170 - 3999",

--- a/repository/c.json
+++ b/repository/c.json
@@ -2924,7 +2924,7 @@
 		},
 		{
 			"details": "https://github.com/facelessuser/ColorHelper",
-			"labels": ["color"],
+			"labels": ["color", "preview", "utilities"],
 			"releases": [
 				{
 					"sublime_text": "3170 - 3999",

--- a/repository/d.json
+++ b/repository/d.json
@@ -1645,7 +1645,7 @@
 		{
 			"name": "Dracula Color Scheme",
 			"details": "https://github.com/dracula/sublime",
-			"labels": ["color scheme"],
+			"labels": ["color scheme", "dark"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/g.json
+++ b/repository/g.json
@@ -661,6 +661,7 @@
 		},
 		{
 			"details": "https://github.com/jisaacks/GitGutter",
+			"labels": ["git", "diff", "gutter"],
 			"releases": [
 				{
 					"sublime_text": "<3176",
@@ -2384,7 +2385,7 @@
 		{
 			"name": "Guna",
 			"details": "https://github.com/poucotm/Guna",
-			"labels": ["theme", "color scheme", "clock", "weather"],
+			"labels": ["theme", "color scheme", "dark", "clock", "weather"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/h.json
+++ b/repository/h.json
@@ -508,7 +508,7 @@
 		},
 		{
 			"details": "https://github.com/facelessuser/HexViewer",
-			"labels": ["language syntax"],
+			"labels": ["language syntax", "binary"],
 			"releases": [
 				{
 					"sublime_text": "3000 - 4200",

--- a/repository/l.json
+++ b/repository/l.json
@@ -576,6 +576,7 @@
 		},
 		{
 			"details": "https://github.com/SublimeText/LaTeXTools",
+			"labels": ["build system", "snippets", "completions", "file navigation", "citations", "latex", "bibtex"],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -1511,7 +1512,7 @@
 		{
 			"name": "LocalizedMenu",
 			"details": "https://github.com/zam1024t/LocalizedMenu",
-			"labels": ["localize", "tool", "menu"],
+			"labels": ["localize", "tool", "menu", "l10n", "i18n"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/r.json
+++ b/repository/r.json
@@ -2518,7 +2518,7 @@
 		{
 			"name": "Rust Enhanced",
 			"details": "https://github.com/rust-lang/rust-enhanced",
-			"labels": ["language syntax"],
+			"labels": ["language syntax", "rust"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",

--- a/repository/s.json
+++ b/repository/s.json
@@ -5955,6 +5955,7 @@
 		{
 			"name": "SyncedSideBar",
 			"details": "https://github.com/TheSpyder/SyncedSideBar",
+			"labels": ["sidebar", "file navigation"],
 			"releases": [
 				{
 					"sublime_text": "<4050",

--- a/repository/t.json
+++ b/repository/t.json
@@ -2134,7 +2134,7 @@
 		{
 			"name": "Theme - Spacegray",
 			"details": "https://github.com/SublimeText/Spacegray",
-			"labels": ["theme", "color scheme"],
+			"labels": ["theme", "color scheme", "dark", "light"],
 			"releases": [
 				{
 					"sublime_text": ">=4000",

--- a/repository/v.json
+++ b/repository/v.json
@@ -602,7 +602,7 @@
 			"name": "Visual Studio Code Plus Scheme",
 			"details": "https://github.com/vbasky/sublime-vscode-plus",
 			"issues": "https://github.com/vbasky/sublime-vscode-plus/issues",
-			"labels": ["color scheme"],
+			"labels": ["color scheme", "dark", "light"],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -613,7 +613,7 @@
 		{
 			"name": "Visual Studio Dark",
 			"details": "https://github.com/nikeee/visual-studio-dark",
-			"labels": ["color scheme"],
+			"labels": ["color scheme", "dark"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
I took a quick run-through of the packages in [PCR](https://packages.sublimetext.io/)'s "Remarkable" section and added tags to the ones in this registry where they were missing.

The "dark" labels may be mediocre value, but a couple of the packages really needed some tagging. LaTeXTools does *even more things,* but I was reluctant to add too many labels.