### PR TITLE
Add Codigrate Themes

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2429,6 +2429,17 @@
 			]
 		},
 		{
+			"name": "Codigrate Themes",
+			"details": "https://github.com/codigrate/sublime-text-themes",
+			"labels": ["color scheme", "theme"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Coffee Color Scheme",
 			"details": "https://github.com/watergear/sublime-coffee-color-scheme",
 			"labels": ["color scheme"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a collection of 12 hand-tuned color schemes inspired by nature and iconic cities (Aurora Borealis, Everest, Sakura, Istanbul, Tokyo, Miami…), each shipping a matching .sublime-theme so the window chrome (sidebar, tabs, status bar) is painted with the same palette — light themes included. The palettes are the Sublime ports of the Codigrate theme family also published for JetBrains IDEs, VS Code and other platforms, so users get consistent colors across their tools. Screenshots for every theme are in the README: https://github.com/codigrate/sublime-text-themes

There are similar color scheme collections in Package Control, but none of these palettes exist on Sublime Text yet — this package brings an actively maintained, cross-editor theme family to Sublime with both editor and UI theming.