### PR TITLE
Add Spintax

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3380,7 +3380,7 @@
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=3092",
 					"tags": true
 				}
 			]

--- a/repository/s.json
+++ b/repository/s.json
@@ -3375,6 +3375,17 @@
 			]
 		},
 		{
+			"name": "Spintax",
+			"details": "https://github.com/investblog/sublime-spintax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SPIP",
 			"details": "https://github.com/phenix-factory/Sublime-SPIP",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette. — the package adds no commands.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view. — none of either.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a syntax definition for **spintax** — the template language used to generate
text variations (`{a|b|c}` enumerations, `[<config>a|b]` permutations, `%vars%`,
`#set`/`#def` directives, `#include`, `{?VAR?…}` conditionals, `{plural N: …}` plural
agreement, `/# … #/` comments). It highlights `.spintax` and `.gtw` files.

The grammar mirrors the `@spintax/core` engine contract rather than approximating it, so the
tricky discriminators behave the way the engine does — a leading `<and>` inside `[ … ]` is a
separator while `<li>…</li>` is content, `{plural ` requires the trailing space and a colon,
`{?VAR?` requires a valid identifier. Those cases are covered by the syntax tests, which run
in CI on Sublime Text `latest`, `stable` and build `3210`.

There are no packages like it in Package Control.