### PR TITLE
Add TabStack package

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -182,6 +182,17 @@
 			]
 		},
 		{
+			"details": "https://github.com/SublimeText/TabStack",
+			"author": ["FichteFoll"],
+			"labels": ["tab navigation"],
+			"releases": [
+				{
+					"sublime_text": ">=4100",
+					"tags": "st-4100/"
+				}
+			]
+		},
+		{
 			"details": "https://github.com/jbrooksuk/TabsToTable",
 			"releases": [
 				{

--- a/repository/t.json
+++ b/repository/t.json
@@ -183,7 +183,7 @@
 		},
 		{
 			"details": "https://github.com/SublimeText/TabStack",
-			"author": ["FichteFoll"],
+			"author": "FichteFoll",
 			"labels": ["tab navigation"],
 			"releases": [
 				{


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a different take on MRU-based tab switching than the available alternatives. Its primary selling factor is that it mimics the behavior found in other places, such as in browsers or on Windows' windows where releasing the control key causes the current selection (in a quick panel) to be committed

- https://packages.sublimetext.com/packages/TabTeleport uses a text-based representation of the tab lists
- https://packages.sublimetext.com/packages/Compass%20Navigator uses a quick panel but follows a different key binding philosophy

Additionally, TabStack properly supports HTML and image sheets by using the newly added `Sheet.name` API of 4205. This was implemented in an optional way so that it supports ST 4 builds back until 4100, which includes the first stable build of ST~~4~~.

Key bindings override default bindings because this package replaces the default functionality on these keys. However, a special context is in place that will cause the bindings not to trigger if the necessary system-level libraries (for ctypes calls) cannot be loaded. This way, the default bindings can still take effect even  when the plugin fails to load properly.

There is no configuration and the commands are not meant to be invoked via the command palette. In fact, it won't even work because the ctrl key must be held at all times.

<!-- 
A word about AI use:
Although we use automation, a human will be reviewing your submission. An important part of this is an assessment of the ability and willingness of the human submitting the package (i.e. you) to support it long term. This is therefore primarily a human to human conversation. While you're welcome to use any form of automation, you are expected to participate in this conversation yourself.

*)   If you do need a context menu, make sure the menu applies to the cursor
     context, and the commands are conditional. Space in this menu is limited!
**)  There aren't enough keys for all packages, so you risk overriding those
     of other packages. You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) Syntaxes should work in any color scheme the user chooses.

For bonus points also consider how the review guidelines apply to your package:
https://docs.sublimetext.io/reference/package-control/reviewing.html
-->
