### PR TITLE
Add Extractor

### DIFF
--- a/repository/e.json
+++ b/repository/e.json
@@ -1981,6 +1981,17 @@
 			]
 		},
 		{
+			"name": "Extractor",
+			"details": "https://github.com/bogdancstrike/sublime_plugin_extractor",
+			"labels": ["text manipulation", "utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "eZ Publish Syntax",
 			"details": "https://github.com/SirReal/eZ-Publish-Syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package, Extractor, scrapes structured data out of the current file (or the selection) and writes the de-duplicated matches into a new tab. It ships 22 built-in extractors — emails, URLs, domains, hostnames, IPv4/IPv6, ports, phone numbers, dates, times, timestamps, file paths, UUIDs, MAC addresses, hex colors, numbers, hashtags, mentions, Luhn-validated credit-card numbers, secrets/API keys and Markdown link URLs — plus a custom-regex extractor. Everything is reachable from the Command Palette and the Tools menu; it has no dependencies and runs on ST3 and ST4.


My package is loosely similar to Extract Text to File and Extract Lines, which write the current selection or matching lines to a file. However it should still be added because it works the other way around: instead of the user selecting or searching first, it recognises 22 kinds of tokens (or any user-supplied regex) anywhere in the file, de-duplicates them, and collects them into a new file in one step.
