### PR TITLE
Add MarkdownPreviewEnhanced package (v0.1.0)

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -732,6 +732,16 @@
 			]
 		},
 		{
+			"details": "https://github.com/CaffeineOddity/MarkdownPreviewEnhanced",
+			"labels": ["markdown", "preview", "mermaid", "live preview", "syntax highlighting"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/naokazuterada/MarkdownTOC",
 			"labels": ["markdown", "toc", "table of contents"],
 			"releases": [
@@ -741,18 +751,7 @@
 				}
 			]
 		},
-			{
-		"name": "MarkdownPreviewEnhanced",
-		"details": "https://github.com/CaffeineOddity/MarkdownPreviewEnhanced",
-		"labels": ["markdown", "preview", "mermaid", "live preview", "syntax highlighting"],
-		"releases": [
-			{
-				"sublime_text": ">=4107",
-				"tags": true
-			}
-		]
-	},
-{
+		{
 			"name": "MarkdownWriter",
 			"details": "https://github.com/vanleo2001/MarkdownWriter",
 			"labels": ["markdown", "html", "converting"],

--- a/repository/m.json
+++ b/repository/m.json
@@ -741,7 +741,18 @@
 				}
 			]
 		},
-		{
+			{
+		"name": "MarkdownPreviewEnhanced",
+		"details": "https://github.com/CaffeineOddity/MarkdownPreviewEnhanced",
+		"labels": ["markdown", "preview", "mermaid", "live preview", "syntax highlighting"],
+		"releases": [
+			{
+				"sublime_text": ">=4107",
+				"tags": true
+			}
+		]
+	},
+{
 			"name": "MarkdownWriter",
 			"details": "https://github.com/vanleo2001/MarkdownWriter",
 			"labels": ["markdown", "html", "converting"],

--- a/repository/m.json
+++ b/repository/m.json
@@ -755,7 +755,7 @@
 		},
 		{
 			"details": "https://github.com/CaffeineOddity/MarkdownPreviewEnhanced",
-			"labels": ["markdown", "preview", "mermaid", "live preview", "syntax highlighting"],
+			"labels": ["markdown", "preview", "mermaid", "live preview"],
 			"releases": [
 				{
 					"sublime_text": ">=4107",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs](https://docs.sublimetext.io/guide/package-control/submitting.html).
- [x] I have tagged a release with a [semver](https://semver.org) version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes](https://www.git-scm.com/docs/gitattributes#_export_ignore) to exclude files from the package: images, test files, sublime-project/workspace.

## MarkdownPreviewEnhanced v0.1.0

**Repository:** https://github.com/CaffeineOddity/MarkdownPreviewEnhanced
**Tag:** `0.1.0`

Live markdown preview in an external browser with full HTML/CSS, tables, Mermaid, KaTeX, and ECharts. Mirrors the editing buffer in real time; the preview updates on every save.

My package is similar to MarkdownPreview and MarkdownLivePreview. However it should still be added because it renders in an external browser with full HTML/CSS support and rich diagram/math libraries (Mermaid, KaTeX, ECharts), none of which the existing packages provide.
