### PR TITLE
Add Carve

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -405,7 +405,6 @@
 			"name": "Carve",
 			"details": "https://github.com/markup-carve/sublime-carve",
 			"labels": ["language syntax", "carve", "markup", "djot"],
-			"description": "Syntax highlighting for Carve, a post-Markdown lightweight markup language",
 			"releases": [
 				{
 					"sublime_text": ">=3092",

--- a/repository/c.json
+++ b/repository/c.json
@@ -402,6 +402,18 @@
 			]
 		},
 		{
+			"name": "Carve",
+			"details": "https://github.com/markup-carve/sublime-carve",
+			"labels": ["language syntax", "carve", "markup", "djot"],
+			"description": "Syntax highlighting for Carve, a post-Markdown lightweight markup language",
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Case Conversion",
 			"details": "https://github.com/jdavisclark/CaseConversion",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a syntax highlighting package for [Carve](https://github.com/markup-carve/carve), a post-Markdown lightweight markup language (`.crv` files). It ships a single `sublime-syntax` (v1, so Sublime Text 3 and 4 are both supported) whose scope names mirror the canonical `text.carve` TextMate grammar, plus syntax-specific editing defaults (soft tabs, word wrap, spell check) that apply automatically to Carve files. There are no commands, menus, key bindings, or color schemes; the settings file is the syntax-specific kind that Sublime Text picks up by name, so there is nothing to surface in the command palette.

There are no packages like it in Package Control. Carve is a distinct language (not Markdown or Djot), and no existing package highlights it.

Sorry for skipping the template the first time - that was my mistake in the submission flow, not lack of intent to maintain this. I am the author of both the language and this package and will support it long term.
