### PR TITLE
Add Vibescript

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -334,6 +334,17 @@
 			]
 		},
 		{
+			"name": "Vibescript",
+			"details": "https://github.com/mgomes/sublime-vibescript",
+			"labels": ["language syntax", "lsp"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "View Bookmarks",
 			"details": "https://github.com/adam-zethraeus/SublimeViewBookmarks",
 			"labels": ["bookmarks", "file navigation"],

--- a/repository/v.json
+++ b/repository/v.json
@@ -336,7 +336,7 @@
 		{
 			"name": "Vibescript",
 			"details": "https://github.com/mgomes/sublime-vibescript",
-			"labels": ["language syntax", "lsp"],
+			"labels": ["language syntax"],
 			"releases": [
 				{
 					"sublime_text": ">=4107",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is language support for [Vibescript](https://github.com/mgomes/vibescript), a Ruby-inspired embeddable scripting language: syntax highlighting for `.vibe` files (strings with interpolation, regex literals, percent arrays, enums, typed signatures), indentation rules, symbol indexing for classes/methods/enums, and LSP integration (diagnostics, hover documentation, completions) through the `vibes lsp` server and the LSP package. Syntax tests run in CI against real Sublime builds.

There are no packages like it in Package Control.