### PR TITLE
Drop language syntax tag from phpfmt

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1395,7 +1395,7 @@
 		{
 			"name": "phpfmt",
 			"details": "https://github.com/driade/phpfmt8",
-			"labels": ["formatting", "language syntax", "php"],
+			"labels": ["formatting", "php"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
phpfmt does not provide either a tmLanguage or sublime-syntax.