### PR TITLE
Update Spartan Color Scheme metadata

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -3270,7 +3270,10 @@
 		{
 			"name": "Spartan Color Scheme",
 			"details": "https://github.com/renzojohnson/spartan-color-scheme",
-			"labels": ["color scheme", "dark"],
+			"homepage": "https://renzojohnson.com",
+			"issues": "https://renzojohnson.com/contact",
+			"donate": "https://www.paypal.com/paypalme/renzojohnson",
+			"labels": ["color scheme", "dark", "light"],
 			"releases": [
 				{
 					"sublime_text": ">=3000",


### PR DESCRIPTION
Supersedes #9345 (closed while awaiting changes — the branch force-push after closure prevented reopening).

All review feedback from #9345 addressed:
- `theme` label removed per @michaelblyons / @braver — labels are now `["color scheme", "dark", "light"]`
- the Mercurial hunk was split out earlier (belongs to its own PR)
- single clean commit on top of current master

Adds `homepage`, `issues` and `donate` URLs for the Spartan Color Scheme entry.