### PR TITLE
Update Mercurial Color Scheme metadata

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1399,8 +1399,10 @@
 		{
 			"name": "Mercurial Color Scheme",
 			"details": "https://github.com/renzojohnson/mercurial-color-scheme",
-			"donate": "https://github.com/sponsors/renzojohnson",
-			"labels": ["color scheme"],
+			"homepage": "https://renzojohnson.com",
+			"issues": "https://renzojohnson.com/contact",
+			"donate": "https://www.paypal.com/paypalme/renzojohnson",
+			"labels": ["color scheme", "dark", "light"],
 			"releases": [
 				{
 					"sublime_text": ">=3149",


### PR DESCRIPTION
Supersedes #9344 (closed while awaiting changes — branch was rebuilt after closure, which prevents reopening).

All review feedback from #9344 addressed:
- `theme` label removed per @michaelblyons / @braver — labels are now `["color scheme", "dark", "light"]`
- single clean commit on top of current master

Adds `homepage` and `issues` URLs and updates the `donate` URL for the Mercurial Color Scheme entry.