### PR TITLE
Add LSP-carve

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1857,6 +1857,17 @@
 			]
 		},
 		{
+			"name": "LSP-carve",
+			"details": "https://github.com/markup-carve/sublime-carve-lsp",
+			"labels": ["language server", "lsp", "carve", "markup"],
+			"releases": [
+				{
+					"sublime_text": ">=4096",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Lua Dev",
 			"details": "https://github.com/rorydriscoll/LuaSublime",
 			"labels": ["language syntax", "lua"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is an LSP client for [Carve](https://github.com/markup-carve/carve), a post-Markdown lightweight markup language. It runs the language server (`carve-lsp`) through `lsp_utils`, which installs it and provides the Node runtime, so users need no global Node. It pairs with the Carve syntax package, which was added to the channel in #9482.

The repository is named `sublime-carve-lsp` to sit alongside the syntax repo (`sublime-carve`) and to avoid confusion with `carve-lsp`, the language server itself; the package installs under the conventional `LSP-carve` name.

There are no packages like it in Package Control.
