### PR TITLE
Add Candela Color Schemes

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -269,6 +269,17 @@
 			]
 		},
 		{
+			"name": "Candela Themes",
+			"details": "https://github.com/schovi/candela-themes-sublime",
+			"labels": ["color scheme", "theme"],
+			"releases": [
+				{
+					"sublime_text": ">=3149",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Candy Dark Color Scheme",
 			"details": "https://github.com/rahulsharmagg/Candy-Dark",
 			"labels": ["color scheme"],

--- a/repository/c.json
+++ b/repository/c.json
@@ -269,9 +269,9 @@
 			]
 		},
 		{
-			"name": "Candela Themes",
+			"name": "Candela Color Schemes",
 			"details": "https://github.com/schovi/candela-themes-sublime",
-			"labels": ["color scheme", "theme"],
+			"labels": ["color scheme"],
 			"releases": [
 				{
 					"sublime_text": ">=3149",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read the docs.
- [x] I have tagged a release with a semver version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use .gitattributes to exclude files from the package: images, test files, sublime-project/workspace.

My package is a family of color schemes (light and dark) tuned for eye-strain comfort: low-glare backgrounds, desaturated accents, and WCAG-AA contrast throughout. It ships only `.sublime-color-scheme` files (no commands, menus, key bindings, or syntaxes).

My package is similar to other color scheme packages in Package Control. However it should still be added because it's a single coordinated multi-scheme family generated from one source of truth, with a specific low-glare / contrast-floor design shared across editors and terminals, rather than a single standalone scheme.

The color schemes are generated from a source-of-truth repo (https://github.com/schovi/candela-themes) and published to the tagged distribution repo linked below; I maintain both.