### PR TITLE
Add TOON

### DIFF
--- a/repository/t.json
+++ b/repository/t.json
@@ -3125,6 +3125,17 @@
 			]
 		},
 		{
+			"name": "TOON",
+			"details": "https://github.com/mpgirro/sublime-toon-syntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Topas Syntax",
 			"details": "https://github.com/davidchall/topas-syntax",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a syntax highlighting package for TOON (Token-Oriented Object Notation, https://toonformat.dev/), a compact JSON-equivalent data format aimed at LLM prompts. It uses standard scope names, targets ST3 and ST4 (`version: 1` sublime-syntax), and CI runs the official headless `syntax_tests` binary plus syntect on every change.

There are no packages like it in Package Control.