### PR TITLE
Add Datapack Icons

### DIFF
--- a/repository/d.json
+++ b/repository/d.json
@@ -333,6 +333,17 @@
 			]
 		},
 		{
+			"name": "Datapack Icons",
+			"details": "https://github.com/FuncFusion/mc-dp-icons-sublime",
+			"labels": ["theme", "file", "icons"],
+			"releases": [
+				{
+					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Datastar",
 			"details": "https://github.com/SublimeText/Datastar",
 			"labels": ["completions", "language syntax"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [ ] Any commands are available via the command palette.
- [ ] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

*Note: Unchecked items are non-applicable to the package

My package is a file icon theme in Mincecraft inspired pixelart style

There are no packages like it in Package Control.
