### PR TITLE
[razor-sublime] Update for ST4 4206.

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -437,8 +437,12 @@
 			"labels": ["language syntax", "razor", "c#", "cshtml"],
 			"releases": [
 				{
-					"sublime_text": ">=4075",
-					"tags": true
+					"sublime_text": "4075 - 4205",
+					"tags": "4075-"
+				},
+				{
+					"sublime_text": ">=4206",
+					"tags": "4206-"
 				}
 			]
 		},


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have read [the docs][1].
- [ ] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is already in package control.  It just needs updates due to breaking syntax changes in the latest dev build.

I have not tagged a release yet because if I do, it will break anybody not currently using ST4 4206 dev, as my existing entry has `"tags": true`.  This merge adds proper tag prefixes so I can section off the breaking changes behind a tag prefix.  Once merged, I can safely add a tag for 4206.